### PR TITLE
refactor(naming): update amazon-growth-os → amazon-growth-engine references

### DIFF
--- a/.github/workflows/amazon-leak-guard.yml
+++ b/.github/workflows/amazon-leak-guard.yml
@@ -7,7 +7,7 @@
 #   - Actual Amazon code paths: Agents/amazon-growth/, Crews/amazon-growth/, etc.
 #   - Customer identifiers: TIMO, timo
 #   - Blocked ASINs from .security/blocklist.txt
-#   - Private repo disclosure: loudmirror/amazon-growth-os, amazon-growth-os in docs
+#   - Private repo disclosure: loudmirror/amazon-growth-engine, amazon-growth-engine in docs
 #
 # What is ALLOWED:
 #   - Generic references like "a private repository"
@@ -48,8 +48,8 @@ jobs:
             "domains/amazon-growth"
             "knowledge/amazon"
             "knowledge/private"
-            "Systems/amazon-growth-os"
-            "systems/amazon-growth-os"
+            "Systems/amazon-growth-engine"
+            "systems/amazon-growth-engine"
             "src/domain/amazon-growth"
           )
 
@@ -169,7 +169,7 @@ jobs:
           # Exclude this workflow file itself (it needs to reference patterns for detection)
           EXCLUDE_PATTERNS=".git|node_modules|\.github/workflows/amazon-leak-guard\.yml"
 
-          FOUND=$(grep -rn -E "loudmirror/amazon-growth-os|github\.com/.*/amazon-growth-os|amazon-growth-os" \
+          FOUND=$(grep -rn -E "loudmirror/amazon-growth-engine|github\.com/.*/amazon-growth-engine|amazon-growth-engine" \
             i18n _meta docs README* 2>/dev/null | grep -v -E "$EXCLUDE_PATTERNS" || true)
 
           if [ -n "$FOUND" ]; then

--- a/tools/recall/recall.js
+++ b/tools/recall/recall.js
@@ -18,7 +18,7 @@
  * Examples:
  *   node recall.js "i18n"
  *   node recall.js "i18n" --domain kernel
- *   node recall.js "ppc optimization" --project amazon-growth-os
+ *   node recall.js "ppc optimization" --project amazon-growth-engine
  */
 
 const fs = require("fs");
@@ -326,7 +326,7 @@ Options:
 Examples:
   node recall.js "i18n"
   node recall.js "i18n" --domain kernel
-  node recall.js "ppc optimization" --project amazon-growth-os
+  node recall.js "ppc optimization" --project amazon-growth-engine
 `);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- Updated `amazon-growth-os` references to `amazon-growth-engine` in workflow file and recall tool
- Ensures consistency with the new project naming convention

## Files Changed
- `.github/workflows/amazon-leak-guard.yml` - Updated security scan patterns
- `tools/recall/recall.js` - Updated example usage in documentation

## Test plan
- [ ] Verify CI workflows pass
- [ ] Confirm security scan patterns still detect intended patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)