### PR TITLE
fix(ci): wire governance guards into Architecture Hardening Gate

### DIFF
--- a/.github/workflows/architecture-hardening-gate.yml
+++ b/.github/workflows/architecture-hardening-gate.yml
@@ -87,3 +87,12 @@ jobs:
           echo "  data/stats/       (formerly stats/)"
           echo "  data/traces/      (formerly traces/)"
           echo "  Artifacts_Vault/reports/ (formerly reports/)"
+
+      - name: Public Boundary Guard
+        run: python3 .claude/scripts/public_boundary_guard.py
+
+      - name: Runbook Migration Guard
+        run: bash .claude/scripts/runbook_migration_guard.sh
+
+      - name: Governance Index Guard
+        run: bash .claude/scripts/governance_index_guard.sh


### PR DESCRIPTION
## Summary
- Wire three governance guard scripts into Architecture Hardening Gate CI workflow
- Guards added as new steps after existing SSOT enforcement

### Guard Steps Added
1. **Public Boundary Guard** - Validates `PUBLIC_BOUNDARY.md` exists and contains required sections
2. **Runbook Migration Guard** - Requires playbook reference for domain-related changes
3. **Governance Index Guard** - Prevents deletion of key governance references from `INDEX.md`

## Test Plan
- [x] Local execution of all three guards passes
- [ ] CI workflow runs successfully with new steps

## Next Step After Merge
Configure this workflow as a Required Check in branch protection settings if not already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)