### PR TITLE
chore(gitignore): P1 收口 - 代码进 main，数据不进 main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -318,9 +318,39 @@ docs/reasoning/demo_runs/*
 .liye/
 
 # ============================================
-# Proactive System Runtime State
+# Proactive System Runtime State (P1 收口)
 # ============================================
+# Runtime state: 点火产物，不进 main
 state/runtime/proactive/runs/
 state/runtime/proactive/facts/
 state/runtime/proactive/rate_limits.json
+state/runtime/learning/
+state/runtime/rate_limits/
+state/runtime/security_events.jsonl
+
+# Facts: append-only 事实文件，不进 main
+state/memory/facts/
+!state/memory/facts/.gitkeep
+
+# Runs: 执行记录，不进 main（AGE 的 runs 也不进）
+data/runs/
+!data/runs/.gitkeep
+
 # Note: kill_switch.json and pr_evidence/ are included for PR but may be gitignored later
+
+# ============================================
+# Learned Policies: 只保留 SAMPLE_* fixtures
+# ============================================
+# 真实 candidate/production policies 由 bundle 管理
+state/memory/learned/policies/candidate/*.yaml
+!state/memory/learned/policies/candidate/SAMPLE_*.yaml
+!state/memory/learned/policies/candidate/.gitkeep
+state/memory/learned/policies/production/*.yaml
+!state/memory/learned/policies/production/SAMPLE_*.yaml
+!state/memory/learned/policies/production/.gitkeep
+
+# ============================================
+# Evidence Packs (打包后的证据，不进 main)
+# ============================================
+evidence/p1-*.tgz
+evidence/*.tgz

--- a/tests/fixtures/heartbeat_learning/sha_same/data/runs/age:bid_recommend:test-run-001/meta.json
+++ b/tests/fixtures/heartbeat_learning/sha_same/data/runs/age:bid_recommend:test-run-001/meta.json
@@ -1,0 +1,7 @@
+{
+  "engine_id": "age",
+  "playbook_id": "bid_recommend",
+  "run_id": "age:bid_recommend:test-run-001",
+  "tier": "recommend",
+  "created_at": "2026-02-11T10:00:00Z"
+}

--- a/tests/fixtures/heartbeat_learning/sha_same/data/runs/age:bid_recommend:test-run-001/playbook_output.json
+++ b/tests/fixtures/heartbeat_learning/sha_same/data/runs/age:bid_recommend:test-run-001/playbook_output.json
@@ -1,0 +1,29 @@
+{
+  "engine_id": "age",
+  "playbook_id": "bid_recommend",
+  "run_id": "age:bid_recommend:test-run-001",
+  "tier": "recommend",
+  "risk_level": "medium",
+  "card_contract_version": "1",
+  "verdict": "WARN",
+  "primary_metric": { "name": "acos", "direction": "low", "lookback_days": 7 },
+  "entities": [
+    {
+      "entity_type": "keyword",
+      "entity_key": "abc123",
+      "label": "organic mushroom",
+      "current": { "acos": 0.18, "cvr": 0.22, "bid": 1.50, "match_type": "exact" },
+      "recommendation": {
+        "action": "bid_adjust",
+        "delta_pct": 25,
+        "delta_pct_cap": 30,
+        "suggested_bid": 1.88,
+        "reason": "High CVR (22.0%), low ACOS (18.0%)",
+        "confidence": 0.75,
+        "policy_id": "RULE_HIGH_CVR_EXACT"
+      }
+    }
+  ],
+  "rollback_plan": { "summary": "Revert bid", "steps": ["Revert", "Wait 48h"] },
+  "created_at": "2026-02-11T10:00:00Z"
+}


### PR DESCRIPTION
## Summary
P1 点火后收口：确保运行时产物不污染主干。

## Changes
- 添加 `state/memory/facts/` 到 gitignore（append-only 事实）
- 添加 `state/runtime/learning/` 和 `rate_limits/` 到 gitignore
- 添加 `data/runs/` 到 gitignore（执行记录）
- 添加 learned policies 规则：只保留 `SAMPLE_*` fixtures
- 添加 `evidence/*.tgz` 到 gitignore
- 添加测试 fixtures (`no_new_runs`, `sha_same`)

## Verification
```bash
# 点火后 git status 必须干净
LIYE_HEARTBEAT_ENABLED=true node .claude/scripts/learning/heartbeat_runner.mjs
git status --short  # 无输出 ✅
```

## Evidence Pack
P1 证据已打包至 `/tmp/p1-ignite-20260218.tgz` (15KB)，包含：
- 88 条 business probes
- 22 个 AGE runs
- Candidate policy (BID_RECOMMEND_...17ED8F)
- Bundle v0.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)