### PR TITLE
chore(public): redact private repository references from docs

### DIFF
--- a/_meta/docs/ARCHITECTURE_CONSTITUTION.md
+++ b/_meta/docs/ARCHITECTURE_CONSTITUTION.md
@@ -306,7 +306,7 @@ Extensions/claude-skills/listing-writer/ (继续存在)
 
 ```
 ✅ 正确命名：
-- amazon-growth-os
+- a private repository
 - medical-research-os
 - content-factory
 
@@ -415,7 +415,7 @@ Systems/{system-name}/
 | Skills 目录 | `{domain}/` 或 `{domain}-{topic}/` | `amazon-operations/`, `medical-research/` |
 | Agent 文件 | `{role}.yaml` | `keyword-analyst.yaml` |
 | Crew 文件 | `{domain}-{purpose}-crew.yaml` | `amazon-launch-crew.yaml` |
-| System 目录 | `{domain}-{function}-os/` 或 `{domain}-{function}/` | `amazon-growth-os/` |
+| System 目录 | `{domain}-{function}-os/` 或 `{domain}-{function}/` | `a private repository/` |
 | Extension 目录 | `{capability}/` | `crewai/`, `sellersprite-api/` |
 
 ### 附录 C：禁止事项

--- a/_meta/docs/FILE_SYSTEM_GOVERNANCE.md
+++ b/_meta/docs/FILE_SYSTEM_GOVERNANCE.md
@@ -40,7 +40,7 @@ File System Governance Plan
 #### P0 - 关键问题（立即处理）
 
 1. **虚拟环境污染 Git**
-   - 位置：`Systems/amazon-growth-os/venv/`
+   - 位置：`Systems/a private repository/venv/`
    - 大小：1.7GB
    - 影响：Clone 时间长、存储浪费、协作困难
    - 根因：`.gitignore` 添加晚于 `venv/` 提交
@@ -59,7 +59,7 @@ File System Governance Plan
 
 4. **重复的 uploads 目录**
    - `Skills/02_Operation_Intelligence/uploads/`
-   - `Systems/amazon-growth-os/uploads/`
+   - `Systems/a private repository/uploads/`
    - 影响：数据分散、不明确的职责划分
 
 5. **命名不一致**
@@ -82,7 +82,7 @@ File System Governance Plan
    - `Skills/99_Incubator/test-skill/skill_definition_template.md`
 
 9. **Systems vs Skills 边界模糊**
-   - `amazon-growth-os` 既在 Systems 又有 skill_definition
+   - `a private repository` 既在 Systems 又有 skill_definition
    - 不清楚两者的区别和关联
 
 ---
@@ -94,14 +94,14 @@ File System Governance Plan
 #### 步骤 1：移除虚拟环境
 
 ```bash
-cd ~/github/liye_os/Systems/amazon-growth-os
+cd ~/github/liye_os/Systems/a private repository
 
 # 1. 备份当前 venv（如果需要）
 tar -czf ~/Downloads/liye_os_venv_backup_$(date +%Y%m%d).tar.gz venv/
 
 # 2. 从 Git 历史中彻底删除
 git filter-branch --force --index-filter \
-  'git rm -rf --cached --ignore-unmatch Systems/amazon-growth-os/venv' \
+  'git rm -rf --cached --ignore-unmatch Systems/a private repository/venv' \
   --prune-empty --tag-name-filter cat -- --all
 
 # 或使用 BFG Repo-Cleaner（更快）
@@ -157,11 +157,11 @@ find . -type f \( -name "*.csv" -o -name "*.xlsx" -o -name "*.xls" \) | grep -v 
 
 # 2. 移动到 Git 外部位置
 mkdir -p ~/Documents/liye_workspace/LiYe_OS_Data/
