### PR TITLE
feat(domain): add GEO OS agent pipeline (Phase 5.3)

### DIFF
--- a/Agents/geo-os/README.md
+++ b/Agents/geo-os/README.md
@@ -1,0 +1,57 @@
+# GEO OS — Domain Agent Pipeline
+
+This pipeline enforces strict separation of concerns:
+
+- Signal Agent: computes metrics only
+- Rule Agent: evaluates boolean triggers only
+- Verdict Agent: outputs schema-bound decisions only
+
+Agents must NOT:
+- Output natural language conclusions
+- Explain reasoning
+- Interpret decision contracts
+
+All explanations are handled by Decision Contracts (Phase 5.2).
+
+## Usage
+
+```js
+import { runSignals } from "./signal_agent.js";
+import { applyRules } from "./rule_agent.js";
+import { generateVerdicts } from "./verdict_agent.js";
+
+const input = {
+  impressions: 5000,
+  category_avg_impressions: 10000,
+  local_pack_position: 5,
+  total_rating_score: 180,
+  review_count: 45,
+  responded_reviews: 20,
+  filled_fields: 8,
+  total_fields: 10,
+  consistent_citations: 40,
+  total_citations: 50,
+  days_since_post: 45
+};
+
+const thresholds = {
+  min_visibility_score: 0.6,
+  max_local_pack_rank: 3,
+  min_review_rating: 4.0,
+  min_review_count: 50,
+  min_response_rate: 0.5,
+  min_profile_completeness: 0.9,
+  min_citation_consistency: 0.85,
+  max_days_since_post: 30
+};
+
+const signals = runSignals(input);
+const ruleResults = applyRules(signals, thresholds);
+const decisions = generateVerdicts(ruleResults, signals);
+```
+
+## Expected Output
+
+- `decisions` is an array
+- Each element is a valid Decision JSON (schema-validated)
+- No natural language output

--- a/Agents/geo-os/rule_agent.js
+++ b/Agents/geo-os/rule_agent.js
@@ -1,0 +1,23 @@
+/**
+ * Rule Agent - GEO OS
+ *
+ * Purpose: Evaluate boolean triggers only, no verdicts
+ *
+ * Rules:
+ * - ❌ Do NOT output Decision JSON
+ * - ❌ Do NOT write recommendations or explanations
+ * - ✅ Only output decision_id: true/false
+ */
+
+export function applyRules(signals, thresholds) {
+  return {
+    VISIBILITY_TOO_LOW: signals.visibility_score < thresholds.min_visibility_score,
+    LOCAL_PACK_RANK_DROP: signals.local_pack_rank > thresholds.max_local_pack_rank,
+    REVIEW_RATING_TOO_LOW: signals.review_rating < thresholds.min_review_rating,
+    REVIEW_COUNT_TOO_LOW: signals.review_count < thresholds.min_review_count,
+    REVIEW_RESPONSE_RATE_LOW: signals.review_response_rate < thresholds.min_response_rate,
+    PROFILE_INCOMPLETE: signals.profile_completeness < thresholds.min_profile_completeness,
+    CITATION_INCONSISTENCY: signals.citation_consistency_score < thresholds.min_citation_consistency,
+    POSTS_STALE: signals.days_since_last_post > thresholds.max_days_since_post
+  };
+}

--- a/Agents/geo-os/signal_agent.js
+++ b/Agents/geo-os/signal_agent.js
@@ -1,0 +1,23 @@
+/**
+ * Signal Agent - GEO OS
+ *
+ * Purpose: Compute metrics only, no judgments
+ *
+ * Rules:
+ * - ❌ Do NOT return decisions
+ * - ❌ Do NOT compare benchmarks
+ * - ✅ Only return numeric facts
+ */
+
+export function runSignals(input) {
+  return {
+    visibility_score: input.impressions / input.category_avg_impressions,
+    local_pack_rank: input.local_pack_position,
+    review_rating: input.total_rating_score / input.review_count,
+    review_count: input.review_count,
+    review_response_rate: input.responded_reviews / input.review_count,
+    profile_completeness: input.filled_fields / input.total_fields,
+    citation_consistency_score: input.consistent_citations / input.total_citations,
+    days_since_last_post: input.days_since_post
+  };
+}

