### PR TITLE
docs(governance): add public boundary policy and domain migration playbook

### DIFF
--- a/docs/governance/INDEX.md
+++ b/docs/governance/INDEX.md
@@ -45,9 +45,11 @@ These files provide guidance but do not enforce policy.
 | File | Purpose |
 |------|---------|
 | `docs/governance/INDEX.md` | This file - governance structure overview |
+| `docs/governance/PUBLIC_BOUNDARY.md` | Public boundary policy - what is/isn't in public repo |
 | `docs/governance/ALIAS_KEYWORDS_REPORT.md` | Keyword alias audit |
 | `docs/governance/PREFIX_DEBT_REPORT.md` | Prefix debt tracking |
 | `docs/governance/REDIRECT_AUDIT.md` | Redirect usage audit |
+| `docs/runbook/DOMAIN_MIGRATION_PLAYBOOK.md` | Domain migration SOP for private extraction |
 | `docs/architecture/*.md` | Architecture decision records |
 
 ---

--- a/docs/governance/PUBLIC_BOUNDARY.md
+++ b/docs/governance/PUBLIC_BOUNDARY.md
@@ -1,0 +1,35 @@
+# Public Boundary Policy
+
+This repository is the **public OS framework**. It is intentionally designed to be safe to publish.
+
+## What this repository includes (Public)
+- **Kernel / Runtime / Governance**
+  - executable governance gates (CI)
+  - replay / drift / contract verification primitives
+- **Public example domain**
+  - `domains/skeleton/` + `data/demo/skeleton/`
+  - used only for verification and demonstration
+- **Documentation**
+  - architecture doctrine, constitution, standards, runbooks
+
+## What is intentionally excluded (Private)
+The following assets are **not** shipped in this public repository:
+- Commercial domains and playbooks (business methodologies, operating knowledge)
+- Customer identifiers, customer data, and any production datasets
+- API keys, secrets, tokens, and production configurations
+- Any domain pack that would enable reconstruction of private operations
+
+## Extension model (How to add domains safely)
+Domains are designed as **domain packs** that integrate via stable interfaces.
+- Public domains may live in this repo (e.g., `domains/skeleton/`)
+- Private domains MUST live outside this repo and must never be referenced by name/URL here
+- Production data should be externalized (env / encrypted files / private data sources)
+
+## Enforcement
+This boundary is enforced by:
+- pre-commit hooks (local)
+- CI security gates (gitleaks + blocklist + leak guards)
+- architecture hardening gates (SSOT + compliance)
+- public replay regression gate (skeleton fixtures)
+
+If you believe an exception is required, document it explicitly and ensure gates are updated accordingly.

--- a/docs/runbook/DOMAIN_MIGRATION_PLAYBOOK.md
+++ b/docs/runbook/DOMAIN_MIGRATION_PLAYBOOK.md
@@ -1,0 +1,57 @@
+# Domain Migration Playbook
+
+Purpose: safely migrate a commercial/private domain out of the public repository while keeping the public OS framework runnable and verifiable.
+
+## When to migrate (Triggers)
+- Domain contains commercial operating knowledge, proprietary methodologies, or customer-specific workflows
+- Domain includes or can reconstruct customer identifiers, datasets, or production metrics
+- Compliance or security review flags potential leakage risk
+- Public release requires a clean boundary (public framework only)
+
+## Target state
+- Public repo: Kernel/Runtime/Governance + public skeleton domain + public docs
+- Private repo: commercial domain code + knowledge base
+- Production data: externalized (env / encrypted local files / private stores)
+- CI gates prevent re-introduction of private assets
+
+## Step-by-step procedure
+
+### 1) Freeze & evidence collection
+- Create a freeze tag on `main`
+- Generate a scope list of files to migrate (paths + keyword hits)
+- Backup (bundle or mirror) before destructive history operations
+
+### 2) Extract to private repository
+- Create private repo (GitHub)
+- Use `git filter-repo` to keep only domain paths and push to private repo
+- Ensure private repo can reference public framework via versioned dependency (tag/commit), not via public docs
+
+### 3) Clean the public repository working tree
+- Remove domain directories from the public repo
+- Replace with skeleton/demo domain if required for runnable verification
+- Sanitize public docs (no private repo names/URLs)
+
+### 4) Rewrite history (if required)
+- Use `git filter-repo --invert-paths` to remove private paths from history
+- Force push rewritten history
+- Announce "history rewritten; re-clone required" to collaborators
+
+### 5) Enforcement gates (non-negotiable)
+- Add a leak guard that blocks:
+  - forbidden code paths
+  - customer identifiers
+  - API key patterns
+  - private repo disclosures (names/URLs)
+- Ensure gitleaks + blocklist scans are required checks on `main`
+- Ensure public replay regression exists and has stable fixtures (skeleton domain)
+
+### 6) Release process
+- Run release DoD (no forbidden identifiers, no tracked runtime artifacts, gates all green)
+- Tag & publish release
+- Verify documentation remains boundary-compliant
+
+## Acceptance criteria (DoD)
+- Public repo contains **no private domain code/knowledge/data**
+- All security + architecture + replay gates pass
+- `rg` scan returns no forbidden disclosures (except CI pattern definitions)
+- Skeleton domain remains runnable for verification/demonstration


### PR DESCRIPTION
## Summary
- Add `docs/governance/PUBLIC_BOUNDARY.md`: defines what is/isn't in public repo
- Add `docs/runbook/DOMAIN_MIGRATION_PLAYBOOK.md`: SOP for private domain extraction
- Update `docs/governance/INDEX.md`: link both new documents in REFERENCE section

## Test plan
- [x] Verified no private repo disclosures in new docs
- [x] Pre-commit checks passed
- [ ] CI gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)