### PR TITLE
docs(contracts): freeze contracts v1.0.0 and enforce CI guard

### DIFF
--- a/docs/runbooks/contracts-v1-freeze.md
+++ b/docs/runbooks/contracts-v1-freeze.md
@@ -1,0 +1,80 @@
+# Contracts v1 Freeze Runbook
+
+**Version**: 1.0.0
+**SSOT**: docs/runbooks/contracts-v1-freeze.md
+**Last Updated**: 2026-02-19
+
+## 边界声明
+
+| 层 | 职责 | 示例 |
+|----|------|------|
+| **Control Plane (LiYe OS)** | 调度、学习、治理、投递、成本 | heartbeat_runner, cost_meter |
+| **Domain Engine (Playbooks)** | 纯函数，无调度、无投递、无状态 | bid_recommend, anomaly_detect |
+
+**三大契约**:
+- `learned_policy.schema.yaml` — 学习策略格式（三信号、scope、confidence）
+- `engine_manifest.schema.yaml` — Engine 能力声明
+- `playbook_io.schema.yaml` — Playbook 输入输出格式
+
+## v1.0.0 升级规则
+
+| 变更类型 | 处理方式 |
+|----------|----------|
+| 新增可选字段 | v1.x.y (minor/patch) |
+| 修改字段描述 | v1.x.y (patch) |
+| 新增 required 字段 | **v2.0.0** (breaking) |
+| 删除/重命名字段 | **v2.0.0** (breaking) |
+| 修改字段类型 | **v2.0.0** (breaking) |
+
+## 本地校验
+
+```bash
+# 校验三大契约 + 所有 policies
+node _meta/contracts/scripts/validate-contracts.mjs
+
+# 校验 bundle (可选)
+node _meta/contracts/scripts/validate-contracts.mjs --bundle state/artifacts/learned-bundles/xxx.tgz
+
+# 校验 cost_meter
+node _meta/contracts/scripts/validate-cost-meter.mjs
+```
+
+## CI 失败修复路径
+
+### 错误 1: Missing required field
+```
+❌ Missing required field: schema_version
+```
+**修复**: 在 policy YAML 中添加缺失字段
+
+### 错误 2: Unknown field not allowed
+```
+❌ Unknown field 'extra_field' not allowed (additionalProperties: false)
+```
+**修复**: 删除未知字段，或在 schema 中添加该字段定义
+
+### 错误 3: confidence must be number
+```
+❌ Field 'confidence' must be a number (0~1), got: string
+```
+**修复**: 将 `confidence: high` 改为 `confidence: 0.85`
+
+### 错误 4: Directory mismatch
+```
+❌ Directory mismatch: file in 'sandbox/' but validation_status is 'production'
+```
+**修复**: 移动文件到正确目录，或修改 `validation_status`
+
+### 错误 5: Production policy requires approval
+```
+❌ Production policy with write actions MUST have 'constraints.require_approval: true'
+```
+**修复**: 设置 `constraints.require_approval: true`
+
+## 关键约束
+
+1. **additionalProperties: false** — 所有 schema 禁止未知字段
+2. **fail-closed** — 校验失败 exit 1，阻断合并
+3. **三信号体系** — `success_signals` 必须有 `exec/operator/business`
+4. **scope 必填** — 防止跨租户污染
+5. **confidence 数值** — 0~1 数值，禁止 high/medium/low 字符串

--- a/evidence/evidence_contracts_v1_freeze.json
+++ b/evidence/evidence_contracts_v1_freeze.json
@@ -1,0 +1,71 @@
+{
+  "evidence_id": "contracts_v1_freeze",
+  "description": "Contracts v1.0.0 Freeze - Schema + Validator + CI Gate",
+  "created_at": "2026-02-19T03:50:00.000Z",
+  "base_git_sha": "af137b77c164656158be5bdbd7735a88b8b2cc9d",
+  "contracts": {
+    "learned_policy": {
+      "path": "_meta/contracts/learning/learned_policy.schema.yaml",
+      "version": "1.0.0",
+      "key_constraints": [
+        "additionalProperties: false",
+        "required: schema_version, scope, success_signals, confidence",
+        "confidence: number 0~1",
+        "success_signals: exec + operator + business"
+      ]
+    },
+    "engine_manifest": {
+      "path": "_meta/contracts/engine/engine_manifest.schema.yaml",
+      "version": "1.0.0",
+      "key_constraints": [
+        "additionalProperties: false",
+        "required: engine_id, domain, contracts_compat, playbooks, write_capability",
+        "write_capability: none | limited | full"
+      ]
+    },
+    "playbook_io": {
+      "path": "_meta/contracts/playbook/playbook_io.schema.yaml",
+      "version": "1.1.1",
+      "key_constraints": [
+        "additionalProperties: false",
+        "required: playbook_id, run_id, timestamp, inputs, outputs",
+        "outputs.verdict: OK | WARN | CRIT",
+        "recommendations[].tier: observe | recommend | execute_limited"
+      ]
+    }
+  },
+  "validator": {
+    "path": "_meta/contracts/scripts/validate-contracts.mjs",
+    "version": "1.1.0",
+    "exit_code_on_error": 1,
+    "features": [
+      "Schema validation",
+      "Directory partition check",
+      "Lifecycle rules (production approval)",
+      "SSOT check (single source of truth)",
+      "Bundle validation (--bundle mode)"
+    ]
+  },
+  "ci_workflow": {
+    "path": ".github/workflows/contracts-gate.yml",
+    "job_name": "Validate Contracts",
+    "triggers": ["pull_request", "push:main"],
+    "required_check": true
+  },
+  "runbook": {
+    "path": "docs/runbooks/contracts-v1-freeze.md",
+    "contents": [
+      "Boundary declaration (Control Plane vs Domain Engine)",
+      "v1.0.0 upgrade rules",
+      "Local validation commands",
+      "CI failure fix paths"
+    ]
+  },
+  "assertions": [
+    "All 3 contracts have version field",
+    "All 3 contracts have additionalProperties: false at root level",
+    "Validator exits 1 on any error (fail-closed)",
+    "CI gate runs on relevant path changes",
+    "Runbook covers common error scenarios"
+  ]
+}


### PR DESCRIPTION
## What
- **Runbook**: `docs/runbooks/contracts-v1-freeze.md` — CI failure fix paths
- **Evidence**: `evidence/evidence_contracts_v1_freeze.json` — freeze baseline

## Why
Semantic freeze before bundle implementation:
- v1.0.0 = stable API, breaking changes require v2
- Contracts already complete: `learned_policy`, `engine_manifest`, `playbook_io`
- Validator already enforces fail-closed + additionalProperties: false

## Safety
| Gate | Status |
|------|--------|
| additionalProperties: false | ✅ All 3 schemas |
| fail-closed (exit 1) | ✅ Validator |
| CI required check | ✅ contracts-gate.yml |
| Versioned contracts | ✅ v1.0.0 / v1.1.1 |

## How to test
```bash
node _meta/contracts/scripts/validate-contracts.mjs
# Expected: PASSED: All contracts valid.
```

## Files Changed
- `docs/runbooks/contracts-v1-freeze.md` (new)
- `evidence/evidence_contracts_v1_freeze.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)