--- a/Agents/geo-os/verdict_agent.js
+++ b/Agents/geo-os/verdict_agent.js
@@ -1,0 +1,171 @@
+/**
+ * Verdict Agent - GEO OS
+ *
+ * Purpose: Output schema-bound decisions only
+ *
+ * Rules:
+ * - ❌ Do NOT return natural language
+ * - ❌ Validation failure throws error
+ * - ✅ Only return schema-validated JSON
+ */
+
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const schema = require("../../contracts/schema/decision.schema.json");
+
+const ajv = new Ajv();
+addFormats(ajv);
+const validate = ajv.compile(schema);
+
+export function generateVerdicts(ruleResults, signals) {
+  const decisions = [];
+  const timestamp = new Date().toISOString();
+
+  if (ruleResults.VISIBILITY_TOO_LOW) {
+    const decision = {
+      decision_id: "VISIBILITY_TOO_LOW",
+      domain: "geo-os",
+      severity: "warning",
+      confidence: 0.80,
+      evidence: {
+        visibility_score: signals.visibility_score
+      },
+      timestamp,
+      version: "v1.0"
+    };
+    if (!validate(decision)) {
+      throw new Error("Schema validation failed: VISIBILITY_TOO_LOW");
+    }
+    decisions.push(decision);
+  }
+
+  if (ruleResults.LOCAL_PACK_RANK_DROP) {
+    const decision = {
+      decision_id: "LOCAL_PACK_RANK_DROP",
+      domain: "geo-os",
+      severity: "critical",
+      confidence: 0.85,
+      evidence: {
+        local_pack_rank: signals.local_pack_rank
+      },
+      timestamp,
+      version: "v1.0"
+    };
+    if (!validate(decision)) {
+      throw new Error("Schema validation failed: LOCAL_PACK_RANK_DROP");
+    }
+    decisions.push(decision);
+  }
+
+  if (ruleResults.REVIEW_RATING_TOO_LOW) {
+    const decision = {
+      decision_id: "REVIEW_RATING_TOO_LOW",
+      domain: "geo-os",
+      severity: "warning",
+      confidence: 0.82,
+      evidence: {
+        review_rating: signals.review_rating
+      },
+      timestamp,
+      version: "v1.0"
+    };
+    if (!validate(decision)) {
+      throw new Error("Schema validation failed: REVIEW_RATING_TOO_LOW");
+    }
+    decisions.push(decision);
+  }
+
+  if (ruleResults.REVIEW_COUNT_TOO_LOW) {
+    const decision = {
+      decision_id: "REVIEW_COUNT_TOO_LOW",
+      domain: "geo-os",
+      severity: "warning",
+      confidence: 0.78,
+      evidence: {
+        review_count: signals.review_count
+      },
+      timestamp,
+      version: "v1.0"
+    };
+    if (!validate(decision)) {
+      throw new Error("Schema validation failed: REVIEW_COUNT_TOO_LOW");
+    }
+    decisions.push(decision);
+  }
+
+  if (ruleResults.REVIEW_RESPONSE_RATE_LOW) {
+    const decision = {
+      decision_id: "REVIEW_RESPONSE_RATE_LOW",
+      domain: "geo-os",
+      severity: "warning",
+      confidence: 0.75,
+      evidence: {
+        review_response_rate: signals.review_response_rate
+      },
+      timestamp,
+      version: "v1.0"
+    };
+    if (!validate(decision)) {
+      throw new Error("Schema validation failed: REVIEW_RESPONSE_RATE_LOW");
+    }
+    decisions.push(decision);
+  }
+
+  if (ruleResults.PROFILE_INCOMPLETE) {
+    const decision = {
+      decision_id: "PROFILE_INCOMPLETE",
+      domain: "geo-os",
+      severity: "warning",
+      confidence: 0.90,
+      evidence: {
+        profile_completeness: signals.profile_completeness
+      },
+      timestamp,
+      version: "v1.0"
+    };
+    if (!validate(decision)) {
+      throw new Error("Schema validation failed: PROFILE_INCOMPLETE");
+    }
+    decisions.push(decision);
+  }
+
+  if (ruleResults.CITATION_INCONSISTENCY) {
+    const decision = {
+      decision_id: "CITATION_INCONSISTENCY",
+      domain: "geo-os",
+      severity: "warning",
+      confidence: 0.85,
+      evidence: {
+        citation_consistency_score: signals.citation_consistency_score
+      },
+      timestamp,
+      version: "v1.0"
+    };
+    if (!validate(decision)) {
+      throw new Error("Schema validation failed: CITATION_INCONSISTENCY");
+    }
+    decisions.push(decision);
+  }
+
+  if (ruleResults.POSTS_STALE) {
+    const decision = {
+      decision_id: "POSTS_STALE",
+      domain: "geo-os",
+      severity: "info",
+      confidence: 0.88,
+      evidence: {
+        days_since_last_post: signals.days_since_last_post
+      },
+      timestamp,
+      version: "v1.0"
+    };
+    if (!validate(decision)) {
+      throw new Error("Schema validation failed: POSTS_STALE");
+    }
+    decisions.push(decision);
+  }
+
+  return decisions;
+}

