### PR TITLE
feat(domain): add minimal skeleton domain + enable integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Verify domain structure
         run: |
           echo "Checking domain structure..."
-          for domain in amazon-growth medical-research geo-os; do
+          for domain in skeleton medical-research geo-os; do
             if [ -d "src/domain/$domain" ]; then
               echo "✓ Domain $domain exists"
               if [ -f "src/domain/$domain/config.yaml" ]; then

--- a/.github/workflows/trace-governance-gate.yml
+++ b/.github/workflows/trace-governance-gate.yml
@@ -52,30 +52,13 @@ jobs:
           else
             echo "WARNING: trace_guard.sh not found at tools/, running inline checks"
 
-            # Inline fallback checks
+            # Inline fallback checks (domain-agnostic)
             ERRORS=0
 
-            # Check 1: Required config files
-            for file in "config/amazon-growth/guardrails.yaml" "config/amazon-growth/priority_score.yaml"; do
-              if [[ -f "$file" ]]; then
-                echo "[PASS] $file exists"
-              else
-                echo "[FAIL] $file missing"
-                ERRORS=$((ERRORS + 1))
-              fi
-            done
+            # Note: Domain-specific config/agent checks are in private repos.
+            # Public repo validates only shared infrastructure.
 
-            # Check 2: Agent files
-            for file in "Agents/amazon-growth/intent-analyst.yaml" "Agents/amazon-growth/trace-scribe.yaml" "Agents/amazon-growth/guardrail-governor.yaml"; do
-              if [[ -f "$file" ]]; then
-                echo "[PASS] $file exists"
-              else
-                echo "[FAIL] $file missing"
-                ERRORS=$((ERRORS + 1))
-              fi
-            done
-
-            # Check 3: TRACE template (canonical path)
+            # Check 1: TRACE template (canonical path)
             if [[ -f "_meta/templates/trace/TRACE_TEMPLATE_v4_2.yaml" ]]; then
               echo "[PASS] TRACE template exists (canonical path)"
             elif [[ -f "templates/trace/TRACE_TEMPLATE_v4_2.yaml" ]]; then
@@ -103,8 +86,9 @@ jobs:
           # Get list of changed files
           CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} || true)
 
-          # Check if any operational config was changed
-          OPERATIONAL_CHANGES=$(echo "$CHANGED_FILES" | grep -E "(Agents/amazon-growth/|config/amazon-growth/)" || true)
+          # Check if any operational config was changed (public domains only)
+          # Note: amazon-growth checks are in private repo workflow
+          OPERATIONAL_CHANGES=$(echo "$CHANGED_FILES" | grep -E "(Agents/skeleton/|src/domain/skeleton/)" || true)
 
           if [[ -n "$OPERATIONAL_CHANGES" ]]; then
             echo "Operational files changed:"

--- a/src/domain/skeleton/README.md
+++ b/src/domain/skeleton/README.md
@@ -1,0 +1,12 @@
+# Skeleton Domain
+
+A minimal, non-sensitive reference domain for LiYe OS.
+
+Purpose:
+- Prove the framework can run end-to-end (contract → trace → replay)
+- Provide a safe template for future domains (e.g., Value Investing OS)
+
+Non-goals:
+- No business heuristics
+- No domain intelligence
+- No customer data

--- a/src/domain/skeleton/agents/skeleton-analyst.yaml
+++ b/src/domain/skeleton/agents/skeleton-analyst.yaml
@@ -1,0 +1,16 @@
+agent:
+  id: skeleton-analyst
+  name: Skeleton Analyst
+  version: "0.1.0"
+  domain: skeleton
+
+persona: |
+  You are a minimal demonstration agent used for validating governance mechanics.
+
+responsibilities:
+  - Validate decision contracts
+  - Emit traces
+
+guardrails:
+  - Never include secrets
+  - Never include customer identifiers

--- a/src/domain/skeleton/config.yaml
+++ b/src/domain/skeleton/config.yaml
@@ -1,0 +1,26 @@
+domain:
+  id: skeleton
+  name: Skeleton Domain
+  version: "0.1.0"
+  description: "Minimal reference domain for validating governance mechanics"
+  layer: core
+
+agents:
+  enabled:
+    - skeleton-analyst
+  orchestrator: skeleton-analyst
+
+workflows:
+  available:
+    - contract-validation
+    - trace-emission
+  default: contract-validation
+
+skills:
+  atomic:
+    - validate_contract
+    - emit_trace
+  composite: []
+
+evolution:
+  enabled: false

--- a/src/domain/skeleton/contracts/decision.contract.yaml
+++ b/src/domain/skeleton/contracts/decision.contract.yaml
@@ -1,0 +1,11 @@
+contract:
+  id: citation_required
+  version: "1.0.0"
+  intent: enforce_citation_for_factual_claims
+
+condition:
+  claim_type: factual
+  citation_count: "== 0"
+
+decision: BLOCK
+reason: "Factual claims must include citations."

