### PR TITLE
feat(domain): add Amazon Growth OS decision inventory (Phase 5.1)

### DIFF
--- a/_meta/docs/GOVERNANCE_CONSTITUTION_INDEX.md
+++ b/_meta/docs/GOVERNANCE_CONSTITUTION_INDEX.md
@@ -1,0 +1,128 @@
+# Governance Constitution Index
+
+> **Status**: Active
+> **Scope**: LiYe OS (main branch)
+> **Audience**: System Owner / Core Maintainers
+> **Purpose**: Enumerate all constitution-level governance mechanisms that are actively enforced.
+
+---
+
+## 1. What This Document Is (and Is Not)
+
+### This document IS:
+- A **canonical index** of active governance constraints
+- A map of **what is enforced, where, and how**
+- A quick reference for reviewers and maintainers
+
+### This document IS NOT:
+- A tutorial
+- A design rationale deep dive
+- A replacement for individual governance documents or CI code
+
+---
+
+## 2. Constitution-Level Invariants
+
+The following invariants define **non-negotiable system truths**.
+
+| Invariant | Description |
+|---------|-------------|
+| Kernel Integrity | System Kernel (`CLAUDE.md`) must not be polluted by feature or domain logic |
+| Truth Source Authority | English is the Single Source of Truth (SSOT); i18n layers must not override meaning |
+| Explicit Change Intent | Any constitution-level change must be explicitly declared |
+| Human Verifiability | Governance decisions must be reviewable without agent execution |
+
+---
+
+## 3. Active Governance Gates (CI-Enforced)
+
+### 3.1 Kernel Guard
+
+| Item | Value |
+|----|----|
+| Target | `CLAUDE.md` |
+| Enforced By | `.github/workflows/kernel-guard.yml` |
+| Trigger | Any PR modifying `CLAUDE.md` targeting `main` |
+| Default Behavior | ❌ Block merge |
+
+**Allowed only if one condition is met:**
+- PR title starts with `governance:` or `kernel:`
+- OR PR has label `kernel-change`
+
+**Invariant Enforced:** Kernel Integrity + Explicit Change Intent
+
+---
+
+### 3.2 i18n Gate (Truth Source Guard)
+
+| Item | Value |
+|----|----|
+| Target | i18n display layers |
+| Enforced By | `.github/workflows/i18n-gate.yml` |
+| Trigger | PRs touching i18n display files |
+| Default Behavior | ❌ Block merge if SSOT violated |
+
+**Invariant Enforced:** Truth Source Authority
+
+---
+
+## 4. Governance Observability (P1)
+
+| Capability | Status |
+|---------|--------|
+| Decision Traceability | ✅ Active |
+| Audit / Replay | ✅ Active |
+| Human-Readable Contract | ✅ Active |
+| Silent Drift Prevention | ✅ Active |
+
+**Notes:**
+- Governance decisions must produce observable artifacts
+- No agent execution is required to validate outcomes
+
+---
+
+## 5. Change Classification (Normative)
+
+All changes to the system implicitly fall into one of the following categories:
+
+| Change Type | Description |
+|-----------|-------------|
+| Governance | Alters system rules, invariants, or enforcement |
+| Infrastructure | Alters tooling without changing rules |
+| Feature | Adds or modifies domain functionality |
+| Concept | Documents models or ideas (non-executable) |
+
+**Rule:**
+Governance changes must never be implicit.
+
+---
+
+## 6. Enforcement Summary
+
+| Layer | Protection Level |
+|-----|------------------|
+| Kernel (`CLAUDE.md`) | CI-blocking |
+| Truth Source (i18n) | CI-blocking |
+| Governance Rules | Explicit declaration required |
+| Feature Semantics | Governed indirectly |
+
+---
+
+## 7. Reading Order for Maintainers
+
+1. `CLAUDE.md` (Kernel)
+2. This document (Constitution Index)
+3. `_meta/docs/ARCHITECTURE_CONSTITUTION.md`
+4. Individual CI workflows under `.github/workflows/`
+
+---
+
+## 8. Amendments
+
+- This index may be updated **only** when a governance mechanism is added, removed, or materially changed.
+- Adding new gates **requires updating this document**.
+
+---
+
+**Last Updated**: 2026-01-02
+**Maintainer**: System Owner