--- a/contracts/geo-os/README.md
+++ b/contracts/geo-os/README.md
@@ -1,0 +1,14 @@
+# GEO OS — Decision Contracts
+
+This directory defines human-consumable contracts for all machine decisions
+produced by GEO OS.
+
+Rules:
+- Contracts explain decisions; they do not generate them
+- Contracts are versioned and governed
+- Any semantic change requires a version bump and ADR
+
+These contracts are used for:
+- User-facing explanations
+- Audit and replay interpretation
+- Consistent action guidance

--- a/contracts/geo-os/contracts.yaml
+++ b/contracts/geo-os/contracts.yaml
@@ -1,0 +1,694 @@
+domain: geo-os
+contract_version: v1.0
+
+decisions:
+
+  # =============================================================================
+  # Visibility & Exposure Decisions
+  # =============================================================================
+
+  VISIBILITY_TOO_LOW:
+    version: v1.0
+    severity: warning
+    meaning: Business is not appearing in relevant local searches
+    what_it_means: >
+      The business listing is receiving fewer impressions in local search
+      results than expected for its category and location, indicating
+      potential optimization or authority issues.
+    typical_actions:
+      - improve listing completeness
+      - build local citations
+      - optimize category selection
+    evidence_fields:
+      - impressions
+      - category_benchmark
+      - visibility_score
+
+  VISIBILITY_DECLINING:
+    version: v1.0
+    severity: warning
+    meaning: Search visibility has decreased over time
+    what_it_means: >
+      The business is appearing in fewer searches compared to the previous
+      period, suggesting competitive pressure or algorithm changes affecting
+      local ranking factors.
+    typical_actions:
+      - audit recent listing changes
+      - check for new competitors
+      - review ranking factors
+    evidence_fields:
+      - current_impressions
+      - previous_impressions
+      - trend_percentage
+
+  MAP_PACK_EXCLUDED:
+    version: v1.0
+    severity: critical
+    meaning: Business is not appearing in the local map pack
+    what_it_means: >
+      The listing is not showing in the top 3 map pack results for key
+      local queries, significantly reducing visibility and click potential.
+    typical_actions:
+      - verify listing eligibility
+      - improve local relevance signals
+      - build proximity relevance
+    evidence_fields:
+      - target_keywords
+      - current_position
+      - map_pack_competitors
+
+  KNOWLEDGE_PANEL_MISSING:
+    version: v1.0
+    severity: warning
+    meaning: Business lacks a knowledge panel in search results
+    what_it_means: >
+      The business does not have a branded knowledge panel appearing for
+      direct searches, reducing credibility and visibility for brand queries.
+    typical_actions:
+      - claim and verify listing
+      - build consistent citations
+      - add structured data
+    evidence_fields:
+      - brand_query
+      - panel_status
+      - entity_recognition
+
+  # =============================================================================
+  # Ranking & Position Decisions
+  # =============================================================================
+
+  RANKING_TOO_LOW:
+    version: v1.0
+    severity: warning
+    meaning: Local search ranking is below target position
+    what_it_means: >
+      The business ranks lower than desired for key local search queries,
+      reducing organic traffic and requiring improved local SEO factors.
+    typical_actions:
+      - optimize Google Business Profile
+      - improve website local signals
+      - build local backlinks
+    evidence_fields:
+      - keyword
+      - current_rank
+      - target_rank
+
+  RANKING_DECLINING:
+    version: v1.0
+    severity: warning
+    meaning: Search ranking position has dropped
+    what_it_means: >
+      The business has lost ranking positions for monitored keywords,
+      indicating competitive pressure or degraded local signals.
+    typical_actions:
+      - analyze ranking factor changes
+      - review competitor improvements
+      - strengthen local signals
+    evidence_fields:
+      - keyword
+      - current_rank
+      - previous_rank
+      - rank_change
+
+  LOCAL_PACK_RANK_DROP:
+    version: v1.0
+    severity: critical
+    meaning: Position in local pack has decreased
+    what_it_means: >
+      The business has dropped from a higher position in the local 3-pack,
+      reducing click-through rate and local traffic significantly.
+    typical_actions:
+      - improve listing engagement
+      - increase review activity
+      - optimize for proximity
+    evidence_fields:
+      - previous_position
+      - current_position
+      - keyword
+
+  # =============================================================================
+  # Local Relevance Decisions
+  # =============================================================================
+
+  LOCAL_RELEVANCE_WEAK:
+    version: v1.0
+    severity: warning
+    meaning: Business signals weak relevance for local queries
+    what_it_means: >
+      The listing lacks strong signals connecting the business to its
+      service area and local search intent.
+    typical_actions:
+      - add location-specific content
+      - build local citations
+      - optimize service area
+    evidence_fields:
+      - relevance_score
+      - location_signals
+      - local_content
+
+  CATEGORY_MISMATCH:
+    version: v1.0
+    severity: warning
+    meaning: Business category does not match search intent
+    what_it_means: >
+      The selected categories do not align well with the queries the
+      business wants to rank for, limiting search relevance.
+    typical_actions:
+      - review primary category
+      - add relevant secondary categories
+      - align with competitor categories
+    evidence_fields:
+      - current_categories
+      - suggested_categories
+      - competitor_categories
+
+  PRIMARY_CATEGORY_SUBOPTIMAL:
+    version: v1.0
+    severity: warning
+    meaning: Primary category is not the best choice
+    what_it_means: >
+      A more relevant primary category exists that would better match
+      the business's core services and target searches.
+    typical_actions:
+      - research category options
+      - analyze top competitors
+      - update primary category
+    evidence_fields:
+      - current_primary
+      - recommended_primary
+      - category_search_volume
+
+  # =============================================================================
+  # Content Completeness Decisions
+  # =============================================================================
+
+  PROFILE_INCOMPLETE:
+    version: v1.0
+    severity: warning
+    meaning: Business profile is missing key information
+    what_it_means: >
+      The Google Business Profile lacks essential information fields
+      that affect ranking and user trust.
+    typical_actions:
+      - complete all profile sections
+      - add missing attributes
+      - verify information accuracy
+    evidence_fields:
+      - completeness_score
+      - missing_fields
+      - profile_checklist
+
+  DESCRIPTION_MISSING:
+    version: v1.0
+    severity: warning
+    meaning: Business description is not set
+    what_it_means: >
+      The listing lacks a business description, missing an opportunity
+      to communicate services and include relevant keywords.
+    typical_actions:
+      - write compelling description
+      - include key services
+      - add location keywords
+    evidence_fields:
+      - description_status
+      - character_count
+
+  HOURS_OUTDATED:
+    version: v1.0
+    severity: warning
+    meaning: Business hours may be incorrect
+    what_it_means: >
+      The listed business hours have not been updated recently and may
+      no longer reflect actual operating hours.
+    typical_actions:
+      - verify current hours
+      - update special hours
+      - set holiday hours
+    evidence_fields:
+      - last_hours_update
+      - current_hours
+      - discrepancy_detected
+
+  PHOTOS_INSUFFICIENT:
+    version: v1.0
+    severity: warning
+    meaning: Listing has too few photos
+    what_it_means: >
+      The business profile has fewer photos than competitors, reducing
+      engagement and trust signals.
+    typical_actions:
+      - add exterior photos
+      - upload interior photos
+      - include team photos
+    evidence_fields:
+      - photo_count
+      - competitor_avg_photos
+      - photo_categories
+
+  POSTS_STALE:
+    version: v1.0
+    severity: info
+    meaning: No recent Google Posts activity
+    what_it_means: >
+      The business has not published Google Posts recently, missing
+      engagement opportunities and freshness signals.
+    typical_actions:
+      - create promotional post
+      - share business updates
+      - post regularly
+    evidence_fields:
+      - last_post_date
+      - days_since_post
+      - post_count
+
+  # =============================================================================
+  # Entity Consistency Decisions
+  # =============================================================================
+
+  NAP_INCONSISTENT:
+    version: v1.0
+    severity: critical
+    meaning: Name, Address, Phone inconsistent across web
+    what_it_means: >
+      The business's core information varies across different citations
+      and directories, confusing search engines and users.
+    typical_actions:
+      - audit all citations
+      - correct inconsistencies
+      - establish NAP standard
+    evidence_fields:
+      - inconsistency_count
+      - affected_sources
+      - variation_types
+
+  DUPLICATE_LISTING_DETECTED:
+    version: v1.0
+    severity: critical
+    meaning: Multiple listings exist for same business
+    what_it_means: >
+      Duplicate Google Business Profiles exist for the same location,
+      splitting ranking signals and confusing users.
+    typical_actions:
+      - identify duplicate listings
+      - merge or remove duplicates
+      - report duplicates to Google
+    evidence_fields:
+      - duplicate_count
+      - duplicate_urls
+      - ownership_status
+
+  CITATION_INCONSISTENCY:
+    version: v1.0
+    severity: warning
+    meaning: Business citations have conflicting information
+    what_it_means: >
+      Directory listings and citations show different information,
+      weakening local trust signals.
+    typical_actions:
+      - audit citation sources
+      - update incorrect listings
+      - build consistent citations
+    evidence_fields:
+      - citation_count
+      - inconsistent_citations
+      - consistency_score
+
+  SCHEMA_MARKUP_MISSING:
+    version: v1.0
+    severity: warning
+    meaning: Website lacks local business structured data
+    what_it_means: >
+      The business website does not have LocalBusiness schema markup,
+      missing opportunities for enhanced search display.
+    typical_actions:
+      - add LocalBusiness schema
+      - include organization schema
+      - validate structured data
+    evidence_fields:
+      - schema_status
+      - recommended_schemas
+      - website_url
+
+  # =============================================================================
+  # Reviews & Reputation Decisions
+  # =============================================================================
+
+  REVIEW_COUNT_TOO_LOW:
+    version: v1.0
+    severity: warning
+    meaning: Business has fewer reviews than competitors
+    what_it_means: >
+      The review count is below category average, reducing trust signals
+      and local ranking potential.
+    typical_actions:
+      - implement review request process
+      - follow up with customers
+      - make reviewing easy
+    evidence_fields:
+      - review_count
+      - competitor_avg_count
+      - category_benchmark
+
+  REVIEW_RATING_TOO_LOW:
+    version: v1.0
+    severity: warning
+    meaning: Average star rating is below threshold
+    what_it_means: >
+      The overall star rating is lower than competitors, potentially
+      deterring customers and affecting rankings.
+    typical_actions:
+      - address negative feedback
+      - improve service quality
+      - encourage happy customers to review
+    evidence_fields:
+      - current_rating
+      - competitor_avg_rating
+      - rating_threshold
+
+  NEGATIVE_REVIEW_SPIKE:
+    version: v1.0
+    severity: critical
+    meaning: Sudden increase in negative reviews detected
+    what_it_means: >
+      An unusual number of low-rating reviews have appeared recently,
+      indicating a service issue or potential attack.
+    typical_actions:
+      - investigate root cause
+      - respond to reviews promptly
+      - address service issues
+    evidence_fields:
+      - recent_negative_count
+      - baseline_negative_rate
+      - spike_percentage
+
+  REVIEW_RESPONSE_RATE_LOW:
+    version: v1.0
+    severity: warning
+    meaning: Business is not responding to reviews
+    what_it_means: >
+      A low percentage of reviews receive owner responses, missing
+      engagement opportunities and trust signals.
+    typical_actions:
+      - respond to all reviews
+      - create response templates
+      - prioritize negative reviews
+    evidence_fields:
+      - response_rate
+      - unresponded_count
+      - avg_response_time
+
+  # =============================================================================
+  # Proximity & Geography Decisions
+  # =============================================================================
+
+  PROXIMITY_DISADVANTAGE:
+    version: v1.0
+    severity: info
+    meaning: Business is far from searcher concentration
+    what_it_means: >
+      The physical location is distant from high-density search areas,
+      creating a natural ranking disadvantage for nearby searches.
+    typical_actions:
+      - optimize for wider service area
+      - target specific neighborhoods
+      - consider additional locations
+    evidence_fields:
+      - distance_to_center
+      - competitor_proximity
+      - search_density_map
+
+  SERVICE_RADIUS_UNDEFINED:
+    version: v1.0
+    severity: warning
+    meaning: Service area is not properly configured
+    what_it_means: >
+      The listing does not clearly define its service area, limiting
+      appearance in relevant nearby searches.
+    typical_actions:
+      - define service areas
+      - set delivery radius
+      - specify served locations
+    evidence_fields:
+      - service_area_status
+      - coverage_type
+      - defined_areas
+
+  LOCATION_PIN_INACCURATE:
+    version: v1.0
+    severity: critical
+    meaning: Map pin location is incorrect
+    what_it_means: >
+      The Google Maps pin does not match the actual business location,
+      causing navigation issues and trust problems.
+    typical_actions:
+      - correct pin location
+      - verify address format
+      - submit location correction
+    evidence_fields:
+      - pin_coordinates
+      - actual_coordinates
+      - distance_error
+
+  # =============================================================================
+  # Competitive Density Decisions
+  # =============================================================================
+
+  MARKET_SATURATION_HIGH:
+    version: v1.0
+    severity: info
+    meaning: High competitor density in target area
+    what_it_means: >
+      Many competitors are vying for the same local searches, requiring
+      stronger differentiation and optimization.
+    typical_actions:
+      - identify unique value proposition
+      - focus on niche keywords
+      - improve all ranking factors
+    evidence_fields:
+      - competitor_count
+      - market_density_score
+      - category
+
+  COMPETITOR_DOMINANCE:
+    version: v1.0
+    severity: warning
+    meaning: A competitor dominates local rankings
+    what_it_means: >
+      One or more competitors consistently outrank for key searches,
+      capturing majority of local traffic.
+    typical_actions:
+      - analyze competitor strategy
+      - identify ranking gaps
+      - develop catch-up plan
+    evidence_fields:
+      - dominant_competitor
+      - their_positions
+      - our_positions
+
+  SHARE_OF_VOICE_LOW:
+    version: v1.0
+    severity: warning
+    meaning: Business captures small portion of local searches
+    what_it_means: >
+      The business appears in a small percentage of relevant local
+      searches compared to total market opportunity.
+    typical_actions:
+      - expand keyword targeting
+      - improve ranking positions
+      - increase content coverage
+    evidence_fields:
+      - share_of_voice
+      - total_opportunity
+      - competitor_shares
+
+  # =============================================================================
+  # Spam & Risk Signals Decisions
+  # =============================================================================
+
+  SPAM_SIGNAL_DETECTED:
+    version: v1.0
+    severity: critical
+    meaning: Listing shows potential spam indicators
+    what_it_means: >
+      The listing exhibits characteristics that could be flagged as spam
+      by Google's algorithms, risking penalties.
+    typical_actions:
+      - remove keyword stuffing
+      - verify business legitimacy
+      - clean up listing
+    evidence_fields:
+      - spam_indicators
+      - risk_score
+      - flagged_elements
+
+  SUSPENSION_RISK:
+    version: v1.0
+    severity: critical
+    meaning: Listing at risk of suspension
+    what_it_means: >
+      The business profile shows patterns that could lead to suspension,
+      requiring immediate corrective action.
+    typical_actions:
+      - review guidelines compliance
+      - remove violations
+      - verify all information
+    evidence_fields:
+      - risk_factors
+      - violation_types
+      - suspension_likelihood
+
+  KEYWORD_STUFFING_DETECTED:
+    version: v1.0
+    severity: warning
+    meaning: Business name contains excessive keywords
+    what_it_means: >
+      The business name includes added keywords beyond the legal name,
+      violating Google guidelines and risking suspension.
+    typical_actions:
+      - revert to legal business name
+      - remove added keywords
+      - use proper categories instead
+    evidence_fields:
+      - current_name
+      - legal_name
+      - added_keywords
+
+  # =============================================================================
+  # Growth Opportunity Decisions
+  # =============================================================================
+
+  NEW_KEYWORD_OPPORTUNITY:
+    version: v1.0
+    severity: info
+    meaning: Untapped keyword potential identified
+    what_it_means: >
+      Relevant local keywords exist where the business could rank
+      but currently has no visibility.
+    typical_actions:
+      - create targeted content
+      - optimize for new keywords
+      - expand service descriptions
+    evidence_fields:
+      - opportunity_keywords
+      - search_volume
+      - competition_level
+
+  CITATION_BUILDING_OPPORTUNITY:
+    version: v1.0
+    severity: info
+    meaning: Valuable citation sources not yet claimed
+    what_it_means: >
+      High-authority directories and citation sources exist where the
+      business is not yet listed.
+    typical_actions:
+      - identify missing citations
+      - claim directory listings
+      - ensure NAP consistency
+    evidence_fields:
+      - missing_citations
+      - priority_sources
+      - potential_authority
+
+  # =============================================================================
+  # Data Quality Decisions
+  # =============================================================================
+
+  DATA_INCOMPLETE:
+    version: v1.0
+    severity: info
+    meaning: Required analysis data is missing
+    what_it_means: >
+      One or more data points needed for accurate decision-making
+      are unavailable, limiting analysis reliability.
+    typical_actions:
+      - verify data source access
+      - check API connectivity
+      - review data freshness
+    evidence_fields:
+      - missing_fields
+      - data_source
+      - last_update
+
+  DATA_STALE:
+    version: v1.0
+    severity: warning
+    meaning: Data has not been refreshed recently
+    what_it_means: >
+      The data used for analysis is older than acceptable thresholds,
+      potentially reflecting outdated conditions.
+    typical_actions:
+      - refresh data sources
+      - check sync status
+      - verify data pipeline
+    evidence_fields:
+      - data_age_days
+      - freshness_threshold
+      - last_sync
+
+  SOURCE_DISCREPANCY:
+    version: v1.0
+    severity: warning
+    meaning: Different data sources show conflicting information
+    what_it_means: >
+      Multiple data sources report different values for the same metric,
+      indicating sync issues or data quality problems.
+    typical_actions:
+      - identify authoritative source
+      - investigate discrepancy
+      - reconcile data
+    evidence_fields:
+      - conflicting_sources
+      - value_differences
+      - reconciliation_needed
+
+  # =============================================================================
+  # System Confidence Decisions
+  # =============================================================================
+
+  SIGNAL_CONFIDENCE_LOW:
+    version: v1.0
+    severity: info
+    meaning: Input signals have low reliability
+    what_it_means: >
+      The data used to generate decisions has lower than normal
+      confidence, potentially affecting decision accuracy.
+    typical_actions:
+      - gather additional data
+      - verify signal sources
+      - apply human review
+    evidence_fields:
+      - confidence_score
+      - low_confidence_signals
+      - threshold
+
+  DECISION_CONFIDENCE_LOW:
+    version: v1.0
+    severity: info
+    meaning: Decision generated with below-threshold confidence
+    what_it_means: >
+      The system produced a decision but supporting evidence is weaker
+      than normal, warranting human review.
+    typical_actions:
+      - review evidence manually
+      - gather additional data
+      - defer action if uncertain
+    evidence_fields:
+      - confidence_score
+      - confidence_threshold
+      - limiting_factors
+
+  MANUAL_REVIEW_REQUIRED:
+    version: v1.0
+    severity: warning
+    meaning: Human review is needed before action
+    what_it_means: >
+      The situation is too complex or ambiguous for automated decision,
+      requiring human judgment.
+    typical_actions:
+      - review all evidence
+      - consult with expert
+      - make informed decision
+    evidence_fields:
+      - review_reason
+      - evidence_summary
+      - recommended_reviewers

