### PR TITLE
feat(domain): add Amazon Growth OS agent pipeline (Phase 5.3)

### DIFF
--- a/Agents/amazon-growth/README.md
+++ b/Agents/amazon-growth/README.md
@@ -1,0 +1,48 @@
+# Amazon Growth OS — Domain Agent Pipeline
+
+This pipeline enforces strict separation of concerns:
+
+- Signal Agent: computes metrics only
+- Rule Agent: evaluates boolean triggers only
+- Verdict Agent: outputs schema-bound decisions only
+
+Agents must NOT:
+- Output natural language conclusions
+- Explain reasoning
+- Interpret decision contracts
+
+All explanations are handled by Decision Contracts (Phase 5.2).
+
+## Usage
+
+```js
+import { runSignals } from "./signal_agent.js";
+import { applyRules } from "./rule_agent.js";
+import { generateVerdicts } from "./verdict_agent.js";
+
+const input = {
+  ad_spend: 1000,
+  ad_sales: 2000,
+  total_sales: 5000,
+  orders: 50,
+  sessions: 1000,
+  inventory_units: 100,
+  daily_sales_velocity: 20
+};
+
+const thresholds = {
+  max_acos: 0.35,
+  min_cvr: 0.05,
+  min_inventory_days: 14
+};
+
+const signals = runSignals(input);
+const ruleResults = applyRules(signals, thresholds);
+const decisions = generateVerdicts(ruleResults, signals);
+```
+
+## Expected Output
+
+- `decisions` is an array
+- Each element is a valid Decision JSON (schema-validated)
+- No natural language output

--- a/Agents/amazon-growth/rule_agent.js
+++ b/Agents/amazon-growth/rule_agent.js
@@ -1,0 +1,18 @@
+/**
+ * Rule Agent - Amazon Growth OS
+ *
+ * Purpose: Evaluate boolean triggers only, no verdicts
+ *
+ * Rules:
+ * - ❌ Do NOT output Decision JSON
+ * - ❌ Do NOT write recommendations or explanations
+ * - ✅ Only output decision_id: true/false
+ */
+
+export function applyRules(signals, thresholds) {
+  return {
+    ACOS_TOO_HIGH: signals.acos > thresholds.max_acos,
+    CONVERSION_RATE_TOO_LOW: signals.conversion_rate < thresholds.min_cvr,
+    STOCKOUT_RISK: signals.inventory_days_left < thresholds.min_inventory_days
+  };
+}

--- a/Agents/amazon-growth/signal_agent.js
+++ b/Agents/amazon-growth/signal_agent.js
@@ -1,0 +1,19 @@
+/**
+ * Signal Agent - Amazon Growth OS
+ *
+ * Purpose: Compute metrics only, no judgments
+ *
+ * Rules:
+ * - ❌ Do NOT return decisions
+ * - ❌ Do NOT compare benchmarks
+ * - ✅ Only return numeric facts
+ */
+
+export function runSignals(input) {
+  return {
+    acos: input.ad_spend / input.ad_sales,
+    tacos: input.ad_spend / input.total_sales,
+    conversion_rate: input.orders / input.sessions,
+    inventory_days_left: input.inventory_units / input.daily_sales_velocity
+  };
+}

--- a/Agents/amazon-growth/verdict_agent.js
+++ b/Agents/amazon-growth/verdict_agent.js
@@ -1,0 +1,77 @@
+/**
+ * Verdict Agent - Amazon Growth OS
+ *
+ * Purpose: Output schema-bound decisions only
+ *
+ * Rules:
+ * - ❌ Do NOT return natural language
+ * - ❌ Validation failure throws error
+ * - ✅ Only return schema-validated JSON
+ */
+
+import Ajv from "ajv";
+import schema from "../../contracts/schema/decision.schema.json" assert { type: "json" };
+
+const ajv = new Ajv();
+const validate = ajv.compile(schema);
+
+export function generateVerdicts(ruleResults, signals) {
+  const decisions = [];
+  const timestamp = new Date().toISOString();
+
+  if (ruleResults.ACOS_TOO_HIGH) {
+    const decision = {
+      decision_id: "ACOS_TOO_HIGH",
+      domain: "amazon-growth",
+      severity: "warning",
+      confidence: 0.82,
+      evidence: {
+        acos: signals.acos
+      },
+      timestamp,
+      version: "v1.0"
+    };
+    if (!validate(decision)) {
+      throw new Error("Schema validation failed: ACOS_TOO_HIGH");
+    }
+    decisions.push(decision);
+  }
+
+  if (ruleResults.CONVERSION_RATE_TOO_LOW) {
+    const decision = {
+      decision_id: "CONVERSION_RATE_TOO_LOW",
+      domain: "amazon-growth",
+      severity: "warning",
+      confidence: 0.76,
+      evidence: {
+        conversion_rate: signals.conversion_rate
+      },
+      timestamp,
+      version: "v1.0"
+    };
+    if (!validate(decision)) {
+      throw new Error("Schema validation failed: CONVERSION_RATE_TOO_LOW");
+    }
+    decisions.push(decision);
+  }
+
+  if (ruleResults.STOCKOUT_RISK) {
+    const decision = {
+      decision_id: "STOCKOUT_RISK",
+      domain: "amazon-growth",
+      severity: "critical",
+      confidence: 0.88,
+      evidence: {
+        inventory_days_left: signals.inventory_days_left
+      },
+      timestamp,
+      version: "v1.0"
+    };
+    if (!validate(decision)) {
+      throw new Error("Schema validation failed: STOCKOUT_RISK");
+    }
+    decisions.push(decision);
+  }
+
+  return decisions;
+}


### PR DESCRIPTION
## Summary

Implement Domain Agent Pipeline with strict separation of concerns:

| Agent | Responsibility | Output |
|-------|---------------|--------|
| Signal Agent | Compute metrics only | Numeric facts |
| Rule Agent | Evaluate boolean triggers | decision_id: true/false |
| Verdict Agent | Output schema-bound decisions | Validated JSON |

## Files Added

| File | Purpose |
|------|---------|
| `agents/amazon-growth/signal_agent.js` | Metric computation |
| `agents/amazon-growth/rule_agent.js` | Boolean rule evaluation |
| `agents/amazon-growth/verdict_agent.js` | Schema-validated decision output |
| `agents/amazon-growth/README.md` | Pipeline documentation |

## Agent Pipeline Flow

```
Input → Signal Agent → Rule Agent → Verdict Agent → Decision[]
```

## Design Principles

- ❌ Agents do NOT output natural language
- ❌ Agents do NOT explain reasoning
- ❌ Agents do NOT interpret contracts
- ✅ All decisions pass `decision.schema.json` validation
- ✅ Explanations handled by Decision Contracts (Phase 5.2)

## Decisions Supported

- `ACOS_TOO_HIGH` (severity: warning)
- `CONVERSION_RATE_TOO_LOW` (severity: warning)
- `STOCKOUT_RISK` (severity: critical)

## DoD Checklist

- [x] Agent only outputs JSON
- [x] All Decisions pass schema validation
- [x] Signal / Rule / Verdict responsibilities separated
- [x] Does not affect existing CI / Runtime
- [x] Can produce at least 2 Decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)