-mv Systems/amazon-growth-os/uploads/*.csv ~/Documents/liye_workspace/LiYe_OS_Data/amazon_uploads/
+mv Systems/a private repository/uploads/*.csv ~/Documents/liye_workspace/LiYe_OS_Data/amazon_uploads/
 mv Skills/02_Operation_Intelligence/uploads/*.csv ~/Documents/liye_workspace/LiYe_OS_Data/operation_uploads/
 
 # 3. 创建软链接（如果需要本地访问）
-ln -s ~/Documents/liye_workspace/LiYe_OS_Data/amazon_uploads Systems/amazon-growth-os/data_external
+ln -s ~/Documents/liye_workspace/LiYe_OS_Data/amazon_uploads Systems/a private repository/data_external
 ln -s ~/Documents/liye_workspace/LiYe_OS_Data/operation_uploads Skills/02_Operation_Intelligence/data_external
 
 # 4. 更新 .gitignore
@@ -289,7 +289,7 @@ liye_os/
 
 ❌ BAD:
 - Skills/05_Medical_Intelligence/Medical_Research_Analyst/
-- Systems/amazon-growth-os/
+- Systems/a private repository/
 - Skills/06_Technical_Development/CrewAI_Multi_Agent_Framework/
 ```
 
@@ -374,10 +374,10 @@ if [ -d "tools/notion-sync" ]; then
   rmdir tools 2>/dev/null || true
 fi
 
-# 4. 重命名 amazon-growth-os
+# 4. 重命名 a private repository
 echo "🏭 标准化 amazon_growth_os 命名..."
-if [ -d "systems/amazon-growth-os" ]; then
-  git mv systems/amazon-growth-os systems/amazon_growth_os
+if [ -d "systems/a private repository" ]; then
+  git mv systems/a private repository systems/amazon_growth_os
 fi
 
 # 5. 精简 Skills 域分类
@@ -742,7 +742,7 @@ git push origin --force
 | `Systems/` | `systems/` | 重命名 |
 | `Skills/05_Medical_Intelligence/Medical_Research_Analyst/` | `skills/medical/medical_research_analyst/` | 重组+重命名 |
 | `Skills/02_Operation_Intelligence/amazon-keyword-analysis/` | `skills/research/amazon_keyword_analysis/` | 迁移+重命名 |
-| `Systems/amazon-growth-os/` | `systems/amazon_growth_os/` | 重命名 |
+| `Systems/a private repository/` | `systems/amazon_growth_os/` | 重命名 |
 | `tools/notion-sync/` | `systems/notion_sync/` | 迁移 |
 | `Glossaries/` | `_meta/glossary/` | 合并 |
 | `Agents/` | (删除) | 移除空目录 |

--- a/_meta/docs/HOME_MIGRATION_STRATEGY.md
+++ b/_meta/docs/HOME_MIGRATION_STRATEGY.md
@@ -212,7 +212,7 @@ ln -s ~/data/shengcai ~/Documents/生财有术
 
 # 2. Git repos 清理历史大文件（如果有）
 cd ~/github/liye_os
-git filter-branch --tree-filter 'rm -rf Systems/amazon-growth-os/venv' HEAD
+git filter-branch --tree-filter 'rm -rf Systems/a private repository/venv' HEAD
 
 # 3. 压缩旧归档（可选）
 tar -czf ~/data/archives/interview_materials_$(date +%Y%m%d).tar.gz ~/Documents/面试相关资料

--- a/docs/architecture/AUDIT_2025-12-31_CLEANUP.md
+++ b/docs/architecture/AUDIT_2025-12-31_CLEANUP.md
@@ -36,7 +36,7 @@
 ./_meta/docs/ARCHITECTURE_CONSTITUTION.md:320:│  🤖 单个 AI 角色定义             → Agents/                  │
 ./_meta/docs/FILE_SYSTEM_GOVERNANCE.md:205:├── Agents/                   # 🔴 空目录 - 移除或合并
 ./_meta/docs/FILE_SYSTEM_GOVERNANCE.md:748:| `Agents/` | (删除) | 移除空目录 |
-./docs/amazon-growth-os/v4.2/WORKFLOW_v4.2.md:124:├── Agents/amazon-growth/
+./docs/a private repository/v4.2/WORKFLOW_v4.2.md:124:├── Agents/amazon-growth/
 ./docs/architecture/AGENT_SPEC.md:44:Agents/
 ./docs/architecture/BOUNDARY_DEHYDRATION.md:47:│                    Agents/ (execution only)                  │
 ./docs/architecture/BOUNDARY_DEHYDRATION.md:205:**Scope:** `Agents/`

--- a/docs/architecture/RELEASE_NOTES_v6.1.1.md
+++ b/docs/architecture/RELEASE_NOTES_v6.1.1.md
@@ -139,7 +139,7 @@ git checkout 8935aaf  # v6.0.0 最后一个 commit
 
 ```bash
 # 仅用于开发环境调试，不推荐生产使用
-git checkout feat/amazon-growth-os-v4.2-governance
+git checkout feat/a private repository-v4.2-governance
 ```
 
 ### 紧急回滚（保留历史）

--- a/docs/architecture/RELEASE_v6.1.1_CHECKLIST.md
+++ b/docs/architecture/RELEASE_v6.1.1_CHECKLIST.md
@@ -12,7 +12,7 @@
 | 项目 | 值 |
 |------|-----|
 | **Base Git SHA** | `8935aafc4ceb6ec652f16c6aaec9712c42d1027a` |
-| **Base Branch** | `feat/amazon-growth-os-v4.2-governance` |
+| **Base Branch** | `feat/a private repository-v4.2-governance` |
 | **Release Branch** | `release/v6.1.1-hardening` |
 | **创建时间** | 2026-01-01 |
 
@@ -129,7 +129,7 @@ python tools/audit/verify_v6_1.py
 
 | 阶段 | 回滚命令 |
 |------|----------|
-| 任意阶段 | `git checkout feat/amazon-growth-os-v4.2-governance` |
+| 任意阶段 | `git checkout feat/a private repository-v4.2-governance` |
 | 部分修改 | `git stash && git checkout .` |
 
 ---

--- a/docs/standard/T1_REASONING_STANDARD.md
+++ b/docs/standard/T1_REASONING_STANDARD.md
@@ -252,7 +252,7 @@ Level 3 requires documented validation evidence.
 
 ### Domain Validations
 
-- `src/domain/amazon-growth-os/` - Commercial domain
+- `src/domain/a private repository/` - Commercial domain
 - `src/domain/investment-os/` - Financial domain
 - `src/domain/medical-os/` - Clinical domain
 

--- a/i18n/display/zh-CN/CLAUDE.display.md
+++ b/i18n/display/zh-CN/CLAUDE.display.md
@@ -105,7 +105,7 @@ node .claude/scripts/guardrail.mjs
 │   └── templates/         # 模板库
 ├── Skills/                # 技能库（12个域）
 ├── Systems/               # 可执行系统
-│   └── amazon-growth-os/  # Amazon 运营系统
+│   └── a private repository/  # Amazon 运营系统
 ├── tools/                 # 工具脚本
 │   └── notion-sync/       # Notion 同步工具
 ├── Projects_Engine/       # 项目管理

--- a/i18n/display/zh-CN/packs/infrastructure.md
+++ b/i18n/display/zh-CN/packs/infrastructure.md
@@ -222,8 +222,8 @@ status: In Progress
 ln -s ~/data/shengcai ~/Documents/生财有术
 
 # 3. 在 repo 中使用外部链接
-# Systems/amazon-growth-os/data_external → ~/data/amazon_reports
-ln -s ~/data/amazon_reports Systems/amazon-growth-os/data_external
+# Systems/a private repository/data_external → ~/data/amazon_reports
+ln -s ~/data/amazon_reports Systems/a private repository/data_external
 ```
 
 **`.gitignore` 配置：**
@@ -279,7 +279,7 @@ Artifacts_Vault/by_project/acme_canada_q4/
 # 格式：<type>(<scope>): <subject>
 
 feat(notion-sync): add diff command to compare local and Notion
-fix(amazon-growth-os): correct keyword analysis ACOS calculation
+fix(a private repository): correct keyword analysis ACOS calculation
 docs(README): update Notion sync configuration guide
 chore(gitignore): add .cache and .env to ignore list
 refactor(Skills): reorganize 12 domains into 6 active domains
@@ -302,7 +302,7 @@ title: Amazon Listing Optimization Report
 date: 2024-01-20
 project: Acme Canada Q4
 author: Claude Sonnet 4.5
-source: ~/github/liye_os/Systems/amazon-growth-os
+source: ~/github/liye_os/Systems/a private repository
 input: data/inputs/campaign_report_20240115.csv
 output: reports/listing_optimization_20240120.md
 ---

--- a/i18n/display/zh-CN/packs/operations.md
+++ b/i18n/display/zh-CN/packs/operations.md
@@ -77,7 +77,7 @@
 
 ## Amazon Growth OS
 
-**位置：** `Systems/amazon-growth-os/`
+**位置：** `Systems/a private repository/`
 
 **用途：** 新品 Launch、老品 Optimize、关键词策略、PPC 分层优化、竞品与漏斗诊断
 
@@ -90,7 +90,7 @@
 **常用入口（从 repo 根目录）：**
 
 ```bash
-cd Systems/amazon-growth-os
+cd Systems/a private repository
 
 # 新品 Launch 模式
 ./run.sh --mode launch --product "XXX" --market "Amazon US"

--- a/i18n/display/zh-CN/packs/protocols.md
+++ b/i18n/display/zh-CN/packs/protocols.md
@@ -84,8 +84,8 @@ Claude (Sonnet):
 优化 Acme Canada ASIN B0XXX 的 Listing，目标提升 CTR 10%，CVR 5%
 
 ## Input
-- 数据源：`Systems/amazon-growth-os/data/inputs/campaign_report_20240115.csv`
-- 配置：`Systems/amazon-growth-os/config/optimization.yaml`
+- 数据源：`Systems/a private repository/data/inputs/campaign_report_20240115.csv`
+- 配置：`Systems/a private repository/config/optimization.yaml`
 - 参考：`Skills/02_Operation_Intelligence/amazon-keyword-analysis/templates/listing_template.md`
 
 ## Steps
@@ -339,7 +339,7 @@ git push origin --force
 **数据回滚：**
 ```bash
 # 从备份恢复
-cp ~/data/amazon_reports/backup_20240120/*.csv Systems/amazon-growth-os/data/inputs/
+cp ~/data/amazon_reports/backup_20240120/*.csv Systems/a private repository/data/inputs/
 
 # 从 Notion 重新同步
 cd tools/notion-sync

--- a/src/kernel/t1/VERDICT_FREEZE.md
+++ b/src/kernel/t1/VERDICT_FREEZE.md
@@ -26,7 +26,7 @@
 
 | Domain | Cases Tested | Lift Confirmed | Evidence File |
 |--------|--------------|----------------|---------------|
-| amazon-growth-os | 3 | 3/3 | `experiments/reasoning_comparison/` |
+| a private repository | 3 | 3/3 | `experiments/reasoning_comparison/` |
 | investment-os | 3 | 3/3 | `src/domain/investment-os/experiments/reasoning_comparison/CROSS_DOMAIN_VERDICT.md` |
 
 ---


### PR DESCRIPTION
## Summary
- Redact all `amazon-growth-os` references from public documentation
- Replace with neutral "a private repository" phrasing
- Affects 12 files across i18n, docs, _meta, and kernel directories

## Changes
- `i18n/display/zh-CN/CLAUDE.display.md`
- `i18n/display/zh-CN/packs/*.md` (3 files)
- `_meta/docs/*.md` (3 files)
- `docs/architecture/*.md` (3 files)
- `docs/standard/T1_REASONING_STANDARD.md`
- `src/kernel/t1/VERDICT_FREEZE.md`

## Verification
```bash
# Confirmed no private repo references remain
rg -n "loudmirror/amazon-growth-os|amazon-growth-os|github\.com/.*/amazon-growth-os" .
# Returns: no matches
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)