--- a/docs/domain/geo-os/DECISIONS.md
+++ b/docs/domain/geo-os/DECISIONS.md
@@ -1,0 +1,183 @@
+# GEO OS — Decision Inventory
+
+> Purpose:
+> This document defines the complete decision surface of GEO OS.
+> Each decision represents a machine-verdict that can be replayed, audited,
+> and governed. Decisions are language-neutral and versioned.
+>
+> Rules:
+> - Decision IDs are immutable once merged
+> - No natural language conclusions
+> - No analysis or reasoning text
+> - Enumeration only
+
+---
+
+## 1. Visibility & Exposure Decisions
+
+- VISIBILITY_TOO_LOW
+- VISIBILITY_DECLINING
+- IMPRESSIONS_BELOW_THRESHOLD
+- SEARCH_APPEARANCE_MISSING
+- MAP_PACK_EXCLUDED
+- FEATURED_SNIPPET_LOST
+- KNOWLEDGE_PANEL_MISSING
+
+---
+
+## 2. Ranking & Position Decisions
+
+- RANKING_TOO_LOW
+- RANKING_DECLINING
+- RANKING_VOLATILE
+- LOCAL_PACK_RANK_DROP
+- ORGANIC_RANK_BELOW_TARGET
+- KEYWORD_RANK_STAGNANT
+- SERP_FEATURE_LOST
+
+---
+
+## 3. Local Relevance Decisions
+
+- LOCAL_RELEVANCE_WEAK
+- SERVICE_AREA_MISMATCH
+- CATEGORY_MISMATCH
+- PRIMARY_CATEGORY_SUBOPTIMAL
+- SECONDARY_CATEGORY_MISSING
+- LOCAL_KEYWORD_COVERAGE_LOW
+- GEO_MODIFIER_MISSING
+
+---
+
+## 4. Content Completeness Decisions
+
+- PROFILE_INCOMPLETE
+- DESCRIPTION_MISSING
+- DESCRIPTION_TOO_SHORT
+- HOURS_MISSING
+- HOURS_OUTDATED
+- ATTRIBUTES_INCOMPLETE
+- PHOTOS_INSUFFICIENT
+- POSTS_STALE
+- QUESTIONS_UNANSWERED
+
+---
+
+## 5. Entity Consistency Decisions
+
+- NAP_INCONSISTENT
+- NAME_MISMATCH
+- ADDRESS_MISMATCH
+- PHONE_MISMATCH
+- WEBSITE_MISMATCH
+- DUPLICATE_LISTING_DETECTED
+- CITATION_INCONSISTENCY
+- SCHEMA_MARKUP_MISSING
+- SCHEMA_MARKUP_INVALID
+
+---
+
+## 6. Reviews & Reputation Decisions
+
+- REVIEW_COUNT_TOO_LOW
+- REVIEW_RATING_TOO_LOW
+- REVIEW_RATING_DECLINING
+- NEGATIVE_REVIEW_SPIKE
+- REVIEW_VELOCITY_TOO_LOW
+- REVIEW_RESPONSE_RATE_LOW
+- REVIEW_RESPONSE_DELAYED
+- FAKE_REVIEW_RISK
+
+---
+
+## 7. Proximity & Geography Decisions
+
+- PROXIMITY_DISADVANTAGE
+- SERVICE_RADIUS_UNDEFINED
+- GEO_TARGETING_MISMATCH
+- LOCATION_PIN_INACCURATE
+- COVERAGE_AREA_GAP
+- MULTI_LOCATION_CONFLICT
+
+---
+
+## 8. Competitive Density Decisions
+
+- MARKET_SATURATION_HIGH
+- COMPETITOR_DOMINANCE
+- COMPETITOR_REVIEW_ADVANTAGE
+- COMPETITOR_CONTENT_SUPERIOR
+- NICHE_OPPORTUNITY_DETECTED
+- SHARE_OF_VOICE_LOW
+
+---
+
+## 9. Spam & Risk Signals Decisions
+
+- SPAM_SIGNAL_DETECTED
+- POLICY_VIOLATION_RISK
+- SUSPENSION_RISK
+- LISTING_SUPPRESSED
+- GUIDELINE_VIOLATION
+- KEYWORD_STUFFING_DETECTED
+- LINK_SCHEME_RISK
+
+---
+
+## 10. Growth Opportunity Decisions
+
+- SCALING_OPPORTUNITY
+- NEW_KEYWORD_OPPORTUNITY
+- NEW_LOCATION_OPPORTUNITY
+- SERVICE_EXPANSION_OPPORTUNITY
+- CONTENT_GAP_OPPORTUNITY
+- CITATION_BUILDING_OPPORTUNITY
+- BACKLINK_OPPORTUNITY
+
+---
+
+## 11. Data Quality Decisions
+
+- DATA_INCOMPLETE
+- DATA_STALE
+- DATA_ANOMALY_DETECTED
+- METRIC_DEFINITION_MISMATCH
+- SOURCE_DISCREPANCY
+- CRAWL_ERROR_DETECTED
+- API_DATA_UNAVAILABLE
+
+---
+
+## 12. System Confidence Decisions
+
+- SIGNAL_CONFIDENCE_LOW
+- DECISION_CONFIDENCE_LOW
+- MANUAL_REVIEW_REQUIRED
+- INSUFFICIENT_DATA
+- MODEL_UNCERTAINTY_HIGH
+
+---
+
+## 13. Decision Lifecycle Notes
+
+- All decisions are:
+  - Language-neutral
+  - Versioned
+  - Replayable
+  - Contract-bound
+
+- Any change to:
+  - Decision ID
+  - Category assignment
+  - Semantic meaning
+
+  requires a new Architecture Decision Record (ADR).
+
+---
+
+## 14. Status
+
+- Phase: 5.1
+- Domain: GEO OS
+- State: Draft → Pending Freeze
+- Next Step: Decision Schema & Contract Definition (Phase 5.2)


### PR DESCRIPTION
## Summary

- Implement domain-restricted agent pipeline for GEO OS
- Follow exact same pattern as Amazon Growth OS
- Uses ajv + ajv-formats for schema validation

## Dependencies

This PR depends on:
- PR #23 (Phase 5.1 - Decision Inventory)
- PR #24 (Phase 5.2 - Decision Contracts)

## Agent Pipeline

| Agent | Purpose | Output |
|-------|---------|--------|
| Signal Agent | Compute metrics | 8 numeric signals |
| Rule Agent | Boolean triggers | 8 decision triggers |
| Verdict Agent | Schema-bound JSON | Validated decisions |

## Signals Computed

- visibility_score
- local_pack_rank
- review_rating
- review_count
- review_response_rate
- profile_completeness
- citation_consistency_score
- days_since_last_post

## Test plan

- [x] Signal Agent only returns numeric facts
- [x] Rule Agent only returns boolean triggers
- [x] Verdict Agent validates against decision.schema.json
- [x] No natural language in any agent output

🤖 Generated with [Claude Code](https://claude.com/claude-code)