### PR TITLE
governance: define explicit code owners for architecture gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # AI Agent Governance - CODEOWNERS
 # Protected governance files require governance-team approval
 
+.github/workflows/architecture-gate.yml   @liyecom
 .github/workflows/**   @liyecom/governance-team
 .github/CODEOWNERS     @liyecom/governance-team
 docs/governance/**     @liyecom/governance-team


### PR DESCRIPTION
## Purpose

Bootstrap governance ownership for critical files.

This PR defines explicit CODEOWNERS for governance-critical paths, with a
special focus on `architecture-gate.yml`.

## What changed

- Assign `@liyecom` as the explicit code owner for:
  - `.github/workflows/architecture-gate.yml`
- Assign `@liyecom/governance-team` as code owners for:
  - other GitHub workflows
  - governance and architecture documentation
  - CODEOWNERS itself

## Why

- Enable deterministic reviewer assignment for governance PRs
- Unblock architecture-gate changes under protected `main`
- Establish a scalable governance ownership model (individual → team)

## Notes

This is a governance bootstrap PR.  
CODEOWNERS rules will take effect **after this PR is merged**.
