### PR TITLE
chore(governance): enforce public boundary + runbook guards

### DIFF
--- a/.claude/scripts/governance_index_guard.sh
+++ b/.claude/scripts/governance_index_guard.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Governance Index Guard: Ensures INDEX.md contains required governance entries.
+# Used by CI gates to prevent accidental deletion of key policy references.
+
+idx="docs/governance/INDEX.md"
+test -f "$idx" || (echo "FAIL: Governance INDEX.md missing"; exit 1)
+
+grep -q "PUBLIC_BOUNDARY.md" "$idx" || (echo "FAIL: INDEX missing PUBLIC_BOUNDARY.md"; exit 1)
+grep -q "DOMAIN_MIGRATION_PLAYBOOK.md" "$idx" || (echo "FAIL: INDEX missing DOMAIN_MIGRATION_PLAYBOOK.md"; exit 1)
+
+echo "PASS: Governance INDEX contains required entries"

--- a/.claude/scripts/public_boundary_guard.py
+++ b/.claude/scripts/public_boundary_guard.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+PUBLIC_BOUNDARY Guard: Ensures the public boundary policy exists and contains required sections.
+Used by CI gates to enforce governance compliance.
+"""
+import pathlib
+import sys
+
+def main():
+    p = pathlib.Path("docs/governance/PUBLIC_BOUNDARY.md")
+    if not p.exists():
+        print("FAIL: PUBLIC_BOUNDARY.md missing")
+        sys.exit(1)
+
+    t = p.read_text(encoding="utf-8", errors="ignore")
+
+    # Required sections (match actual content)
+    must = [
+        "What this repository includes",
+        "What is intentionally excluded",
+        "Enforcement",
+    ]
+
+    missing = [m for m in must if m not in t]
+    if missing:
+        print("FAIL: PUBLIC_BOUNDARY missing sections:", missing)
+        sys.exit(1)
+
+    print("PASS: PUBLIC_BOUNDARY sections OK")
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/runbook_migration_guard.sh
+++ b/.claude/scripts/runbook_migration_guard.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Runbook Migration Guard: Ensures domain-related PRs reference the migration playbook.
+# Used by CI gates to enforce governance compliance.
+
+# Only enforce when PR changes touch domain-related paths
+if ! git diff --name-only origin/main...HEAD 2>/dev/null | grep -qE '(^src/domain/|^Agents/|^Crews/|^docs/runbook/)'; then
+  echo "Runbook Guard: skip (no domain-related changes)"
+  exit 0
+fi
+
+# Require PR body (if available) or commit message to reference the playbook
+# Fallback: require a marker file added/updated in docs/runbook/
+if git log -1 --pretty=%B | grep -qE 'DOMAIN_MIGRATION_PLAYBOOK|Domain Migration Playbook|迁移回放|runbook'; then
+  echo "Runbook Guard: PASS (commit references playbook)"
+  exit 0
+fi
+
+if git diff --name-only origin/main...HEAD 2>/dev/null | grep -qE '^docs/runbook/DOMAIN_MIGRATION_PLAYBOOK\.md'; then
+  echo "Runbook Guard: PASS (playbook updated in this PR)"
+  exit 0
+fi
+
+echo "Runbook Guard: FAIL"
+echo "Domain-related change detected but no reference to docs/runbook/DOMAIN_MIGRATION_PLAYBOOK.md"
+exit 1

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
   <a href="./README.md">English</a> | <a href="./README.zh-CN.md">简体中文</a>
 </p>
 
+> **LiYe OS is an open governance and execution framework.**
+> **Domain intelligence and business data are intentionally excluded.**
+
+See: [`docs/governance/PUBLIC_BOUNDARY.md`](docs/governance/PUBLIC_BOUNDARY.md) for the public/private boundary.
+
 > **Governance & Architecture Reference Implementation for Claude Code / AI-Collaborative Development**
 >
 > Turn AI outputs into auditable, replayable, and controllable engineering systems.


### PR DESCRIPTION
## Summary
P0 enforcement scripts for governance compliance:
- `public_boundary_guard.py`: validates PUBLIC_BOUNDARY.md exists with required sections
- `runbook_migration_guard.sh`: requires playbook reference for domain changes  
- `governance_index_guard.sh`: prevents deletion of key policy refs from INDEX.md

P1 visibility:
- Add PUBLIC_BOUNDARY reference to README first screen

## Test plan
- [x] `python3 .claude/scripts/public_boundary_guard.py` → PASS
- [x] `.claude/scripts/runbook_migration_guard.sh` → skip (no domain changes)
- [x] `.claude/scripts/governance_index_guard.sh` → PASS
- [x] Pre-commit checks passed
- [ ] CI gates pass

## Next step
Wire these scripts into CI workflows as new steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)