--- a/docs/domain/amazon-growth/DECISIONS.md
+++ b/docs/domain/amazon-growth/DECISIONS.md
@@ -1,0 +1,177 @@
+# Amazon Growth OS — Decision Inventory
+
+> Purpose:
+> This document defines the complete decision surface of Amazon Growth OS.
+> Each decision represents a machine-verdict that can be replayed, audited,
+> and governed. Decisions are language-neutral and versioned.
+>
+> Rules:
+> - Decision IDs are immutable once merged
+> - No natural language conclusions
+> - No analysis or reasoning text
+> - Enumeration only
+
+---
+
+## 1. Listing Quality Decisions
+
+- LISTING_INCOMPLETE
+- LISTING_TITLE_WEAK
+- LISTING_BULLET_WEAK
+- LISTING_DESCRIPTION_WEAK
+- LISTING_IMAGE_WEAK
+- LISTING_IMAGE_NON_COMPLIANT
+- LISTING_KEYWORD_MISMATCH
+- LISTING_BACKEND_KEYWORDS_MISSING
+- LISTING_A_PLUS_MISSING
+- LISTING_A_PLUS_UNDERUTILIZED
+
+---
+
+## 2. Traffic & Exposure Decisions
+
+- IMPRESSIONS_TOO_LOW
+- IMPRESSIONS_DECLINING
+- IMPRESSIONS_VOLATILE
+- CLICK_THROUGH_RATE_TOO_LOW
+- TRAFFIC_SOURCE_OVERCONCENTRATED
+- ORGANIC_TRAFFIC_TOO_LOW
+- PAID_TRAFFIC_OVERDEPENDENT
+
+---
+
+## 3. Conversion & CVR Decisions
+
+- CONVERSION_RATE_TOO_LOW
+- CONVERSION_RATE_DECLINING
+- PRICE_NOT_COMPETITIVE
+- OFFER_NOT_COMPETITIVE
+- BUY_BOX_LOSS
+- REVIEW_COUNT_TOO_LOW
+- REVIEW_RATING_TOO_LOW
+- NEGATIVE_REVIEW_SPIKE
+
+---
+
+## 4. Advertising Efficiency Decisions
+
+- ACOS_TOO_HIGH
+- ACOS_TOO_LOW
+- TACOS_TOO_HIGH
+- TACOS_TOO_LOW
+- ROAS_TOO_LOW
+- PPC_SPEND_OVERUTILIZED
+- PPC_SPEND_UNDERUTILIZED
+- KEYWORD_MATCH_TYPE_MISMATCH
+- SEARCH_TERM_WASTE
+- BUDGET_CAPPED
+
+---
+
+## 5. Keyword & Search Decisions
+
+- KEYWORD_COVERAGE_INSUFFICIENT
+- HIGH_IMPRESSION_NO_CLICK
+- HIGH_CLICK_NO_CONVERSION
+- SEARCH_TERM_NOT_INDEXED
+- SEARCH_TERM_LOW_RELEVANCE
+- RANKING_DECLINING
+- RANKING_OPPORTUNITY
+
+---
+
+## 6. Inventory & Supply Chain Decisions
+
+- STOCKOUT_RISK
+- STOCKOUT_IMMINENT
+- OVERSTOCK_RISK
+- INVENTORY_TURNOVER_TOO_SLOW
+- INVENTORY_TURNOVER_TOO_FAST
+- RESTOCK_LEAD_TIME_TOO_LONG
+- STORAGE_FEE_RISK
+
+---
+
+## 7. Pricing & Promotion Decisions
+
+- PRICE_TOO_HIGH
+- PRICE_TOO_LOW
+- DISCOUNT_MISCONFIGURED
+- PROMOTION_NOT_EFFECTIVE
+- PROMOTION_OVERUSED
+- COUPON_NOT_UTILIZED
+- DEAL_ELIGIBLE_NOT_USED
+
+---
+
+## 8. Account & Policy Risk Decisions
+
+- ACCOUNT_HEALTH_AT_RISK
+- POLICY_VIOLATION_WARNING
+- SUPPRESSION_RISK
+- LISTING_SUSPENDED
+- CATEGORY_RESTRICTION_RISK
+
+---
+
+## 9. Competitive Landscape Decisions
+
+- COMPETITOR_PRICE_UNDERCUT
+- COMPETITOR_REVIEW_ADVANTAGE
+- COMPETITOR_LISTING_SUPERIOR
+- MARKET_SATURATION_HIGH
+- NICHE_OPPORTUNITY_DETECTED
+
+---
+
+## 10. Growth Opportunity Decisions
+
+- SCALING_OPPORTUNITY
+- NEW_KEYWORD_OPPORTUNITY
+- NEW_MARKETPLACE_OPPORTUNITY
+- PRODUCT_EXPANSION_OPPORTUNITY
+- BRAND_BUILDING_OPPORTUNITY
+
+---
+
+## 11. Data Quality & Observability Decisions
+
+- DATA_INCOMPLETE
+- DATA_STALE
+- DATA_ANOMALY_DETECTED
+- METRIC_DEFINITION_MISMATCH
+- ATTRIBUTION_UNCLEAR
+
+---
+
+## 12. System Confidence Decisions
+
+- SIGNAL_CONFIDENCE_LOW
+- DECISION_CONFIDENCE_LOW
+- MANUAL_REVIEW_REQUIRED
+
+---
+
+## 13. Decision Lifecycle Notes
+
+- All decisions are:
+  - Language-neutral
+  - Versioned
+  - Replayable
+  - Contract-bound
+
+- Any change to:
+  - Decision ID
+  - Category assignment
+  - Semantic meaning
+
+  requires a new Architecture Decision Record (ADR).
+
+---
+
+## 14. Status
+
+- Phase: 5.1
+- Domain: Amazon Growth OS
+- State: Draft → Pending Freeze
+- Next Step: Decision Schema & Contract Definition (Phase 5.2)


### PR DESCRIPTION
## Summary

- Add complete Decision Inventory for Amazon Growth OS
- 63 Decision IDs across 12 categories
- Language-neutral, versioned, replayable machine-verdicts

## Decision Categories

| # | Category | Count |
|---|----------|-------|
| 1 | Listing Quality | 10 |
| 2 | Traffic & Exposure | 7 |
| 3 | Conversion & CVR | 8 |
| 4 | Advertising Efficiency | 10 |
| 5 | Keyword & Search | 7 |
| 6 | Inventory & Supply Chain | 7 |
| 7 | Pricing & Promotion | 7 |
| 8 | Account & Policy Risk | 5 |
| 9 | Competitive Landscape | 5 |
| 10 | Growth Opportunity | 5 |
| 11 | Data Quality & Observability | 5 |
| 12 | System Confidence | 3 |

## Rules

- Decision IDs are immutable once merged
- No natural language conclusions
- No analysis or reasoning text
- Enumeration only

## Next Step

Phase 5.2: Decision Schema & Contract Definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)