### PR TITLE
fix(cost-meter): strengthen fail-closed on invalid config

### DIFF
--- a/.claude/scripts/learning/heartbeat_runner.mjs
+++ b/.claude/scripts/learning/heartbeat_runner.mjs
@@ -457,6 +457,15 @@ export async function runHeartbeat(options = {}) {
     checkAndRecordDayReset(runId);
   }
 
+  // Handle cost meter SKIP (fail-closed on config error)
+  if (costSwitchResult.action === 'SKIP') {
+    console.error('[heartbeat] Cost meter SKIP: fail-closed due to config errors');
+    result.action = 'skipped';
+    result.steps.skip_reason = 'cost_config_fail_closed';
+    result.steps.cost_config_errors = costSwitchResult.config_errors;
+    return result;
+  }
+
   // If cost meter is enabled, check budget
   if (costSwitchResult.action === 'ENABLED') {
     const projectedSteps = {


### PR DESCRIPTION
## Summary
- **Vulnerability 1**: `cost_weights: null` silently fell back to defaults instead of fail-closed
- **Vulnerability 2**: `SKIP` action from cost meter was not handled in heartbeat_runner

## Changes
1. `cost_meter.mjs`: Added validation for cost_weights (null check, object type, required keys)
2. `heartbeat_runner.mjs`: Added explicit SKIP branch to halt execution on config error

## Test Evidence
Three-round stress test:

| Round | Scenario | Expected | Result |
|-------|----------|----------|--------|
| 1 | budget=10, projected=13, skip_all | Block | ✅ |
| 2 | budget=13, projected=13 | Allow | ✅ |
| 3 | cost_weights=null | Block (fail-closed) | ✅ |

## Error Codes Added
- `INVALID_COST_WEIGHTS`: cost_weights is null or not an object
- `INCOMPLETE_COST_WEIGHTS`: Missing required component weight keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)