--- a/src/domain/skeleton/main.py
+++ b/src/domain/skeleton/main.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Skeleton Domain - Main Entry Point
+
+Minimal reference implementation demonstrating World Model Gate integration.
+This domain contains no business logic, heuristics, or customer data.
+
+Purpose:
+- Validate governance mechanics end-to-end
+- Serve as template for future domains
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# World Model Gate import
+from src.kernel.world_model import run_world_model, WORLD_MODEL_REQUIRED
+
+
+def parse_args():
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Skeleton Domain - Minimal Reference Implementation"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate World Model Gate without executing domain logic"
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose output"
+    )
+    return parser.parse_args()
+
+
+def main():
+    """Main entry point for skeleton domain."""
+    args = parse_args()
+
+    print("=" * 60)
+    print("Skeleton Domain - World Model Gate Enforcement")
+    print("=" * 60)
+
+    # World Model Gate is REQUIRED before any domain execution
+    if WORLD_MODEL_REQUIRED:
+        print("\n[INFO] World Model Gate is enforced")
+
+        if args.dry_run:
+            print("[DRY-RUN] Validating World Model Gate...")
+            # In dry-run mode, just validate the gate exists
+            print("[DRY-RUN] Gate validation passed")
+            return 0
+
+        # Run World Model analysis
+        result = run_world_model(
+            domain="skeleton",
+            task="contract_validation",
+            dry_run=args.dry_run
+        )
+
+        if args.verbose:
+            print(f"\n[RESULT] World Model analysis complete")
+            print(f"  Domain: {result.get('domain', 'skeleton')}")
+            print(f"  Status: {result.get('status', 'unknown')}")
+
+    print("\n[SUCCESS] Skeleton domain executed successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/domain/skeleton/traces/trace.example.json
+++ b/src/domain/skeleton/traces/trace.example.json
@@ -1,0 +1,9 @@
+{
+  "trace_id": "demo-trace-001",
+  "domain": "skeleton",
+  "contract_id": "citation_required",
+  "inputs": { "claim_type": "factual", "citation_count": 0 },
+  "decision": "BLOCK",
+  "reason": "Factual claims must include citations.",
+  "timestamp": "2026-01-04T00:00:00Z"
+}

--- a/src/domain/skeleton/tracks/example/README.md
+++ b/src/domain/skeleton/tracks/example/README.md
@@ -1,0 +1,3 @@
+# Example Track
+
+This is a placeholder track for demonstrating the orchestration shape.

--- a/tests/smoke/test_world_model_gate.py
+++ b/tests/smoke/test_world_model_gate.py
@@ -233,12 +233,10 @@ class TestWorldModelGateNegative:
         assert any("version" in e for e in errors)
 
 
-@pytest.mark.skip(reason="Skeleton domain not yet implemented - integration tests deferred")
 class TestWorldModelGateIntegration:
     """Integration tests for World Model Gate in skeleton entry.
 
-    NOTE: These tests are skipped until a skeleton domain is implemented.
-    The skeleton domain will serve as a minimal reference implementation
+    The skeleton domain serves as a minimal reference implementation
     demonstrating World Model Gate integration patterns.
     """
 


### PR DESCRIPTION
## Summary

- Add minimal skeleton domain as non-sensitive reference implementation
- Enable World Model Gate integration tests (previously skipped)
- Update CI workflows to use skeleton instead of amazon-growth

## Changes

### P1-1: Skeleton Domain (Minimal)
- `src/domain/skeleton/README.md` - Domain documentation
- `src/domain/skeleton/config.yaml` - Registry integration
- `src/domain/skeleton/contracts/decision.contract.yaml` - Example contract
- `src/domain/skeleton/traces/trace.example.json` - Example trace format
- `src/domain/skeleton/agents/skeleton-analyst.yaml` - Minimal agent
- `src/domain/skeleton/main.py` - World Model Gate integration

### P1-2: Test Recovery
- `tests/smoke/test_world_model_gate.py` - Remove skip from integration tests
- `.github/workflows/ci.yml` - Replace amazon-growth with skeleton
- `.github/workflows/trace-governance-gate.yml` - Remove amazon-growth inline checks

## Purpose

- Prove framework runs end-to-end (contract → trace → replay)
- Provide safe template for future domains
- Decouple public repo CI from private amazon-growth

## Non-goals (by design)
- No business heuristics
- No domain intelligence  
- No customer data

## Test plan
- [ ] CI passes all gates
- [ ] Integration tests execute (not skipped)
- [ ] No sensitive tokens in skeleton domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)