### PR TITLE
docs(adr): add automated gh identity enforcement

### DIFF
--- a/.claude/scripts/gh-identity-guard.sh
+++ b/.claude/scripts/gh-identity-guard.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# gh-identity-guard.sh
+# ADR-0008: Auto-switch gh account based on current repo
+#
+# Usage: Source this in your shell rc file:
+#   source ~/github/liye_os/.claude/scripts/gh-identity-guard.sh
+#
+# Then use `gh` normally - it will auto-switch when needed.
+
+_gh_get_expected_account() {
+    local remote_url
+    remote_url=$(git config --get remote.origin.url 2>/dev/null || echo "")
+
+    if [[ "$remote_url" == *"liyecom"* ]]; then
+        echo "liyecom"
+    elif [[ "$remote_url" == *"loudmirror"* ]]; then
+        echo "loudmirror"
+    else
+        echo ""
+    fi
+}
+
+_gh_get_current_account() {
+    # Parse the active account from gh auth status
+    # "Logged in to github.com account liyecom (keyring)" -> liyecom is $(NF-1)
+    gh auth status 2>&1 | awk '
+        /Logged in to github.com account/ { account = $(NF-1) }
+        /Active account: true/ { print account; exit }
+    ' || echo ""
+}
+
+gh() {
+    local expected current
+    expected=$(_gh_get_expected_account)
+    current=$(_gh_get_current_account)
+
+    # Only check for commands that create/modify PRs
+    if [[ "$1" == "pr" && ("$2" == "create" || "$2" == "merge" || "$2" == "review") ]]; then
+        if [[ -n "$expected" && "$expected" != "$current" ]]; then
+            echo "[ADR-0008] Auto-switching gh account: $current → $expected"
+            command gh auth switch --user "$expected" 2>/dev/null
+        fi
+    fi
+
+    command gh "$@"
+}
+
+# Export for subshells
+export -f gh _gh_get_expected_account _gh_get_current_account 2>/dev/null || true
+
+echo "[gh-identity-guard] Loaded. PR commands will auto-switch account per ADR-0008."

--- a/docs/adr/governance/ADR-GITHUB-MULTI-ACCOUNT-IDENTITY.md
+++ b/docs/adr/governance/ADR-GITHUB-MULTI-ACCOUNT-IDENTITY.md
@@ -61,12 +61,33 @@ alias gh-liye='gh auth switch --user liyecom && gh'
 alias gh-age='gh auth switch --user loudmirror && gh'
 ```
 
-### 3. Governance Rule
+### 3. Automated Enforcement (Added 2026-02-18)
+
+**Pre-push Hook** (fail-closed gate):
+```
+.git/hooks/pre-push  # Blocks push if gh account != repo owner
+```
+
+The hook automatically:
+- Detects repo owner from `remote.origin.url`
+- Checks current `gh auth` active account
+- Blocks push with clear error message if mismatch
+
+**Shell Wrapper** (optional, auto-switch):
+```bash
+source ~/.../gh-identity-guard.sh  # Auto-switches for pr create/merge/review
+```
+
+### 4. Governance Rule
 
 | Repo | Allowed gh Command | Blocked |
 |------|-------------------|---------|
 | liye_os | `gh-liye pr create` | `gh pr create` (without switch) |
 | AGE (private) | `gh-age pr create` | `gh pr create` (without switch) |
+
+**Automated Gates**:
+- `pre-push` hook blocks if gh account mismatch (fail-closed)
+- Manual `gh pr create` without switch will fail at push time
 
 ## Consequences
 
@@ -99,6 +120,7 @@ From **PR #94 onwards** in `liyecom/liye-ai`:
 
 **Affected PRs (Historical - Accepted)**:
 - liyecom/liye-ai #84 through #93 (author displayed as `loudmirror`)
+- liyecom/liye-ai #110 (author displayed as `loudmirror`, approved by `liyecom` on 2026-02-18)
 
 **Clean Slate Begins**:
-- liyecom/liye-ai #94+ (author MUST be `liyecom`)
+- liyecom/liye-ai #94+ (author MUST be `liyecom`, with exceptions noted above)


### PR DESCRIPTION
## Summary
- ADR-0008 update: automated pre-push hook blocks push on account mismatch
- Add `gh-identity-guard.sh` for optional shell auto-switching
- Record PR #110 as exception (author=loudmirror, approved by liyecom)

## Changes
- `.git/hooks/pre-push`: Fail-closed gate that blocks push if gh active account ≠ repo owner
- `.claude/scripts/gh-identity-guard.sh`: Optional shell wrapper for auto-switching

## Test
```bash
# Switch to wrong account
gh auth switch --user loudmirror

# Try to push (should be blocked)
git push  # ❌ Blocked with clear error

# Fix
gh auth switch --user liyecom
git push  # ✅ Allowed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)