### PR TITLE
feat(sfc): multi-source skill inventory sweep (internal/external/peer)

### DIFF
--- a/.claude/scripts/sfc_sweep_multi.mjs
+++ b/.claude/scripts/sfc_sweep_multi.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * SFC Sweep Multi-Source (WARNING-only)
+ *
+ * Runs sfc_sweep.mjs against multiple roots:
+ * - liye_os repo root (.)
+ * - ~/.claude/skills (external plugins)
+ * - ~/github/amazon-growth-engine (peer repo) if present
+ *
+ * Outputs separate reports under:
+ * docs/reports/skill-factory/
+ */
+
+import fs from "fs";
+import path from "path";
+import { spawnSync } from "child_process";
+
+function exists(p) {
+  try {
+    fs.accessSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runSweep({ id, root, label }) {
+  const script = path.resolve(".claude/scripts/sfc_sweep.mjs");
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const reportPath = path.resolve(`docs/reports/skill-factory/SFC_SWEEP_${id}_${ts}.md`);
+
+  console.log(`\n=== Running SFC Sweep: ${label} ===`);
+  console.log(`Root: ${root}`);
+  console.log(`Report: ${reportPath}`);
+
+  const res = spawnSync(process.execPath, [script, root], { encoding: "utf8" });
+
+  const out = [
+    `# SFC Sweep Report`,
+    ``,
+    `- Source: ${label}`,
+    `- Root: ${root}`,
+    `- Timestamp: ${new Date().toISOString()}`,
+    ``,
+    `---`,
+    ``,
+    `## Raw Output`,
+    ``,
+    "```",
+    (res.stdout || "").trim(),
+    (res.stderr || "").trim(),
+    "```",
+    ``,
+    `---`,
+    ``,
+    `Exit Code: ${res.status}`,
+    ``,
+  ].join("\n");
+
+  fs.writeFileSync(reportPath, out, "utf8");
+
+  return {
+    id,
+    label,
+    root,
+    reportPath,
+    exitCode: res.status ?? -1,
+  };
+}
+
+function main() {
+  const HOME = process.env.HOME || "";
+  const sources = [
+    { id: "liye_os", root: ".", label: "LiYe OS Repo (internal)" },
+    { id: "external_plugins", root: path.join(HOME, ".claude/skills"), label: "Claude External Skills (read-only plugins)" },
+    { id: "amazon_growth_engine", root: path.join(HOME, "github/amazon-growth-engine"), label: "Amazon Growth Engine (peer repo)" },
+  ];
+
+  const results = [];
+  for (const s of sources) {
+    if (!s.root || !exists(s.root)) {
+      console.log(`\n--- Skipped: ${s.label}`);
+      console.log(`Reason: path not found -> ${s.root}`);
+      continue;
+    }
+    results.push(runSweep(s));
+  }
+
+  console.log(`\n=== Summary ===`);
+  for (const r of results) {
+    console.log(`- ${r.label}`);
+    console.log(`  Root: ${r.root}`);
+    console.log(`  Report: ${r.reportPath}`);
+    console.log(`  Exit: ${r.exitCode}`);
+  }
+
+  console.log(`\nDONE ✅ Multi-source sweep complete (reports generated).`);
+}
+
+main();

--- a/_meta/skill-factory/SKILL_SOURCES.md
+++ b/_meta/skill-factory/SKILL_SOURCES.md
@@ -1,0 +1,20 @@
+# Skill Sources (Global Inventory)
+
+This document defines all Skill sources observed by SFC in LiYe OS.
+
+## Source Buckets
+
+### 1) Internal Repo Skills (Editable)
+- Path: `~/github/liye_os/Skills/**`
+- Policy: MUST comply with SFC v0.1
+- Action: Patchable + PR-able
+
+### 2) External Plugin Skills (Read-only)
+- Path: `~/.claude/skills/**`
+- Policy: Observe + lock versions only (do NOT patch in place)
+- Action: If customization needed, mirror into liye_os then patch
+
+### 3) Peer Repo Skills (Editable, Separate Product Line)
+- Example: `~/github/amazon-growth-engine/**`
+- Policy: Separate sweep + separate debt pool + separate PR in that repo
+- Action: Patch inside its own repo only


### PR DESCRIPTION
## Summary
- Adds `sfc_sweep_multi.mjs` to scan all skill sources in one command
- Documents skill source buckets in `SKILL_SOURCES.md`

## Skill Sources Observed
1. **Internal Repo** (`liye_os/Skills/**`) - Editable, SFC v0.1 compliant
2. **External Plugins** (`~/.claude/skills/**`) - Read-only, observe + lock only
3. **Peer Repo** (`amazon-growth-engine/**`) - Separate product line, separate debt pool

## Reports Generated (local only, gitignored)
- `SFC_SWEEP_liye_os_*.md` - 17 SKILL.md, 0 debt
- `SFC_SWEEP_external_plugins_*.md` - Plugins status
- `SFC_SWEEP_amazon_growth_engine_*.md` - Peer repo status

## Non-goals
- No patching/migration in this PR
- Reports are local observability artifacts, not committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)