### PR TITLE
fix(ci): governance gates - proper workflow content and PR-only trigger

### DIFF
--- a/.github/workflows/constitution-bmad-boundary-gate.yml
+++ b/.github/workflows/constitution-bmad-boundary-gate.yml
@@ -3,8 +3,6 @@ name: Constitution - BMad Boundary Gate
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 jobs:
   bmad-boundary:

--- a/.github/workflows/governance-file-change-gate.yml
+++ b/.github/workflows/governance-file-change-gate.yml
@@ -1,1 +1,28 @@
-docs/governance/governance-file-change-gate.yml
+name: Governance File Change Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/CODEOWNERS'
+      - 'docs/governance/**'
+      - 'docs/architecture/**'
+      - 'CLAUDE.md'
+
+jobs:
+  governance-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check governance file changes
+        run: |
+          echo "=== Governance File Change Gate ==="
+          echo "This PR modifies protected governance files."
+          echo "Requires approval from @liyecom/governance-team per CODEOWNERS."
+          echo ""
+          echo "Changed governance files:"
+          git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '^\.github/|^docs/governance/|^docs/architecture/|^CLAUDE\.md' || echo "No governance files changed"
+          echo ""
+          echo "Gate passed - CODEOWNERS will enforce review requirement."


### PR DESCRIPTION
## Summary
- Fix governance-file-change-gate.yml which contained only a path reference instead of actual workflow content
- Remove push trigger from bmad-boundary gate (github.base_ref is only available on pull_request events)

## Changes
1. **governance-file-change-gate.yml**: Added proper workflow that logs governance file changes and reminds about CODEOWNERS review requirement
2. **constitution-bmad-boundary-gate.yml**: Removed `push` trigger to avoid errors on main branch pushes

## Rationale
- BMAD boundary check during PR review is the appropriate enforcement point (before merge, not after)
- The governance gate works with CODEOWNERS to enforce review requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)