### PR TITLE
governance: ADR P1 seal + BGHS validator (PR 2/8)

### DIFF
--- a/.claude/scripts/validate_adr_bghs.mjs
+++ b/.claude/scripts/validate_adr_bghs.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+/**
+ * BGHS ADR Validation Script
+ *
+ * Validates ADRs in the BGHS Track format (YAML frontmatter + bolded header
+ * fields). Defined by `_meta/EVOLUTION_ROADMAP_2025.md` § BGHS Track.
+ *
+ * Scope: `_meta/adr/ADR-*.md` files that do NOT start with a numeric prefix
+ *        (e.g. ADR-OpenClaw-Capability-Boundary.md).
+ *        Legacy numeric-prefix ADRs (ADR-004-*.md) are handled by
+ *        validate_adr.mjs (the MaaP validator) and are ignored here.
+ *
+ * Per-file checks:
+ *   1. YAML frontmatter present between two `---` markers.
+ *   2. Required keys:
+ *      - artifact_scope
+ *      - artifact_name
+ *      - artifact_role ∈ {doctrine, contract, harvest, component}
+ *      - target_layer ∈ {0, 1, 2, 3, cross}
+ *      - is_bghs_doctrine ∈ {yes, no, true, false}
+ *   3. artifact_name matches filename (`ADR-<artifact_name>.md`).
+ *   4. Body has `# ADR` H1 header.
+ *   5. `**Status**:` present and ∈ {Proposed, Accepted, Superseded, Rejected, Deprecated}.
+ *   6. `**Date**:` present and matches YYYY-MM-DD.
+ *   7. Status = Accepted → `**Accepted-Date**:` present and valid date.
+ *   8. Status = Superseded → `**Superseded-Date**:` + `**Superseded-By**:` present;
+ *      Superseded-By target file must exist.
+ *
+ * Cross-file checks:
+ *   - artifact_name uniqueness across all BGHS ADRs.
+ *   - Frontmatter `superseded_by` target file must exist (if set and not "null").
+ *
+ * Exit 0 = pass. Exit 1 = fail.
+ */
+
+import fs from "fs";
+import path from "path";
+import fg from "fast-glob";
+
+const ADR_DIR = "_meta/adr";
+const VALID_ROLES = new Set(["doctrine", "contract", "harvest", "component"]);
+const VALID_LAYERS = new Set(["0", "1", "2", "3", "cross"]);
+const VALID_BOOL = new Set(["yes", "no", "true", "false"]);
+const VALID_STATUS = new Set([
+  "Proposed",
+  "Accepted",
+  "Superseded",
+  "Rejected",
+  "Deprecated",
+]);
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const errors = [];
+
+function fail(file, msg) {
+  errors.push(`[${path.basename(file)}] ${msg}`);
+}
+
+/** Parse YAML frontmatter between `---` markers. Returns {meta, body} or null. */
+function parseFrontmatter(content) {
+  const m = content.match(/^---\n([\s\S]+?)\n---\n([\s\S]*)$/);
+  if (!m) return null;
+  const meta = {};
+  for (const line of m[1].split("\n")) {
+    const kv = line.match(/^([a-z_]+):\s*(.*)$/);
+    if (!kv) continue;
+    meta[kv[1]] = kv[2].trim();
+  }
+  return { meta, body: m[2] };
+}
+
+function validate(file) {
+  const content = fs.readFileSync(file, "utf8");
+  const parsed = parseFrontmatter(content);
+  if (!parsed) {
+    fail(file, "missing YAML frontmatter (expected `---\\n...\\n---\\n` at file head)");
+    return null;
+  }
+  const { meta, body } = parsed;
+
+  // 2. required keys
+  for (const k of [
+    "artifact_scope",
+    "artifact_name",
+    "artifact_role",
+    "target_layer",
+    "is_bghs_doctrine",
+  ]) {
+    if (!meta[k]) fail(file, `frontmatter missing key: ${k}`);
+  }
+
+  if (meta.artifact_role && !VALID_ROLES.has(meta.artifact_role)) {
+    fail(
+      file,
+      `artifact_role invalid: "${meta.artifact_role}" (expected one of ${[...VALID_ROLES].join("/")})`,
+    );
+  }
+  if (meta.target_layer && !VALID_LAYERS.has(String(meta.target_layer))) {
+    fail(
+      file,
+      `target_layer invalid: "${meta.target_layer}" (expected one of ${[...VALID_LAYERS].join("/")})`,
+    );
+  }
+  if (meta.is_bghs_doctrine && !VALID_BOOL.has(String(meta.is_bghs_doctrine))) {
+    fail(file, `is_bghs_doctrine invalid: "${meta.is_bghs_doctrine}" (expected yes/no)`);
+  }
+
+  // 3. artifact_name matches filename
+  const basename = path.basename(file, ".md"); // ADR-OpenClaw-Capability-Boundary
+  const expectedName = basename.replace(/^ADR-/, "");
+  if (meta.artifact_name && meta.artifact_name !== expectedName) {
+    fail(
+      file,
+      `artifact_name "${meta.artifact_name}" does not match filename-derived "${expectedName}"`,
+    );
+  }
+
+  // 4. H1 header
+  if (!/(^|\n)# ADR/.test(body)) {
+    fail(file, "body missing '# ADR' H1 header");
+  }
+
+  // 5. Status
+  const statusMatch = body.match(/^\*\*Status\*\*:\s*(\S+)/m);
+  if (!statusMatch) {
+    fail(file, "missing '**Status**:' line");
+    return { meta, file };
+  }
+  const status = statusMatch[1];
+  if (!VALID_STATUS.has(status)) {
+    fail(
+      file,
+      `Status invalid: "${status}" (expected one of ${[...VALID_STATUS].join("/")})`,
+    );
+  }
+
+  // 6. Date
+  const dateMatch = body.match(/^\*\*Date\*\*:\s*(\S+)/m);
+  if (!dateMatch) {
+    fail(file, "missing '**Date**:' line");
+  } else if (!DATE_RE.test(dateMatch[1])) {
+    fail(file, `Date invalid: "${dateMatch[1]}" (expected YYYY-MM-DD)`);
+  }
+
+  // 7. Accepted → Accepted-Date
+  if (status === "Accepted") {
+    const m = body.match(/^\*\*Accepted-Date\*\*:\s*(\S+)/m);
+    if (!m) {
+      fail(file, "Accepted status requires '**Accepted-Date**: YYYY-MM-DD' line");
+    } else if (!DATE_RE.test(m[1])) {
+      fail(file, `Accepted-Date invalid: "${m[1]}" (expected YYYY-MM-DD)`);
+    }
+  }
+
+  // 8. Superseded → Superseded-Date + Superseded-By + target existence
+  if (status === "Superseded") {
+    const sdate = body.match(/^\*\*Superseded-Date\*\*:\s*(\S+)/m);
+    const sby = body.match(/^\*\*Superseded-By\*\*:\s*`([^`]+)`/m);
+    if (!sdate) {
+      fail(file, "Superseded status requires '**Superseded-Date**: YYYY-MM-DD' line");
+    } else if (!DATE_RE.test(sdate[1])) {
+      fail(file, `Superseded-Date invalid: "${sdate[1]}" (expected YYYY-MM-DD)`);
+    }
+    if (!sby) {
+      fail(file, "Superseded status requires '**Superseded-By**: `<path>`' line");
+    } else {
+      const target = sby[1];
+      if (!fs.existsSync(target)) {
+        fail(file, `Superseded-By target file does not exist: ${target}`);
+      }
+    }
+  }
+
+  // frontmatter superseded_by target must exist (if a path)
+  if (meta.superseded_by && meta.superseded_by !== "null") {
+    const v = meta.superseded_by;
+    if (v.includes("/") && !fs.existsSync(v)) {
+      fail(file, `frontmatter superseded_by target does not exist: ${v}`);
+    }
+  }
+
+  return { meta, file };
+}
+
+function main() {
+  const all = fg.sync(`${ADR_DIR}/ADR-*.md`);
+  // BGHS format = no numeric prefix after "ADR-"
+  const bghsFiles = all.filter((f) => !/\/ADR-\d/.test(f));
+
+  if (bghsFiles.length === 0) {
+    console.log("[BGHS ADR VALIDATION] No BGHS-format ADRs found; nothing to check.");
+    process.exit(0);
+  }
+
+  console.log(`[BGHS ADR VALIDATION] Checking ${bghsFiles.length} file(s)...`);
+  const results = [];
+  for (const f of bghsFiles) {
+    const r = validate(f);
+    if (r) results.push(r);
+  }
+
+  // Cross-file uniqueness check
+  const nameToFiles = new Map();
+  for (const r of results) {
+    const n = r.meta.artifact_name;
+    if (!n) continue;
+    if (!nameToFiles.has(n)) nameToFiles.set(n, []);
+    nameToFiles.get(n).push(r.file);
+  }
+  for (const [name, files] of nameToFiles) {
+    if (files.length > 1) {
+      errors.push(
+        `[cross-file] artifact_name "${name}" appears in multiple files: ${files.map((f) => path.basename(f)).join(", ")}`,
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error("\n❌ BGHS ADR validation FAILED:");
+    for (const e of errors) console.error("  - " + e);
+    process.exit(1);
+  }
+  console.log(`✅ All ${bghsFiles.length} BGHS ADR(s) valid.`);
+  process.exit(0);
+}
+
+main();

--- a/.claude/scripts/validate_adr_bghs.mjs
+++ b/.claude/scripts/validate_adr_bghs.mjs
@@ -182,12 +182,43 @@ function validate(file) {
   return { meta, file };
 }
 
+function validateLegacySupersede(file) {
+  const md = fs.readFileSync(file, "utf8");
+  const status = md.match(/\*\*Status\*\*:\s*([^\s*]+)/)?.[1];
+
+  // Only enforce supersede markers when the legacy ADR claims to be Superseded.
+  // Active legacy ADRs (Accepted/Proposed) are out of scope; pre-existing missing-status
+  // ADRs are pre-PR-2 tech debt left untouched.
+  if (status !== "Superseded") return;
+
+  const supersededBy = md.match(/\*\*Superseded-By\*\*:\s*`?([^`\n]+?)`?\s*$/m)?.[1]?.trim();
+  const supersededDate = md.match(/\*\*Superseded-Date\*\*:\s*(\S+)/)?.[1];
+
+  if (!supersededBy) {
+    fail(file, "legacy ADR marked Superseded but missing **Superseded-By** marker");
+  }
+  if (!supersededDate || !DATE_RE.test(supersededDate)) {
+    fail(file, `legacy ADR marked Superseded but missing or malformed **Superseded-Date** (got "${supersededDate ?? "missing"}")`);
+  }
+}
+
 function main() {
   const all = fg.sync(`${ADR_DIR}/ADR-*.md`);
   // BGHS format = no numeric prefix after "ADR-"
   const bghsFiles = all.filter((f) => !/\/ADR-\d/.test(f));
+  const legacyFiles = all.filter((f) => /\/ADR-\d/.test(f));
+
+  if (legacyFiles.length > 0) {
+    console.log(`[BGHS ADR VALIDATION] Legacy supersede-marker check on ${legacyFiles.length} numeric-prefix file(s)...`);
+    for (const f of legacyFiles) validateLegacySupersede(f);
+  }
 
   if (bghsFiles.length === 0) {
+    if (errors.length > 0) {
+      console.error("\n❌ Legacy ADR supersede-marker check FAILED:");
+      for (const e of errors) console.error("  - " + e);
+      process.exit(1);
+    }
     console.log("[BGHS ADR VALIDATION] No BGHS-format ADRs found; nothing to check.");
     process.exit(0);
   }

--- a/.claude/scripts/validate_adr_bghs.mjs
+++ b/.claude/scripts/validate_adr_bghs.mjs
@@ -38,8 +38,8 @@ import path from "path";
 import fg from "fast-glob";
 
 const ADR_DIR = "_meta/adr";
-const VALID_ROLES = new Set(["doctrine", "contract", "harvest", "component"]);
-const VALID_LAYERS = new Set(["0", "1", "2", "3", "cross"]);
+const VALID_ROLES = new Set(["doctrine", "contract", "harvest"]);
+const VALID_LAYERS = new Set(["0", "1", "2", "3", "cross", "none"]);
 const VALID_BOOL = new Set(["yes", "no", "true", "false"]);
 const VALID_STATUS = new Set([
   "Proposed",

--- a/.github/workflows/adr-bghs-gate.yml
+++ b/.github/workflows/adr-bghs-gate.yml
@@ -1,0 +1,36 @@
+name: BGHS ADR Gate
+
+# Validates BGHS-track ADRs (YAML frontmatter + bolded header) against the
+# schema in .claude/scripts/validate_adr_bghs.mjs.
+# Legacy numeric-prefix ADRs (ADR-004-*.md etc.) are handled by the MaaP
+# validator in .github/workflows/governance-audit.yml / validate_adr.mjs
+# and are intentionally ignored here.
+
+on:
+  pull_request:
+    paths:
+      - '_meta/adr/ADR-*.md'
+      - '.claude/scripts/validate_adr_bghs.mjs'
+      - '.github/workflows/adr-bghs-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - '_meta/adr/ADR-*.md'
+      - '.claude/scripts/validate_adr_bghs.mjs'
+      - '.github/workflows/adr-bghs-gate.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install fast-glob
+        run: npm install --no-save fast-glob
+
+      - name: Validate BGHS ADRs
+        run: node .claude/scripts/validate_adr_bghs.mjs

--- a/.github/workflows/adr-bghs-gate.yml
+++ b/.github/workflows/adr-bghs-gate.yml
@@ -2,9 +2,11 @@ name: BGHS ADR Gate
 
 # Validates BGHS-track ADRs (YAML frontmatter + bolded header) against the
 # schema in .claude/scripts/validate_adr_bghs.mjs.
-# Legacy numeric-prefix ADRs (ADR-004-*.md etc.) are handled by the MaaP
-# validator in .github/workflows/governance-audit.yml / validate_adr.mjs
-# and are intentionally ignored here.
+# Legacy numeric-prefix ADRs (ADR-004-*.md etc.) live in _meta/adr/ and are
+# NOT covered by validate_adr.mjs (which only scans docs/adr/**/*.md). The
+# BGHS validator therefore performs a lightweight supersede-marker check
+# on those files (Status: Superseded + Superseded-By + Superseded-Date)
+# while skipping full BGHS schema validation.
 
 on:
   pull_request:

--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,9 @@ evidence/p1-*.tgz
 evidence/*.tgz
 # Bundle build outputs
 dist/bundles/
+
+# ============================================
+# Runtime traces (generated, not source)
+# ============================================
+data/traces/
+state/traces/

--- a/.planning/archive/remote_branches_to_delete_20260311.txt
+++ b/.planning/archive/remote_branches_to_delete_20260311.txt
@@ -1,0 +1,12 @@
+# Remote branches scheduled for deletion — 2026-03-11
+# All branches have archive tags pushed to origin before deletion.
+# Recovery: git checkout -b <branch> archive/<branch>-20260311
+#
+origin/chore/p3-patches-deny-and-diagnostics
+origin/docs/coexistence-adoption-kit
+origin/docs/readme-start-here-router
+origin/feat/epiplexity-observe-v0
+origin/feat/p0-cost-meter
+origin/feat/p2b-evidence-artifact
+origin/feat/phase2w1-real-write-gray
+origin/feat/pr2-feishu-operator-loop-bid-recommend

--- a/.planning/baseline/uncommitted-code-triage.md
+++ b/.planning/baseline/uncommitted-code-triage.md
@@ -133,7 +133,7 @@
 ## 建议执行顺序（Sprint 0 收口时）
 
 1. **Owner 审 A3 diff** → 决定 keep / commit / revert
-2. **discard C1/C2/D1**：`rm -rf data/traces/ state/traces/ evidence/remote_branches_to_delete_20260311.txt`
+2. **discard C1/C2/D1**（按 Appendix · Cleanup Discipline 模板）：先 `git ls-files <dir>` + `git status --short <dir>` 枚举，仅按 untracked 子项精确删；混居目录禁用目录级 `rm -rf`。`evidence/remote_branches_to_delete_20260311.txt` 是单文件，可直接 `rm`。
 3. **补 `.gitignore`**：加 `data/traces/` + `state/traces/`
 4. **Commit #1（A1 + A2 + B1-B3）**：`feat(runtime): add control plane + orchestrator baseline with tests`
 5. **Commit #2（E1-E4 + 本文件）**：`docs(roadmap): add BGHS track + BGHS ADR validator + Sprint 0 triage`

--- a/.planning/baseline/uncommitted-code-triage.md
+++ b/.planning/baseline/uncommitted-code-triage.md
@@ -1,0 +1,180 @@
+# Uncommitted Code Triage — Baseline Before Sprint 1
+
+**Purpose**: 盘点 Sprint 0 进入点时的未提交/已修改文件，为每块给出明确处置与是否阻塞 Sprint 1 的判定。
+
+**Date**: 2026-04-17
+**Owner**: liye
+**Git Head at Triage**: `af0300e` (docs(adr): mark legacy P1 drafts as superseded by accepted ADRs)
+
+---
+
+## 处置分类
+
+- **keep**：保留在本地工作区，暂不提交（待后续明确归属）
+- **discard**：从 working tree 删除（或 gitignore）
+- **commit-as-baseline**：作为 baseline 一并提交（通常在 Sprint 0 收口时）
+- **needs-review**：处置待定，需要 owner 做判断
+
+---
+
+## 逐块清单
+
+### A. Src 层（实质代码）
+
+#### A1. `src/control/`（9 files · 1 438 LOC · untracked）
+
+| 属性 | 值 |
+|---|---|
+| 内容 | AI Agent Capability Control Plane：`registry.ts` (CapabilityRegistry class), `types.ts` (7-field CapabilityContract + AgentCard), `extractor.ts`, `trust.ts`, `a3-*.ts`, `execution-policy.ts`, `discovery-policy.ts`, `index.ts` |
+| 被依赖 | `src/runtime/orchestrator/router.ts` 等（orchestrator 构建在其之上） |
+| 与 Sprint 4 关系 | **F2 核心：这是 AI agent 层的 CapabilityRegistry，不是 BGHS 层的 capability runtime**。Sprint 4 会在 `src/runtime/governance/capability/` 新建独立 BGHS registry，与本目录划清边界（README + 硬纪律「不得跨 import」） |
+| 处置 | **commit-as-baseline** |
+| 阻塞 Sprint 1？ | **否**（Sprint 1 工作在 `src/runtime/governance/session/` 与 `src/runtime/governance/wake/`，与本目录并排） |
+| 备注 | 提交前建议：head 注释补一行「AI Agent Capability layer — see Sprint 4 README for boundary vs `src/runtime/governance/capability/`」 |
+
+#### A2. `src/runtime/orchestrator/`（5 files · 1 076 LOC · untracked）
+
+| 属性 | 值 |
+|---|---|
+| 内容 | Runtime orchestrator：`decomposer.ts` (RuleBasedDecomposer), `router.ts` (CapabilityRouter), `engine.ts` (OrchestrationEngine), `types.ts`, `index.ts` |
+| 依赖 | `src/control/` |
+| 与 Sprint 4+ 关系 | 这是 execution 面 orchestrator，不是 governance 面；与 Sprint 4 BGHS capability 正交 |
+| 处置 | **commit-as-baseline** |
+| 阻塞 Sprint 1？ | **否** |
+
+#### A3. `src/runtime/scheduler/dag.ts`（**M** modified · +255/-9 lines）
+
+| 属性 | 值 |
+|---|---|
+| 改动规模 | 264 行变更（基线是 `b715779 release v3.1.0`） |
+| 与本会话关系 | 未知——改动早于本会话 |
+| 风险 | 改动规模很大，**不建议盲提交** |
+| 处置 | **needs-review**（在 commit-as-baseline 之前，由 owner 审 `git diff src/runtime/scheduler/dag.ts`，确认是有意改动后再提） |
+| 阻塞 Sprint 1？ | **否**（Sprint 1 不碰 scheduler） |
+
+---
+
+### B. Tests（配套测试）
+
+#### B1. `tests/control/control-plane.test.ts`
+#### B2. `tests/orchestrator/{approval-workflow,crew-matching,orchestrator}.test.ts`
+#### B3. `tests/trial-run/{v1-*,v2-*}.test.ts`（5 files）
+
+| 属性 | 值 |
+|---|---|
+| 内容 | A1/A2 的配套测试 |
+| 处置 | **commit-as-baseline**（与 A1/A2 同一批，保证测试覆盖随代码落盘） |
+| 阻塞 Sprint 1？ | **否** |
+
+---
+
+### C. Runtime 生成数据（应 gitignore）
+
+#### C1. `data/traces/`（15 目录）
+
+| 属性 | 值 |
+|---|---|
+| 内容 | `a3/`, `a3-batch1/`, `a3-batch1-tmp/`, `age-anomaly_detect-*`, `d7/`, `epiplexity/`, `investment/`, `kernel/`, `medical/`, `orchestrator/`, `revalidation/`, `run-20260208-*`, `world_model/` 等——全部是运行生成的 trace 数据 |
+| .gitignore 状态 | **当前未忽略** |
+| 处置 | **discard**（从 working tree 清理）+ **新增 `.gitignore` 规则 `data/traces/`**（与 `evidence/*.tgz` 同级纪律） |
+| 阻塞 Sprint 1？ | **否** |
+| 备注 | 若某个 trace 有审计价值，单独 copy 到 `.planning/` 或 `evidence/`（非泛 `data/traces/` 归属），不污染 runtime 目录 |
+
+#### C2. `state/traces/`（2 trace-UUID 目录）
+
+| 属性 | 值 |
+|---|---|
+| 内容 | `trace-21010724-89da-48b2-9b6c-a91ca4d79849/`, `trace-46926c23-fe72-45e2-aa04-7de702a2b33c/` |
+| 处置 | **discard** + **gitignore `state/traces/`** |
+| 阻塞 Sprint 1？ | **否** |
+
+---
+
+### D. 一次性 evidence
+
+#### D1. `evidence/remote_branches_to_delete_20260311.txt`（489 字节）
+
+| 属性 | 值 |
+|---|---|
+| 内容 | 2026-03-11 列出「待删远端分支」清单 |
+| 时效 | 一次性作业凭据；已过 5 周 |
+| 处置 | **discard**（删除文件；若要留证，存到 `.planning/archive/2026-03/`） |
+| 阻塞 Sprint 1？ | **否** |
+
+---
+
+### E. 本 Sprint 0 产物（待 commit）
+
+#### E1. `_meta/EVOLUTION_ROADMAP_2025.md`（**M**）— Sprint 0.1 新增 BGHS Track
+#### E2. `.claude/scripts/validate_adr_bghs.mjs`（untracked）— Sprint 0.2 新 validator
+#### E3. `.github/workflows/adr-bghs-gate.yml`（untracked）— Sprint 0.2 CI gate
+#### E4. `.planning/baseline/uncommitted-code-triage.md`（untracked）— 本文件
+
+| 处置 | **commit-as-baseline**（Sprint 0 收口时统一提交） |
+| 阻塞 Sprint 1？ | **否**（本身就是 Sprint 0 产物） |
+
+---
+
+## 汇总表
+
+| 块 | 处置 | 阻塞 Sprint 1 | 备注 |
+|---|---|---|---|
+| A1 `src/control/` | commit-as-baseline | 否 | 提交前加边界注释 |
+| A2 `src/runtime/orchestrator/` | commit-as-baseline | 否 | — |
+| A3 `src/runtime/scheduler/dag.ts` (M) | **needs-review** | 否 | owner 审 diff 后再定 |
+| B1-B3 tests/ | commit-as-baseline | 否 | 与 A1/A2 同批 |
+| C1 `data/traces/` | discard + gitignore | 否 | 规则加 `data/traces/` |
+| C2 `state/traces/` | discard + gitignore | 否 | 规则加 `state/traces/` |
+| D1 `evidence/remote_branches_...txt` | discard | 否 | 可归档到 `.planning/archive/2026-03/` |
+| E1-E4 Sprint 0 产物 | commit-as-baseline | 否 | Sprint 0 收口 commit |
+
+---
+
+## 建议执行顺序（Sprint 0 收口时）
+
+1. **Owner 审 A3 diff** → 决定 keep / commit / revert
+2. **discard C1/C2/D1**：`rm -rf data/traces/ state/traces/ evidence/remote_branches_to_delete_20260311.txt`
+3. **补 `.gitignore`**：加 `data/traces/` + `state/traces/`
+4. **Commit #1（A1 + A2 + B1-B3）**：`feat(runtime): add control plane + orchestrator baseline with tests`
+5. **Commit #2（E1-E4 + 本文件）**：`docs(roadmap): add BGHS track + BGHS ADR validator + Sprint 0 triage`
+6. **（可选）Commit #3（A3）**：若 owner 审过确认保留，单独提交，避免与 baseline 混
+
+---
+
+## 退出条件（Sprint 0.3 closure）
+
+- [ ] A3 dag.ts 归属明确
+- [ ] C1/C2/D1 已 discard 或归档
+- [ ] .gitignore 更新（如选 discard 路径）
+- [ ] A1/A2/B1-B3 + E1-E4 已提交（或明确延后理由）
+- [ ] `git status` 干净至仅剩 owner 认可的未提交项
+
+满足 → 进入 Sprint 1。
+
+---
+
+## Appendix · Cleanup Discipline（2026-04-17 立规）
+
+**背景**：本 Sprint 0.3 执行中，原 triage 第 2 步写的是 `rm -rf data/traces/ state/traces/ evidence/...`。实际执行时发现 `data/traces/` 有 29 个 **tracked** 文件与 6 个 untracked 子目录**混居**。目录级 `rm -rf` 把 tracked 文件一并删除（所幸 working-tree 级别可恢复，通过 `git restore --source=HEAD --staged --worktree -- data/traces/`）。
+
+**规则（强制）**：
+
+> Future destructive cleanup 必须先 `git ls-files <dir>` + `git status --short <dir>` 枚举；只允许按文件/子目录精确删，**禁止目录级 `rm -rf`**（除非该目录本身在 `.gitignore` 下且 `git ls-files <dir>` 返回空）。
+
+**执行模板**：
+
+```bash
+# Step 1: 盘点
+git ls-files <dir>          # tracked 清单（精确到文件）
+git status --short <dir>    # untracked 子项（?? 开头的才能删）
+
+# Step 2: 只删 untracked 项（精确到子目录或文件）
+rm -rf <dir>/<untracked-subdir-1>
+rm -rf <dir>/<untracked-subdir-2>
+# …
+
+# Step 3: 验证
+git status --short <dir>    # 应无 D 行（无意外误删 tracked）
+```
+
+**适用范围**：任何对 `data/` / `state/` / `evidence/` / `artifacts/` 或其他历史性/混居目录的清理动作。纯工作区 ignored artifact（build output 等）不受此约束。

--- a/_meta/EVOLUTION_ROADMAP_2025.md
+++ b/_meta/EVOLUTION_ROADMAP_2025.md
@@ -2,7 +2,7 @@
 
 **Vision**: Build a self-evolving personal operating system powered by dual AI engines (Claude Code + Antigravity)
 
-**Last Updated**: 2026-01-31
+**Last Updated**: 2026-04-17
 **Status**: Active Planning
 
 ---
@@ -17,6 +17,70 @@
 > - Public endpoint: `https://gateway.liye.ai`
 > - Runbook: `docs/ops/RUNBOOK_GATEWAY.md`
 > - Dify integration verified (ALLOW/BLOCK scenarios)
+
+---
+
+## 🧭 BGHS Track (2026-04-)
+
+> **双轨并存**：此 section 与上方 2025 Governance Gateway 轨道**正交**——「P1」等编号在两条轨道里含义不同，不得混用。BGHS Track 的 P 编号是 **Capability Harvest + Contract ADR 批次**，不是 Gateway 里程碑。
+
+### 轨道定义
+
+- **主题**：BGHS 四分类（Brain / Governance / Hands / Session）体系落地 + 参考项目（OpenClaw / Hermes / AGE）能力收割
+- **SSOT**：`_meta/adr/` 所有 `ADR-*-*.md`（YAML frontmatter 体系，**不是** 旧 MaaP `- decision_id: ADR-XXXX` 格式）
+- **ADR validator**：`.claude/scripts/validate_adr_bghs.mjs`（本 Track 专用，**不**复用 `validate_adr.mjs`）
+
+### P1 批次 · Capability Harvest + Contract ADR（已封板 2026-04-17）
+
+**Status**: SEALED ✅ · Accepted on 2026-04-17
+
+| ID | ADR 文件 | Role | Target Layer |
+|---|---|---|---|
+| Doctrine | [ADR-Architecture-Doctrine-BGHS-Separation.md](./adr/ADR-Architecture-Doctrine-BGHS-Separation.md) | doctrine | cross |
+| P1-a | [ADR-OpenClaw-Capability-Boundary.md](./adr/ADR-OpenClaw-Capability-Boundary.md) | harvest | 0 |
+| P1-b | [ADR-Hermes-Skill-Lifecycle.md](./adr/ADR-Hermes-Skill-Lifecycle.md) | harvest | cross |
+| P1-c | [ADR-Hermes-Memory-Orchestration.md](./adr/ADR-Hermes-Memory-Orchestration.md) | harvest | 1 |
+| P1-d | [ADR-Loamwise-Guard-Content-Security.md](./adr/ADR-Loamwise-Guard-Content-Security.md) | harvest | 1 |
+| P1-e | [ADR-Session-and-Session-Adjacent-Taxonomy-Federated-Query.md](./adr/ADR-Session-and-Session-Adjacent-Taxonomy-Federated-Query.md) | contract | cross |
+| P1-f | [ADR-Credential-Mediation.md](./adr/ADR-Credential-Mediation.md) | contract | cross |
+| P1-g | [ADR-AGE-Wake-Resume.md](./adr/ADR-AGE-Wake-Resume.md) | contract | 2 |
+
+**历史参考**（Superseded 2026-04-17，保留为审计痕迹，不再生效）：
+
+| 旧 ADR | Superseded-By |
+|---|---|
+| ADR-004-OpenClaw-Capability-Boundary.md | ADR-OpenClaw-Capability-Boundary.md |
+| ADR-005-Hermes-Skill-Lifecycle.md | ADR-Hermes-Skill-Lifecycle.md |
+| ADR-006-Hermes-Memory-Orchestration.md | ADR-Hermes-Memory-Orchestration.md |
+| ADR-007-Loamwise-Guard-Content-Security.md | ADR-Loamwise-Guard-Content-Security.md |
+
+### 实施阶段 · Sprint 0 → Sprint 7
+
+封板后的实施顺序严格按下表执行（非概念顺序，是**代码库实况兼容的施工顺序**）：
+
+| Sprint | 内容 | 关键路径 | 前置 |
+|---|---|---|---|
+| **0** | Baseline 收口：roadmap + `validate_adr_bghs.mjs` + 未提交代码盘点 | `_meta/`, `.claude/scripts/`, `.planning/baseline/` | — |
+| **1** | AGE 恢复闭环（P1-e StreamRegistry + P1-g wake validator + 3 store `--diff`） | `src/runtime/governance/session/`, `src/runtime/governance/wake/`, `/Users/liye/github/amazon-growth-engine/scripts/onboarding/_lib/wake_contract.py` | Sprint 0.3 |
+| **2** | P1-f CredentialBroker seam + env hygiene gate | `src/runtime/credential/`, `.claude/.githooks/pre-commit` (Check 7), `.github/workflows/env-hygiene-gate.yml` | — |
+| **3** | P1-d Guard runtime skeleton（**不接线**） | `src/runtime/governance/guard/`（evidence 走 `src/audit/evidence/`） | — |
+| **4** | P1-a BGHS CapabilityRegistry + README 硬边界 | `src/runtime/governance/capability/`（**不动** `src/control/registry.ts`） | — |
+| **5** | P1-b Skill Lifecycle + Guard 接线-1（skill candidate submit） | `src/runtime/governance/skill_lifecycle/`（**不动** `src/skill/`） | Sprint 3 |
+| **6** | P1-c Memory frozen + Guard 接线-2（memory write / assembly fragment ingest） | `src/runtime/governance/memory/`（**不动** `src/memory/`） | Sprint 3 |
+| **7** | Guard escalation 评审（SHADOW → ADVISORY） | 数据驱动；前置 Sprint 3 shadow ≥ 1 周数据 | Sprint 3, 5, 6 |
+
+### 架构硬约束（跨 Sprint 不变）
+
+1. **新 BGHS runtime 统一落 `src/runtime/governance/`**（不动 `src/control/` / `src/skill/` / `src/memory/` / `src/brokers/`——这些目录已有不同语义的占位者）
+2. **`src/runtime/governance/capability/` ⇎ `src/control/registry.ts` 不得跨 import**（BGHS capability vs AI agent capability，语义不同）
+3. **Evidence 只有一套基建**：`src/audit/evidence/`（不得建第三套 mjs/ts 变体）
+4. **P2 Guard 必须 SHADOW → ADVISORY → ACTIVE 逐级升级**（P1-d §5 强制）
+5. **P3 学习环必须 quarantine-first**（P1-b 强制）
+6. **P4 检索默认 strict_truth**（P1-c / P1-e 强制）
+
+### Track 版本
+
+- v1.0（2026-04-17）：P1 封板 · 8 ADR Accepted · 4 ADR Superseded · Sprint 0–7 计划就绪
 
 ---
 

--- a/_meta/adr/ADR-004-OpenClaw-Capability-Boundary.md
+++ b/_meta/adr/ADR-004-OpenClaw-Capability-Boundary.md
@@ -1,0 +1,452 @@
+# ADR-004: OpenClaw Capability Boundary -- 插件主权模型与安全审计
+
+**Status**: Superseded
+**Date**: 2026-04-14
+**Superseded-Date**: 2026-04-17
+**Superseded-By**: `_meta/adr/ADR-OpenClaw-Capability-Boundary.md`
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-004-OpenClaw-Capability-Boundary.md`
+
+> Historical draft. Superseded by `ADR-OpenClaw-Capability-Boundary.md` on 2026-04-17. Retained for audit/history only.
+
+## Context
+
+SYSTEMS.md 进化路线 P1 要求产出 4 份 Capability Harvest ADR，每份必须附最小 contract 草图。
+本 ADR 聚焦 OpenClaw 生态（`openclaw-skillgate` 仓库 + `src/gateway/openclaw/` 网关层）的三个关键 pattern：
+
+1. **插件主权边界** -- Skill 作为独立所有权单元，通过 manifest 声明能力而非源码耦合
+2. **供应链安全审计** -- 三层发现 + 规则扫描 + combo 评分 + 隔离/恢复闭环
+3. **治理通信协议** -- Gate/Enforce/Route/Execute/Verdict 五阶段管线 + HMAC 鉴权
+
+LiYe OS 当前已有 `CapabilityContract`（7 字段冻结）、`CapabilityRegistry`、`ExecutionPolicy` 等控制面原语（`src/control/`），
+但缺少：
+- Skill/Plugin 级别的供应链安全审计机制
+- 能力注册时的自动化威胁扫描
+- 隔离/恢复操作的 evidence 闭环
+
+本 ADR 明确从 OpenClaw 生态吸收哪些 pattern、拒绝哪些，并给出 LiYe Systems 自有实现的 contract 草图。
+
+## 上游核心做法
+
+### 1. 三层 Skill 发现 (Three-Layer Discovery)
+
+`/Users/liye/github/openclaw-skillgate/src/core/discover.ts` 实现了三层扫描源：
+
+| 层 | Source | 路径 | 含义 |
+|---|--------|------|------|
+| workspace | 当前工作目录 | `process.cwd()` | 项目本地 skill |
+| managed | 全局安装目录 | `~/.openclaw/skills` | 用户级 skill |
+| extraDirs | 配置文件中声明 | `~/.openclaw/openclaw.json → skills.dirs[]` | 外挂目录 |
+
+Skill 识别标记文件：`skill.json`, `skill.yaml`, `package.json`, `openclaw.skill.json`。
+SkillKey 优先级：`metadata.openclaw.skillKey > metadata.name > 目录名`。
+
+### 2. 插件清单 (Plugin Manifest)
+
+`/Users/liye/github/openclaw-skillgate/openclaw.plugin.json` 定义了插件元数据契约：
+- `commands` -- 命令注册表，声明每个 slash command 的 usage、requiresAuth
+- `hooks.onSkillInstall` -- 生命周期钩子，安装时自动触发扫描
+- `config` -- 声明配置路径和默认策略（`conservative`）
+
+### 3. 规则引擎 + Combo 评分
+
+`/Users/liye/github/openclaw-skillgate/src/core/scan.ts` 定义 17 条扫描规则，分 4 级：
+- CRITICAL (5): `curl|bash`, `wget|sh`, `base64|sh`, `rm -rf /`, `eval(fetch())`
+- HIGH (5): download-execute, env-exfiltration, hardcoded-token, shell-spawn-untrusted, install-download
+- MEDIUM (4): dynamic-require, fs-write-root, network-listener, obfuscated-code
+- LOW (3): shell-exec, network-request, file-system-access
+
+`/Users/liye/github/openclaw-skillgate/src/core/decision.ts` 实现 combo 叠加机制：
+- 5 个 combo 定义（supply-chain-attack, obfuscated-execution, credential-theft, destructive-payload, install-hook-risky）
+- 单条 finding 按 severity 加权（CRITICAL=100, HIGH=50, MEDIUM=20, LOW=5）
+- Combo 触发时额外加分（40-100），最终 score 决定 RiskLevel 和 RecommendedAction
+
+### 4. Fail-Closed 鉴权
+
+`/Users/liye/github/openclaw-skillgate/src/core/authz.ts`:
+- 所有写操作（quarantine/restore/allow/disable）必须显式用户确认
+- 非交互模式 (`!process.stdin.isTTY`) 一律拒绝 -- fail-closed
+- 30 秒超时自动拒绝
+
+### 5. Evidence 不落明文
+
+`/Users/liye/github/openclaw-skillgate/src/core/redaction.ts`:
+- 所有 finding snippet 只存 `sha256:hash`，不存原文
+- 9 类敏感模式检测（API key, AWS cred, private key, connection string, email, IP, credential URL）
+
+### 6. 治理通信管线 (LiYe Gateway 已有实现)
+
+`/Users/liye/github/liye_os/src/gateway/openclaw/job_runner.ts` 实现五阶段管线：
+```
+Gate(0-10%) -> Enforce(10-20%) -> Route(20-30%) -> Execute(30-90%) -> Verdict(90-100%)
+```
+
+`/Users/liye/github/liye_os/src/gateway/openclaw/types.ts` 定义了 `GovToolCallRequestV1` / `GovToolCallResponseV1`，
+包含 `Decision: ALLOW | BLOCK | DEGRADE | PENDING` 四种判定。
+
+`/Users/liye/github/liye_os/contracts/governance/v1/gov_tool_call_request_v1.schema.json` 提供 JSON Schema 验证。
+
+## 吸收项
+
+### A1: Capability Registration 时的 Threat Scan 钩子
+
+**OpenClaw pattern**: `hooks.onSkillInstall` -- 安装时自动触发扫描
+**LiYe 吸收**: 在 `CapabilityRegistry.registerAgent()` 流程中增加 pre-register scan gate。
+Agent/Skill 注册前必须通过最小安全扫描，CRITICAL 级别自动拒绝注册。
+
+**理由**: 当前 `src/control/registry.ts` 的 `registerAgent()` 是无条件接受，
+缺少供应链安全的第一道防线。吸收此 pattern 可以在注册入口实现 fail-closed。
+
+### A2: 规则 + Combo 的复合评分模型
+
+**OpenClaw pattern**: severity 加权 + combo 叠加 + threshold 分级
+**LiYe 吸收**: 采用相同的评分架构（base score + combo bonus → risk level），
+但规则集针对 LiYe Systems 的实际威胁面重写（见 Contract Sketch）。
+
+**理由**: 单一规则匹配容易误报/漏报。Combo 机制用"组合证据"降低误判率，
+是比简单 allowlist/blocklist 更成熟的方案。
+
+### A3: Evidence 不落明文 + Redaction
+
+**OpenClaw pattern**: `snippet_redacted: true` + `snippet_hash: sha256:...`
+**LiYe 吸收**: 所有 capability scan 的 evidence 只存 hash，不存源码片段。
+与现有 `TraceStore`（`src/gateway/openclaw/trace_store.ts`）的 append-only 模型兼容。
+
+**理由**: LiYe OS 的 evidence 可能包含第三方 engine 源码或配置，
+落明文会造成审计日志本身成为攻击面。
+
+### A4: Quarantine / Restore 闭环操作
+
+**OpenClaw pattern**: quarantine = backup + disable + evidence 记录; restore = re-enable + 清除标记
+**LiYe 吸收**: 在 `CapabilityContract` 层面增加 `status: active | quarantined | disabled` 字段，
+支持隔离和恢复操作。与 ADR-001 的 `sandbox/candidate/production/disabled/quarantine` 分区模型对齐。
+
+**理由**: 当前 `AgentCard.status` 只有 `available | busy | deprecated`，
+缺少"因安全原因临时隔离"的语义。
+
+## 不吸收项
+
+### R1: OpenClaw 产品级 Runtime 主权
+
+**不吸收**: OpenClaw 的 `~/.openclaw/` 全局状态目录、`openclaw.json` 配置体系、
+`openclaw.plugin.json` 插件注册格式。
+
+**理由**: LiYe OS 不构建在 OpenClaw 之上。LiYe OS 是独立制度底座，
+有自己的 `_meta/contracts/` 合约体系和 `engine_manifest.schema.yaml`。
+引入 OpenClaw 的配置体系会造成双重配置源。
+
+### R2: 三层目录发现 (workspace/managed/extraDirs)
+
+**不吸收**: OpenClaw 的三层文件系统扫描发现模式。
+
+**理由**: LiYe Systems 的 capability 发现走 `engine_manifest.yaml` 声明式注册
+（见 SYSTEMS.md D0->D1 流程），不走文件系统扫描。
+声明式注册比目录扫描更安全（防止未声明的 skill 被意外加载）。
+
+### R3: Skill 作为一等执行单元
+
+**不吸收**: OpenClaw 中 Skill 是直接可执行的代码单元。
+
+**理由**: LiYe Systems 的执行单元是 Engine Playbook（`engine_manifest.playbooks[]`），
+Skill 在 LiYe OS 语境中是知识文档而非代码执行器。
+引入 OpenClaw 的 Skill 概念会与现有 `Skills/` 目录语义冲突。
+
+### R4: 直接调用 @skillgate/openclaw-skillgate npm 包
+
+**不吸收**: 不在 LiYe OS CI/runtime 中直接依赖 openclaw-skillgate 包。
+
+**理由**: Fork 纪律（SYSTEMS.md）明确规定"上游参考仓只提供 pattern benchmark，不作为实现主干"。
+安全扫描逻辑需要独立实现，规则集需要针对 LiYe 威胁面定制。
+
+## 与 LiYe Systems 分层关系
+
+| 吸收项 | 落地层 | 落地位置 | 与现有组件关系 |
+|--------|--------|---------|---------------|
+| A1: Registration Scan Gate | Layer 0 (LiYe OS) | `src/control/registration-gate.ts` | 插入 `CapabilityRegistry.registerAgent()` 前 |
+| A2: 复合评分模型 | Layer 0 (LiYe OS) | `src/control/threat-scanner.ts` | 新增组件，被 Registration Gate 调用 |
+| A3: Evidence Redaction | Layer 0 (LiYe OS) | `src/control/evidence-redact.ts` | 集成到现有 `TraceStore` 写入链路 |
+| A4: Quarantine/Restore | Layer 0 (LiYe OS) | `src/control/types.ts` (扩展) | 扩展 `AgentCard.status` 枚举 |
+| 规则集定制 | Layer 1 (Loamwise) | `loamwise/govern/scan-rules/` | Loamwise GuardChain 消费规则集 |
+| Engine 级扫描触发 | Layer 2 (Domain Engines) | 各 engine 的 CI pre-register gate | engine_manifest 注册前的必经检查 |
+| 面向用户的安全报告 | Layer 3 (Product Lines) | 各产品线自行决定展示形式 | 不在本 ADR 范围 |
+
+**依赖方向**:
+```
+Layer 2 Engine --注册--> Layer 0 Registration Gate --调用--> Layer 0 Threat Scanner
+                                                    --写入--> Layer 0 TraceStore (with Redaction)
+Layer 1 Loamwise --消费--> Layer 0 扫描规则集 (scan-rules schema)
+```
+
+**禁止方向**:
+```
+禁止: Layer 0 依赖 OpenClaw runtime
+禁止: Layer 2 绕过 Registration Gate 直接注册
+禁止: 扫描规则硬编码在 Layer 2（规则集属于 Layer 0/1）
+```
+
+## Decision
+
+LiYe Systems 采用 OpenClaw SkillGate 的"注册时扫描 + 复合评分 + evidence 不落明文 + 隔离恢复闭环"四个 pattern，
+在 Layer 0 (`src/control/`) 独立实现。
+
+核心原则：**Capability 是核心合约，Agent/Engine 是所有权边界**。
+
+- Capability 注册是能力合约的发布行为，必须通过安全审计 gate
+- Agent/Engine 拥有其 Capability 的所有权，可被整体隔离/恢复
+- 扫描规则集是治理原语，归 Layer 0 所有，Layer 1 (Loamwise) 可扩展但不可覆盖
+- Evidence 全链路 redaction，审计日志不成为新攻击面
+
+不采用 OpenClaw 的产品级运行时、配置体系、目录发现模式。
+不在 LiYe OS 中引入 openclaw-skillgate 作为运行时依赖。
+
+## Contract Sketch
+
+### 1. CapabilityContract 扩展 (Layer 0)
+
+```typescript
+// src/control/types.ts -- 扩展现有 7 字段冻结 contract
+
+/** 注册时威胁扫描结果，附加到 CapabilityContract 上 */
+export interface ThreatScanResult {
+  scan_id: string;                     // 格式: "scan-{uuid8}"
+  scanned_at: string;                  // ISO 8601
+  scanner_version: string;             // 扫描器版本
+  risk_level: 'CRITICAL' | 'HIGH' | 'MEDIUM' | 'LOW' | 'SAFE';
+  risk_score: number;                  // 0-999
+  finding_count: number;
+  critical_count: number;
+  high_count: number;
+  combos_detected: string[];           // combo 名称列表
+  evidence_hash: string;               // sha256 of full evidence (not stored inline)
+}
+
+/** AgentCard.status 扩展 */
+export type AgentStatus =
+  | 'available'
+  | 'busy'
+  | 'deprecated'
+  | 'quarantined'     // 新增: 因安全原因隔离
+  | 'scan_pending';   // 新增: 等待首次扫描
+
+/** 隔离元数据 */
+export interface QuarantineRecord {
+  quarantined_at: string;              // ISO 8601
+  reason: string;
+  evidence_hash: string;
+  can_restore: boolean;                // false = 需要重新注册
+  restored_at?: string;
+}
+```
+
+### 2. Registration Gate 接口 (Layer 0)
+
+```typescript
+// src/control/registration-gate.ts
+
+import type { AgentCard, ThreatScanResult } from './types';
+
+export interface RegistrationGateResult {
+  allowed: boolean;
+  scan: ThreatScanResult;
+  rejection_reason?: string;
+}
+
+export interface IRegistrationGate {
+  /**
+   * 注册前检查。CRITICAL 直接拒绝，HIGH 需要人工审批。
+   * fail-closed: 扫描失败 = 拒绝注册。
+   */
+  check(card: AgentCard): Promise<RegistrationGateResult>;
+}
+
+/** 注册拒绝阈值 */
+export const REGISTRATION_THRESHOLDS = {
+  auto_reject: 'CRITICAL' as const,    // 自动拒绝
+  require_approval: 'HIGH' as const,   // 需要人工审批
+  auto_accept: 'MEDIUM' as const,      // 自动接受 (记录 warning)
+} as const;
+```
+
+### 3. Threat Scanner 规则 Schema (Layer 0)
+
+```yaml
+# _meta/contracts/security/scan_rule.schema.yaml
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://liye.com/contracts/security/scan_rule.v1"
+title: "Capability Scan Rule"
+version: "1.0.0"
+type: object
+
+required:
+  - id
+  - severity
+  - pattern
+  - description
+  - category
+
+properties:
+  id:
+    type: string
+    pattern: "^[a-z0-9-]+$"
+    description: "规则唯一标识"
+  severity:
+    type: string
+    enum: [CRITICAL, HIGH, MEDIUM, LOW, INFO]
+  pattern:
+    type: string
+    description: "正则表达式字符串"
+  description:
+    type: string
+    maxLength: 200
+  category:
+    type: string
+    enum:
+      - supply-chain
+      - injection
+      - data-exfiltration
+      - credentials
+      - destructive
+      - obfuscation
+      - filesystem
+      - network
+      - dynamic-loading
+  file_types:
+    type: array
+    items:
+      type: string
+    description: "仅对特定文件类型生效"
+  enabled:
+    type: boolean
+    default: true
+
+additionalProperties: false
+```
+
+### 4. Combo 定义 Schema (Layer 0)
+
+```yaml
+# _meta/contracts/security/scan_combo.schema.yaml
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://liye.com/contracts/security/scan_combo.v1"
+title: "Scan Combo Definition"
+version: "1.0.0"
+type: object
+
+required:
+  - name
+  - description
+  - rules
+  - min_matches
+  - score_bonus
+
+properties:
+  name:
+    type: string
+    pattern: "^[a-z0-9-]+$"
+  description:
+    type: string
+    maxLength: 200
+  rules:
+    type: array
+    items:
+      type: string
+    minItems: 2
+    description: "参与 combo 的 rule id 列表"
+  min_matches:
+    type: integer
+    minimum: 1
+    description: "触发 combo 所需的最少匹配规则数"
+  score_bonus:
+    type: integer
+    minimum: 0
+    maximum: 200
+    description: "combo 触发时的额外加分"
+
+additionalProperties: false
+```
+
+### 5. Evidence Redaction 接口 (Layer 0)
+
+```typescript
+// src/control/evidence-redact.ts
+
+export interface RedactedEvidence {
+  scan_id: string;
+  agent_id: string;
+  scanned_at: string;
+  risk_level: string;
+  risk_score: number;
+  findings: RedactedFinding[];
+  combos: string[];
+  content_hash: string;               // sha256 of full unredacted evidence
+}
+
+export interface RedactedFinding {
+  rule_id: string;
+  severity: string;
+  file: string;
+  line: number;
+  description: string;
+  snippet_hash: string;               // sha256 of matched snippet
+  snippet_redacted: true;             // 常量, 确认已脱敏
+}
+
+export interface IEvidenceRedactor {
+  /** 将扫描结果转为脱敏 evidence */
+  redact(scanResult: RawScanResult): RedactedEvidence;
+  /** 验证 evidence 完整性 (hash 比对) */
+  verify(evidence: RedactedEvidence, rawHash: string): boolean;
+}
+```
+
+### 6. 端到端注册流程 (Layer 0 + Layer 2)
+
+```
+Engine (Layer 2)                     LiYe OS (Layer 0)
+     |                                     |
+     |-- engine_manifest.yaml ------------>|
+     |                                     |-- RegistrationGate.check()
+     |                                     |     |-- ThreatScanner.scan()
+     |                                     |     |     |-- 加载 scan_rule + scan_combo
+     |                                     |     |     |-- 扫描 source_path 下所有文件
+     |                                     |     |     |-- 计算 base_score + combo_bonus
+     |                                     |     |     `-- 返回 ThreatScanResult
+     |                                     |     |
+     |                                     |     |-- EvidenceRedactor.redact()
+     |                                     |     |     `-- 返回 RedactedEvidence (写入 TraceStore)
+     |                                     |     |
+     |                                     |     |-- 判定: CRITICAL -> reject
+     |                                     |     |         HIGH -> pending_approval
+     |                                     |     |         MEDIUM/LOW/SAFE -> accept
+     |                                     |     `-- 返回 RegistrationGateResult
+     |                                     |
+     |                        allowed=true |-- CapabilityRegistry.registerAgent()
+     |                                     |-- AgentCard.status = 'available'
+     |                                     |
+     |<-- registration result -------------|
+```
+
+## 非目标
+
+1. **不定义具体扫描规则内容** -- 规则集内容属于 P2 实现范畴，本 ADR 只定义规则的 schema
+2. **不实现 Loamwise GuardChain 集成** -- 属于 P2-B1 (Content Threat Detection)
+3. **不定义跨 Engine 的信任传播机制** -- 属于后续 ADR
+4. **不重新设计 CapabilityContract 的 7 字段冻结核心** -- 只做 status 枚举扩展和 scan result 附加
+5. **不涉及 Hermes Agent 的学习循环** -- 属于 ADR-005/006 范畴
+6. **不构建 OpenClaw Plugin 兼容层** -- LiYe OS 不是 OpenClaw 插件宿主
+
+## 后续实现入口
+
+| Phase | 内容 | 前置条件 |
+|-------|------|---------|
+| P2-B1 | Content Threat Detection 最小集 (3 Guards) | 本 ADR 中 scan_rule schema 冻结 |
+| P2 实现 | `registration-gate.ts` + `threat-scanner.ts` 编码 | 本 ADR accepted |
+| P3-A1 | Governed Learning Loop 的 candidate quarantine-first | A4 隔离/恢复机制就绪 |
+| P4-C1 | Session Retrieval 集成 evidence 检索 | Evidence Redaction 接口就绪 |
+| P5 | Long-task context compression | 不直接依赖本 ADR |
+
+---
+
+**Version**: 1.0.0
+**Last Updated**: 2026-04-14
+**Char Count**: ~8,600

--- a/_meta/adr/ADR-005-Hermes-Skill-Lifecycle.md
+++ b/_meta/adr/ADR-005-Hermes-Skill-Lifecycle.md
@@ -1,0 +1,326 @@
+# ADR-005: Hermes Skill Lifecycle — candidate-first 技能生命周期
+
+**Status**: Superseded
+**Date**: 2026-04-14
+**Superseded-Date**: 2026-04-17
+**Superseded-By**: `_meta/adr/ADR-Hermes-Skill-Lifecycle.md`
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-005-Hermes-Skill-Lifecycle.md`
+
+> Historical draft. Superseded by `ADR-Hermes-Skill-Lifecycle.md` on 2026-04-17. Retained for audit/history only.
+
+## Context
+
+SYSTEMS.md 进化路线 P1 要求产出 4 份 Capability Harvest ADR（含 contract sketch）。
+本 ADR 聚焦 **P3 (A1) — Governed Learning Loop candidate-only** 的设计决策：
+从 Hermes Agent 的 skill 生命周期实现中吸收可复用的治理模式，
+同时严守 quarantine-first 原则——**candidate 不是 skill，不得自动激活。**
+
+Fork 纪律（SYSTEMS.md §参考与卫星项目）：hermes-agent 只做只读参考，
+需要的能力通过本 ADR 决议后在 Loamwise 独立实现，不直接搬模块。
+
+## 上游核心做法
+
+Hermes Agent 的 skill 系统由三个核心文件和一个 Hub 库组成：
+
+### 1. Skill 创建（skill_manager_tool.py）
+
+**文件**: `/Users/liye/github/hermes-agent/tools/skill_manager_tool.py`
+
+- Agent 可在运行时通过 `skill_manage(action="create")` 直接创建 skill
+- 新 skill 写入 `~/.hermes/skills/` 目录，**立即可用**
+- 支持 6 种 action: `create`, `edit`, `patch`, `delete`, `write_file`, `remove_file`
+- 每个 skill 是一个目录，包含 `SKILL.md`（YAML frontmatter + Markdown body）和可选的 `references/`, `templates/`, `scripts/`, `assets/` 子目录
+- 创建后立即触发安全扫描；若扫描 blocked，回滚删除整个 skill 目录
+- **关键特征：创建即激活，没有 review/quarantine 中间态**
+
+### 2. 安全扫描（skills_guard.py）
+
+**文件**: `/Users/liye/github/hermes-agent/tools/skills_guard.py`
+
+- 基于正则的静态分析：~80 条 threat patterns，覆盖 exfiltration、injection、destructive、persistence、obfuscation、privilege escalation、supply chain 等类别
+- 结构检查：文件数上限 50、总大小 1MB、单文件 256KB、二进制文件检测、symlink 逃逸检测
+- 不可见 Unicode 字符检测（零宽空格、方向覆盖等注入手段）
+- Trust levels:
+  - `builtin`: 随 Hermes 发布，不扫描
+  - `trusted`: openai/skills + anthropics/skills，caution 允许通过
+  - `community`: 任何 finding = blocked（除非 `--force`）
+  - `agent-created`: safe/caution 允许，dangerous 需用户确认（`ask`）
+- 三级 verdict: `safe` → `caution` → `dangerous`
+- Install policy 矩阵决定 `allow` / `ask` / `block`
+
+### 3. Skill 使用与发现（skills_tool.py）
+
+**文件**: `/Users/liye/github/hermes-agent/tools/skills_tool.py`
+
+- Progressive disclosure 3 层架构：
+  - Tier 0: `skills_categories()` — 分类浏览
+  - Tier 1: `skills_list()` — name + description（低 token）
+  - Tier 2/3: `skill_view(name)` — 加载完整内容
+- Platform 过滤（`platforms` frontmatter 字段）
+- 支持 disabled skill 管理
+- 运行时注入检测（加载时再检一遍 prompt injection patterns）
+
+### 4. Hub 安装流水线（skills_hub.py）
+
+**文件**: `/Users/liye/github/hermes-agent/tools/skills_hub.py`
+
+- 外部 skill 有 quarantine 流程：download → `quarantine_bundle()` → `scan_skill()` → `install_from_quarantine()`
+- quarantine 目录: `~/.hermes/skills/.hub/quarantine/`
+- 安装后记录 provenance: `lock.json`（source, trust_level, scan_verdict, content_hash）
+- 审计日志: `audit.log`（时间戳 + action + verdict）
+- **但 agent-created skill 绕过 quarantine，直接写入 skills 目录**
+
+### Hermes 生命周期总结
+
+```
+外部 skill (Hub):  download → quarantine → scan → install → 可用
+Agent-created:     create → scan → 可用（无 quarantine）
+使用:              skills_list → skill_view → agent 消费
+修改:              edit / patch → re-scan
+删除:              delete → rmtree
+```
+
+## 吸收项
+
+| # | Hermes Pattern | 吸收理由 |
+|---|---------------|---------|
+| A1 | **安全扫描三级 verdict** (`safe` / `caution` / `dangerous`) | 简洁有效的分级机制，直接映射到 review 优先级 |
+| A2 | **Trust level 矩阵决定 install policy** | 信任源 × 扫描结果的矩阵决策比单维判断更精确 |
+| A3 | **SKILL.md frontmatter 元数据** | name/description/version/platforms 结构已被验证，可作为 candidate metadata 基础 |
+| A4 | **Quarantine 目录隔离**（Hub 流程） | 外部 skill 进 quarantine 再安装的思路正确，我们将其推广到**所有来源** |
+| A5 | **Provenance 记录** (lock.json + audit.log) | source + trust_level + scan_verdict + content_hash 完整追溯链 |
+| A6 | **Progressive disclosure 加载** | 按需加载降低 token 消耗，复用其分层思路 |
+| A7 | **原子写入 + 扫描失败回滚** | `_atomic_write_text()` + 扫描 blocked 则 rollback，保证一致性 |
+
+## 不吸收项
+
+| # | Hermes Pattern | 不吸收理由 |
+|---|---------------|-----------|
+| R1 | **Agent-created skill 无 quarantine** | Hermes 允许 agent 创建后直接可用。我们要求**所有来源（含 agent）的 candidate 必须经过 quarantine + human review** |
+| R2 | **Auto skill repair** | SYSTEMS.md 明确排除：不引入 auto skill repair |
+| R3 | **Smart routing** | SYSTEMS.md 明确排除：不引入 smart routing |
+| R4 | **Honcho 用户建模** | SYSTEMS.md 明确排除：不引入重用户建模 |
+| R5 | **扫描通过即信任** | Hermes 的 `safe` verdict 直接 allow。我们要求 `safe` 仍需 human review 才能 promote |
+| R6 | **`--force` 覆盖 blocked** | Hermes 允许用户 force install。我们不提供绕过 quarantine 的快捷方式 |
+| R7 | **Skill 即时可编辑/可删** | Hermes agent 可随时 edit/patch/delete 任何 skill。我们只允许对 candidate 进行 edit，production skill 变更需要走 change review |
+
+## 与 LiYe Systems 分层关系
+
+```
+Layer 0: LiYe OS (制度底座)
+  ├── 定义 skill candidate 的 metadata schema (本 ADR Contract Sketch)
+  ├── 定义 review_status / trust_level 枚举
+  └── 定义 promotion 合约（晋升守卫条件）
+
+Layer 1: Loamwise (编排中间层)   ← skill lifecycle runtime 在这里
+  ├── loamwise/construct/candidates/  — candidate 提交、review queue
+  ├── loamwise/govern/               — 安全扫描 guard chain
+  └── loamwise/construct/            — quarantine → promotion 状态机
+
+Layer 2: Domain Engines (专业执行器)
+  └── 产出 skill candidate 的 raw material（例如 AGE 发现的广告优化模式）
+
+Layer 3: Product Lines
+  └── 不涉及 skill lifecycle
+```
+
+**关键边界：Skill lifecycle runtime 属于 `/Users/liye/github/loamwise/`，不属于 `/Users/liye/github/liye_os/`。**
+LiYe OS 只定义 schema 和合约，Loamwise 执行生命周期管理。
+这与 SYSTEMS.md 的依赖方向一致：`liye_os → loamwise`（合约定义 → 中间层执行）。
+
+## Decision
+
+**Core decision: candidate-only, quarantine-first.**
+
+1. **所有 skill candidate 无论来源（agent-generated、domain engine 产出、手动创建）一律进入 quarantine，不直接激活。** 这是与 Hermes 最大的分歧点。
+2. Candidate 不是 skill。Candidate 是一个带有完整溯源信息的提案，必须经过 review 才能晋升为可执行 skill。
+3. Review 过程要求 human reviewer 明确标记 `ACCEPTED`，系统才执行 materialize。
+4. 晋升路径沿用 ADR-001 的分区思路：`quarantine/ → candidate/ → production/`。
+5. 安全扫描机制吸收 Hermes 的 verdict 分级（A1），但扫描通过不等于信任（R5）。
+6. Provenance 全链路追溯：每个 candidate 必须携带 `source_trace_id`、`generated_by`、`risk_class`。
+
+## Contract Sketch
+
+### 1. SkillCandidate Metadata
+
+```typescript
+/**
+ * Skill Candidate 元数据 — LiYe OS 合约定义
+ * Runtime implementation: loamwise/construct/candidates/
+ *
+ * 每个 candidate 必须包含以下字段，无论来源。
+ */
+interface SkillCandidateMetadata {
+  // === 身份 ===
+  candidate_id: string;           // UUID v4, 全局唯一
+  name: string;                   // 技能名称, lowercase, [a-z0-9._-], max 64 chars
+  description: string;            // 技能描述, max 1024 chars
+  version: string;                // SemVer, e.g. "0.1.0"
+
+  // === 溯源 (Provenance) ===
+  source_trace_id: string;        // 产生此 candidate 的 trace ID（关联到具体执行记录）
+  source_domain: string;          // 来源领域, e.g. "amazon-advertising", "domain-analysis"
+  generated_by: string;           // 生成者标识, e.g. "agent:claude-opus-4", "human:liye", "engine:age"
+  generated_at: string;           // ISO 8601 时间戳
+
+  // === 安全与信任 ===
+  risk_class: "low" | "medium" | "high" | "critical";
+  trust_level: "untrusted" | "scanned" | "reviewed" | "trusted";
+  scan_verdict: "pending" | "safe" | "caution" | "dangerous";
+  scan_findings_count: number;    // 扫描发现的问题数
+
+  // === 生命周期 ===
+  review_status: ReviewStatus;
+  reviewer: string | null;        // human reviewer ID
+  reviewed_at: string | null;     // ISO 8601
+  expires_at: string;             // ISO 8601, candidate 过期时间（默认 30 天）
+
+  // === 内容摘要 ===
+  content_hash: string;           // sha256:<hex>, 内容完整性校验
+  content_size_bytes: number;
+  file_count: number;
+
+  // === 作用域 ===
+  target_domain: string;          // 目标 domain engine
+  scope: Record<string, string>;  // 作用范围键值对
+}
+```
+
+### 2. ReviewStatus 枚举与状态机
+
+```typescript
+/**
+ * Review status 枚举
+ * 对齐 loamwise/construct/__init__.py 的 ReviewState
+ */
+type ReviewStatus =
+  | "QUARANTINED"      // 初始态：已提交，待扫描
+  | "SCANNED"          // 已通过安全扫描，待 human review
+  | "UNDER_REVIEW"     // Human reviewer 已认领
+  | "ACCEPTED"         // 通过 review，可 promote
+  | "REJECTED"         // 被拒绝，附 reason
+  | "EXPIRED"          // 超过 expires_at 未 review，自动归档
+  | "PROMOTED"         // 已晋升为 production skill
+  | "REVOKED";         // 已晋升后被撤回
+```
+
+### 3. 状态转换与守卫
+
+```
+                          ┌─────────────────────────────────┐
+                          │                                 │
+  [any source] ──submit──▶│  QUARANTINED                    │
+                          │  guard: must have source_trace_id, │
+                          │         generated_by, expires_at │
+                          └──────────┬──────────────────────┘
+                                     │
+                             scan_skill()
+                                     │
+                          ┌──────────▼──────────────────────┐
+                          │  SCANNED                        │
+                          │  guard: scan_verdict != "dangerous" │
+                          │  (dangerous → auto REJECTED)    │
+                          └──────────┬──────────────────────┘
+                                     │
+                           human claims review
+                                     │
+                          ┌──────────▼──────────────────────┐
+                          │  UNDER_REVIEW                   │
+                          │  guard: reviewer != null        │
+                          └───┬──────────────────┬──────────┘
+                              │                  │
+                         accept()           reject(reason)
+                              │                  │
+                  ┌───────────▼───┐    ┌─────────▼─────────┐
+                  │  ACCEPTED     │    │  REJECTED          │
+                  │  guard:       │    │  requires: reason  │
+                  │   reviewer != │    └────────────────────┘
+                  │   generated_by│
+                  └───────┬───────┘
+                          │
+                   promote() (manual trigger)
+                          │
+                  ┌───────▼───────────────────────┐
+                  │  PROMOTED                      │
+                  │  guard: content_hash unchanged │
+                  │  guard: risk_class <= "medium"  │
+                  │  (high/critical 需要额外审批)   │
+                  └───────┬───────────────────────┘
+                          │
+                    revoke(reason) (if drift/issue detected)
+                          │
+                  ┌───────▼───────┐
+                  │  REVOKED      │
+                  └───────────────┘
+
+  ─── 超时守卫 ───
+  QUARANTINED/SCANNED/UNDER_REVIEW:
+    if now > expires_at → auto transition to EXPIRED
+```
+
+### 4. 状态转换守卫汇总
+
+| Transition | Guard Conditions |
+|-----------|-----------------|
+| `→ QUARANTINED` | `source_trace_id` 非空; `generated_by` 非空; `expires_at` 在 1-90 天内; `content_hash` 已计算 |
+| `QUARANTINED → SCANNED` | 安全扫描完成; `scan_verdict` in (`safe`, `caution`); findings 已记录 |
+| `QUARANTINED → REJECTED` | `scan_verdict` == `dangerous`; auto-reject, reason = scan report |
+| `SCANNED → UNDER_REVIEW` | `reviewer` 已赋值; reviewer != `generated_by`（不可自审） |
+| `UNDER_REVIEW → ACCEPTED` | Human reviewer 明确批准; reviewer 签名记录 |
+| `UNDER_REVIEW → REJECTED` | Human reviewer 提供 `reason`; reason 非空 |
+| `ACCEPTED → PROMOTED` | `content_hash` 未变（防止 promote 前被篡改）; `risk_class` <= `medium`（high/critical 需二级审批） |
+| `PROMOTED → REVOKED` | 提供 `revoke_reason`; 自动从 production 移回 quarantine |
+| `* → EXPIRED` | `now > expires_at`; 定时任务检查; 不可从 PROMOTED/REVOKED 过期 |
+
+### 5. 目录布局（Loamwise 侧）
+
+```
+loamwise/construct/candidates/
+├── quarantine/          # QUARANTINED + SCANNED 状态的 candidate
+│   └── <candidate_id>/
+│       ├── metadata.yaml
+│       └── content/
+│           ├── SKILL.md
+│           └── references/
+├── accepted/            # ACCEPTED 状态，待 promote
+│   └── <candidate_id>/
+├── promoted/            # PROMOTED — 已激活为 production skill
+│   └── <candidate_id>/
+└── rejected/            # REJECTED + EXPIRED 的归档
+    └── <candidate_id>/
+```
+
+## 非目标
+
+本 ADR **不决定**以下内容：
+
+1. **具体扫描规则**：threat pattern 清单由 P2 (B1 Content Threat Detection) 决定，不在本 ADR 范围
+2. **Skill 的运行时加载机制**：progressive disclosure 的具体实现属于 Loamwise runtime
+3. **Domain Engine 如何产出 candidate**：各 engine 的 candidate 产出协议由各自的 ADR 决定
+4. **自动化测试**：candidate 的 automated testing framework 是后续工作
+5. **P2 / P4 / P5 的实现**：本 ADR 仅覆盖 P3 (A1)，不展开其他阶段
+
+## 后续实现入口
+
+**P3 (A1) — Governed Learning Loop candidate-only**
+
+实现位置: `/Users/liye/github/loamwise/construct/`
+
+现有基础:
+- `loamwise/construct/__init__.py` 已定义 `ReviewState` 枚举（SUGGESTED / REVIEWED / ACCEPTED / REJECTED）
+- `loamwise/construct/candidates/review_queue.py` 已实现 `ReviewQueue`（submit → review → accept/reject → materialize）
+
+待实现（本 ADR 不实现，仅标记入口）:
+- [ ] 扩展 `ReviewState` 为本 ADR 定义的 `ReviewStatus`（增加 QUARANTINED, SCANNED, UNDER_REVIEW, PROMOTED, REVOKED, EXPIRED）
+- [ ] 实现 `SkillCandidateMetadata` schema 验证
+- [ ] 实现 quarantine 目录管理
+- [ ] 实现 scan → review → promote 状态机守卫
+- [ ] 实现 expires_at 超时自动归档
+- [ ] 实现 content_hash 完整性校验
+- [ ] 连接 liye_os 合约（`_meta/contracts/` 中发布 schema）
+
+---
+
+**Version**: 1.0.0
+**Last Updated**: 2026-04-14

--- a/_meta/adr/ADR-006-Hermes-Memory-Orchestration.md
+++ b/_meta/adr/ADR-006-Hermes-Memory-Orchestration.md
@@ -1,0 +1,297 @@
+# ADR-006: Hermes Memory Orchestration — truth-first 检索分层
+
+**Status**: Superseded
+**Date**: 2026-04-14
+**Superseded-Date**: 2026-04-17
+**Superseded-By**: `_meta/adr/ADR-Hermes-Memory-Orchestration.md`
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-006-Hermes-Memory-Orchestration.md`
+
+> Historical draft. Superseded by `ADR-Hermes-Memory-Orchestration.md` on 2026-04-17. Retained for audit/history only.
+
+## Context
+
+SYSTEMS.md 进化路线 P4 (C1 - Session Retrieval truth-first) 要求：
+> 先检索结构化真相（receipts, verdicts, traces, ADRs），最后才搜会话文本。
+
+Hermes Agent 作为参考仓（`hermes-agent (fork)` — 只读参考），其 memory 编排层是目前我们可参考的最成熟的 agent memory runtime。
+本 ADR 对 Hermes 的 memory 编排做法进行结构化提取，明确吸收项与不吸收项，为 Loamwise (Layer 1) 的 session retrieval 实现提供 pattern benchmark。
+
+**硬约束**：LiYe Systems 的检索优先级是 truth-first，不是 chat-history-first。Hermes 的做法是 session-text-centric（会话文本为中心），我们必须反转这个优先级。
+
+## 上游核心做法
+
+### MemoryManager 编排器
+
+文件：`/Users/liye/github/hermes-agent/agent/memory_manager.py`
+
+MemoryManager 是 Hermes 的 memory 编排入口，管理 builtin + 至多一个 external provider。核心职责：
+
+1. **Provider 注册** — `add_provider()` 注册 MemoryProvider 实例，builtin 永远第一，external 最多一个
+2. **System prompt 组装** — `build_system_prompt()` 收集所有 provider 的静态 prompt block
+3. **Prefetch** — `prefetch_all(query)` 在每轮 API 调用前收集所有 provider 的召回上下文
+4. **Sync** — `sync_all(user, assistant)` 每轮结束后将对话同步到所有 provider
+5. **Tool routing** — `handle_tool_call()` 根据 tool name 路由到对应 provider
+6. **Lifecycle hooks** — `on_turn_start()`, `on_session_end()`, `on_pre_compress()`, `on_memory_write()`, `on_delegation()`
+
+关键设计：context fencing — 用 `<memory-context>` 标签隔离 prefetch 结果，防止模型将召回内容误认为用户输入。
+
+### MemoryProvider 抽象基类
+
+文件：`/Users/liye/github/hermes-agent/agent/memory_provider.py`
+
+定义 provider 生命周期协议：
+
+```
+initialize() → system_prompt_block() → [per-turn: prefetch() → on_turn_start() → sync_turn() → queue_prefetch()] → on_session_end() → shutdown()
+```
+
+可选 hook：`on_pre_compress()`, `on_memory_write()`, `on_delegation()`
+
+### Builtin Memory (MEMORY.md / USER.md)
+
+文件：`/Users/liye/github/hermes-agent/tools/memory_tool.py`
+
+MemoryStore 实现：
+- 两个文件级存储：MEMORY.md（agent 笔记）和 USER.md（用户画像）
+- **Frozen snapshot pattern**：session 开始时拍快照注入 system prompt，mid-session 写入只写磁盘不改 prompt（保护 prefix cache）
+- 有界存储：memory 2200 chars, user 1375 chars
+- 安全扫描：`_scan_memory_content()` 检测 prompt injection / exfiltration patterns
+- 原子写：temp file + `os.replace()` 避免并发读写竞态
+
+### Session Search (会话检索)
+
+文件：`/Users/liye/github/hermes-agent/tools/session_search_tool.py`
+
+- 基于 SQLite FTS5 的全文搜索
+- 两种模式：recent sessions（零 LLM 成本）和 keyword search（LLM 摘要）
+- 搜索结果经过 truncate + LLM 摘要压缩后注入上下文
+- 排除当前 session 及其子 session（delegation chain 感知）
+
+### External Provider (以 Honcho 为例)
+
+文件：`/Users/liye/github/hermes-agent/plugins/memory/honcho/__init__.py`
+
+三种 recall_mode：context（自动注入）、tools（工具调用）、hybrid（两者兼有）。
+提供 4 个工具：honcho_profile, honcho_search, honcho_context, honcho_conclude。
+包含 user modeling、dialectic Q&A、peer cards 等重用户建模能力。
+
+### 集成点 (run_agent.py)
+
+文件：`/Users/liye/github/hermes-agent/run_agent.py`
+
+Agent 启动时：
+1. 加载 builtin MemoryStore，从磁盘读取 MEMORY.md / USER.md
+2. 按 config `memory.provider` 加载 external provider plugin
+3. `initialize_all()` 初始化所有 provider
+4. 将 provider tool schemas 注入 agent tool surface
+
+每轮循环：
+1. `_build_system_prompt()` — builtin 快照 + external provider prompt block
+2. `prefetch_all(query)` — 每轮前一次性 prefetch（缓存结果，不重复调用）
+3. `build_memory_context_block()` — 将 prefetch 结果包裹在 `<memory-context>` fence 中注入
+4. `sync_all()` + `queue_prefetch_all()` — 轮后同步 + 预加载下轮
+
+Session 结束：`on_session_end()` → `shutdown_all()`
+
+## 吸收项
+
+从 Hermes memory 编排中吸收以下 **patterns**（不搬代码）：
+
+| Pattern | Hermes 来源 | LiYe Systems 用途 |
+|---------|-------------|-------------------|
+| **Provider 抽象** | `MemoryProvider` ABC | Loamwise retrieval provider 接口 |
+| **Lifecycle hooks** | `on_turn_start`, `on_session_end`, `on_pre_compress` | 任务阶段 hook（非 turn-level） |
+| **Prefetch + cache** | `prefetch_all()` 每轮一次 | 任务启动时一次性 truth prefetch |
+| **Context fencing** | `<memory-context>` 标签隔离 | 用 `<truth-context>` 隔离结构化真相注入 |
+| **Frozen snapshot** | system prompt 快照不变 | 防止 mid-task prompt 突变 |
+| **安全扫描** | `_scan_memory_content()` | Guard 层 prompt injection 检测（P2 范畴） |
+| **Bounded storage** | char limit + atomic write | 资源约束 pattern |
+
+## 不吸收项
+
+| 不吸收 | 原因 |
+|--------|------|
+| **Honcho user modeling** | 重用户建模与 LiYe Systems 治理导向不符。我们的 "用户" 是 LiYe 本人，不需要 dialectic Q&A / peer cards / user representation |
+| **Smart routing** | Hermes 的 model routing 是面向多模型成本优化，与 Loamwise 的 policy-driven dispatch 正交 |
+| **Auto skill repair** | LiYe Systems 的 skill 走 quarantine-first 流程（P3），不做 auto repair |
+| **"对话代理就是一切" 的世界观** | Hermes 以会话为中心组织记忆。LiYe Systems 以结构化真相为中心，会话文本是最低优先级的补充信息 |
+| **Session search as primary recall** | Hermes 的 `session_search` 是主要检索手段（FTS5 → LLM 摘要）。我们反转：先结构化真相，最后才 fallback 到会话文本 |
+| **Turn-level sync** | Hermes 每轮同步对话到 provider。LiYe Systems 不做 turn-level 会话同步，只在 governed path 产出 traces/verdicts |
+
+## 与 LiYe Systems 分层关系
+
+| 四层架构 | Hermes 对应 | LiYe Systems 吸收后落地 |
+|---------|------------|----------------------|
+| **Layer 0: LiYe OS** | — | 定义 retrieval priority 合约、truth source schema |
+| **Layer 1: Loamwise** | MemoryManager + MemoryProvider | `loamwise/align/` 实现 truth-first retrieval orchestrator |
+| **Layer 2: Domain Engines** | Builtin MemoryStore | Domain engines 产出 receipts/verdicts/traces（被检索方） |
+| **Layer 3: Product Lines** | Honcho, session_search | 不涉及（产品线不参与检索编排） |
+
+核心差异：Hermes 的 MemoryManager 编排的是 **session memory**（会话记忆）。
+Loamwise 编排的是 **truth retrieval**（真相检索）。Session text 只是 truth 的最低优先级来源之一。
+
+## Decision
+
+**核心决策：truth-first retrieval — 结构化真相优先于自然语言会话文本。**
+
+LiYe Systems 借鉴 Hermes MemoryManager 的 provider 抽象和 lifecycle hook 设计，但反转其检索优先级：
+
+1. Hermes: session text (primary) → memory notes (frozen) → external provider context (supplementary)
+2. LiYe Systems: structured truth (primary) → traces/evidence (secondary) → session text (tertiary, fallback only)
+
+Loamwise 在 `loamwise/align/` 实现 truth-first retrieval orchestrator，遵循以下优先级分层。
+
+## Contract Sketch
+
+### 1. Truth-first 检索分层
+
+```
+Retrieval Priority (highest → lowest):
+
+  Priority 1 — Structured Truth (结构化真相)
+  ├── receipts     (execution receipts from domain engines)
+  ├── verdicts     (decision semantics, human-readable judgments)
+  ├── contracts    (governance constraints, machine-enforced)
+  └── ADRs         (architectural decision records)
+
+  Priority 2 — Traces & Evidence (过程证据)
+  ├── traces/      (execution traces, session traces)
+  ├── evidence/    (verification evidence, test results)
+  └── memory_brief (governed path curated session memory)
+
+  Priority 3 — Session Text (会话文本, fallback only)
+  ├── session transcripts  (raw conversation history)
+  └── compressed summaries (post-compression session digests)
+```
+
+**规则**：Priority 1 的检索结果已足够回答查询时，不继续检索 Priority 2/3。Priority 3 只在 Priority 1+2 均无匹配时才 fallback。
+
+### 2. Memory/Session Orchestration 最小接口
+
+```typescript
+/**
+ * TruthProvider — 从某个 truth source 检索结构化信息。
+ * 对标 Hermes MemoryProvider，但以 truth retrieval 为核心而非 session memory。
+ */
+interface TruthProvider {
+  /** Provider identifier, e.g. "receipts", "verdicts", "traces", "session" */
+  readonly name: string;
+
+  /** 该 provider 负责的优先级层 */
+  readonly priority: RetrievalPriority;
+
+  /** 初始化（任务启动时调用一次） */
+  initialize(taskId: string, context: TaskContext): Promise<void>;
+
+  /** 根据查询返回匹配的 truth fragments */
+  retrieve(query: RetrievalQuery): Promise<TruthFragment[]>;
+
+  /** 任务结束后清理（flush, close） */
+  shutdown(): Promise<void>;
+}
+
+/**
+ * TruthOrchestrator — 编排多个 TruthProvider，执行 truth-first 检索。
+ * 对标 Hermes MemoryManager，但强制 priority ordering。
+ */
+interface TruthOrchestrator {
+  /** 注册 provider（按 priority 排序） */
+  addProvider(provider: TruthProvider): void;
+
+  /**
+   * Truth-first retrieval — 从高优先级到低优先级逐层检索。
+   * 若高优先级已返回足够结果，跳过低优先级层。
+   */
+  retrieve(query: RetrievalQuery): Promise<RetrievalResult>;
+
+  /** 初始化所有 provider */
+  initializeAll(taskId: string, context: TaskContext): Promise<void>;
+
+  /** 关闭所有 provider */
+  shutdownAll(): Promise<void>;
+}
+```
+
+### 3. Retrieval Priority 类型定义
+
+```typescript
+/** 检索优先级枚举 — 数字越小优先级越高 */
+enum RetrievalPriority {
+  /** receipts, verdicts, contracts, ADRs */
+  STRUCTURED_TRUTH = 1,
+  /** traces, evidence, memory_brief */
+  TRACES_EVIDENCE = 2,
+  /** session transcripts, compressed summaries */
+  SESSION_TEXT = 3,
+}
+
+interface RetrievalQuery {
+  /** 自然语言查询或关键词 */
+  text: string;
+  /** 限定检索的 priority 层（默认全部，从高到低） */
+  maxPriority?: RetrievalPriority;
+  /** 最大返回条目数 */
+  limit?: number;
+  /** 是否启用 early-stop（高优先级足够时跳过低优先级） */
+  earlyStop?: boolean;
+}
+
+interface TruthFragment {
+  /** 来源 provider */
+  source: string;
+  /** 优先级层 */
+  priority: RetrievalPriority;
+  /** 内容 */
+  content: string;
+  /** 来源文件路径或 ID */
+  ref: string;
+  /** 相关性分数（0-1） */
+  relevance: number;
+}
+
+interface RetrievalResult {
+  /** 按 priority 排序的检索结果 */
+  fragments: TruthFragment[];
+  /** 实际检索了哪些层 */
+  layersSearched: RetrievalPriority[];
+  /** 是否触发了 early-stop */
+  earlyStopTriggered: boolean;
+}
+
+interface TaskContext {
+  /** 当前 track ID（如有） */
+  trackId?: string;
+  /** 执行模式 */
+  mode: "fast" | "governed";
+  /** 相关 domain engine */
+  engine?: string;
+}
+```
+
+## 非目标
+
+本 ADR **不**决定以下事项：
+
+- **不引入 Honcho** — 不做 dialectic Q&A、peer cards、user representation。LiYe 是系统唯一用户，不需要用户建模。
+- **不引入 smart routing** — 模型选择不在 retrieval 层解决。
+- **不实现 turn-level sync** — LiYe Systems 不是聊天应用，不需要每轮同步会话到外部 provider。
+- **不做 auto skill repair** — 走 P3 quarantine-first 流程。
+- **不扩展 P2/P3/P5 范畴** — 本 ADR 只覆盖 P4 (Session Retrieval truth-first)。
+- **不做会话文本的 FTS5 索引** — session text 是 Priority 3 fallback，初期可以不实现。
+
+## 后续实现入口
+
+实现位置：`loamwise/align/`（Layer 1 编排中间层）。
+
+对应 SYSTEMS.md 进化路线：
+> P4 | C1 | Session Retrieval（truth-first） | loamwise/align/ | **先检索结构化真相，后检索会话文本**
+
+实现时参照本 ADR 的 Contract Sketch，按以下顺序：
+1. 定义 `TruthProvider` 接口 + `RetrievalPriority` 类型
+2. 实现 `ReceiptsProvider` (Priority 1) — 检索 verdicts/, contracts/, _meta/adr/
+3. 实现 `TracesProvider` (Priority 2) — 检索 traces/, evidence/
+4. 实现 `TruthOrchestrator` — priority-ordered retrieval with early-stop
+5. （远期）实现 `SessionTextProvider` (Priority 3) — 仅在 1+2 无结果时 fallback
+
+**本 ADR 只做决策，不做实现。**

--- a/_meta/adr/ADR-007-Loamwise-Guard-Content-Security.md
+++ b/_meta/adr/ADR-007-Loamwise-Guard-Content-Security.md
@@ -1,0 +1,362 @@
+# ADR-007: Loamwise Guard Content Security — 从 Hermes 萃取内容安全 Guard
+
+**Status**: Superseded
+**Date**: 2026-04-14
+**Superseded-Date**: 2026-04-17
+**Superseded-By**: `_meta/adr/ADR-Loamwise-Guard-Content-Security.md`
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-007-Loamwise-Guard-Content-Security.md`
+
+> Historical draft. Superseded by `ADR-Loamwise-Guard-Content-Security.md` on 2026-04-17. Retained for audit/history only.
+
+## Context
+
+SYSTEMS.md 进化路线 P2 (B1 - Content Threat Detection) 要求 Loamwise GuardChain 实现最小内容安全 Guard 集合。Hermes Agent 作为只读参考仓（见 SYSTEMS.md "参考与卫星项目"），已在生产中运行了多层内容安全防御。本 ADR 从 Hermes 萃取可吸收的 runtime patterns，设计 3 个 Guard 的 contract sketch，并明确吸收/不吸收边界。
+
+SYSTEMS.md 硬约束：**P2 Content Guard 必须先 shadow mode（只观测不拦截）**，逐步启用拦截。
+
+## 上游核心做法
+
+Hermes Agent 的内容安全分布在 4 个层次、5 个扫描入口，按威胁类型分类如下：
+
+### 层次 1: Prompt/Context Injection Detection（上下文注入检测）
+
+**入口**: `/Users/liye/github/hermes-agent/agent/prompt_builder.py`
+
+- `_CONTEXT_THREAT_PATTERNS` (10 条规则) 扫描所有注入 system prompt 的外部上下文文件（AGENTS.md, .cursorrules, SOUL.md, .hermes.md 等）
+- 检测模式：prompt injection (`ignore previous instructions`), deception (`do not tell the user`), system prompt override, restriction bypass, HTML comment injection, hidden div, translate-then-execute, credential exfiltration via curl/cat
+- `_CONTEXT_INVISIBLE_CHARS` 检测零宽字符（U+200B/200C/200D/2060/FEFF/202A-202E）
+- **动作**: 匹配时整个文件被替换为 `[BLOCKED: ... contained potential prompt injection]`，内容不注入 system prompt
+
+### 层次 2: Dangerous Command Detection（危险命令检测）
+
+**入口**: `/Users/liye/github/hermes-agent/tools/approval.py`
+
+- `DANGEROUS_PATTERNS` (35+ 条规则) 对 agent 拟执行的 shell 命令做 regex 检测
+- 覆盖：递归删除、权限修改、磁盘格式化、SQL 破坏、系统配置覆盖、fork bomb、pipe-to-shell、script-via-heredoc、git 破坏性操作、自终止保护等
+- `_normalize_command_for_detection()` 先做 ANSI escape strip + null byte strip + Unicode NFKC normalize，防绕过
+- **动作**: 匹配后进入 approval flow（once/session/always/deny），非 hard block
+- 额外集成 tirith binary 做内容级扫描（homograph URL, terminal injection 等）
+
+**入口**: `/Users/liye/github/hermes-agent/tools/tirith_security.py`
+
+- 调用外部 tirith 二进制做命令级安全扫描
+- exit code 决定 verdict: 0=allow, 1=block, 2=warn
+- JSON stdout 提供 findings/summary 但不覆盖 exit code verdict
+- fail_open/fail_closed 可配置（spawn 失败、超时时的行为）
+- **动作**: block 时拒绝执行，warn 时允许但提示
+
+### 层次 3: Memory/Truth Write Protection（记忆/真相写保护）
+
+**入口**: `/Users/liye/github/hermes-agent/tools/memory_tool.py`
+
+- `_MEMORY_THREAT_PATTERNS` (14 条规则) 扫描所有写入 MEMORY.md / USER.md 的内容
+- 检测：prompt injection, role hijack (`you are now`), deception, system prompt override, restriction bypass, credential exfiltration (curl/wget/cat), SSH backdoor, SSH access, Hermes env access
+- `_INVISIBLE_CHARS` 检测零宽字符
+- **动作**: 匹配时 `_scan_memory_content()` 返回错误字符串，写入被拒绝
+- 设计理由：memory 被注入 system prompt，投毒 memory = 持久化 prompt injection
+
+### 层次 4: Skill Supply Chain Scanning（技能供应链扫描）
+
+**入口**: `/Users/liye/github/hermes-agent/tools/skills_guard.py`
+
+- `THREAT_PATTERNS` (80+ 条规则，按 category 分组) 是 Hermes 最完整的威胁模式库
+- 7 大 category: exfiltration, injection, destructive, persistence, network, obfuscation, execution, traversal, mining, supply_chain, privilege_escalation, credential_exposure
+- Trust-aware policy: `builtin` / `trusted` / `community` / `agent-created` 四级信任
+- 结构检查: MAX_FILE_COUNT(50), MAX_TOTAL_SIZE_KB(1024), MAX_SINGLE_FILE_KB(256), 二进制文件检测, symlink 检测
+- Verdict: safe / caution / dangerous，结合 trust level 查 INSTALL_POLICY 矩阵决定 allow/block/ask
+- **动作**: community source + caution/dangerous → block；trusted + dangerous → block
+
+### 附加: Cron Prompt Scanning
+
+**入口**: `/Users/liye/github/hermes-agent/tools/cronjob_tools.py`
+
+- `_CRON_THREAT_PATTERNS` (10 条 critical-only 规则) 扫描 cron job 的 prompt
+- 只保留最严重的检测（injection, exfil, backdoor, destructive），因 cron 有完整工具权限且无人值守
+
+### 附加: SSRF Prevention
+
+**入口**: `/Users/liye/github/hermes-agent/tools/url_safety.py`
+
+- 所有 URL 请求前做 DNS 解析 + IP 范围检查（private/loopback/link-local/reserved/multicast/CGNAT）
+- 已知内部域名黑名单（cloud metadata endpoints）
+- fail-closed: DNS 解析失败 → block
+
+## 吸收项
+
+从 Hermes 的多层防御中，为 Loamwise GuardChain 吸收以下 3 个 Guard 的 runtime pattern:
+
+### Guard 1: ContentScanGuard（内容扫描 Guard）
+
+吸收来源：`skills_guard.py` 的 THREAT_PATTERNS + `approval.py` 的 DANGEROUS_PATTERNS
+
+- 吸收 regex-based 威胁模式检测架构（pattern → finding → verdict 三阶段）
+- 吸收 category 分类体系: exfiltration, injection, destructive, persistence, network, obfuscation
+- 吸收 severity 分级: critical / high / medium / low
+- 吸收 Unicode normalization + invisible char detection 的反绕过手段
+- 吸收 trust-aware policy 矩阵的设计思路（不照搬具体 trust level）
+
+### Guard 2: TruthWriteGuard（真相写保护 Guard）
+
+吸收来源：`memory_tool.py` 的 `_scan_memory_content()` + `_MEMORY_THREAT_PATTERNS`
+
+- 吸收"写入系统 prompt 的内容必须经过扫描"的原则
+- 吸收 injection + exfiltration + persistence 三类威胁检测对写操作的保护
+- 吸收 invisible unicode 检测对写路径的覆盖
+- 适配 Loamwise 场景：保护 T1/T2/T3 truth 写入、learned_policy 写入、memory_brief 写入
+
+### Guard 3: ContextInjectGuard（上下文注入 Guard）
+
+吸收来源：`prompt_builder.py` 的 `_scan_context_content()` + `_CONTEXT_THREAT_PATTERNS`
+
+- 吸收"外部上下文注入前必须扫描"的原则
+- 吸收 prompt injection / deception / hidden content 检测模式
+- 吸收 HTML comment injection + hidden div 检测
+- 适配 Loamwise 场景：保护 engine_manifest 加载、外部 context file 注入、plugin 输出注入
+
+## 不吸收项
+
+| Hermes 做法 | 不吸收原因 |
+|-------------|-----------|
+| Tirith 二进制集成 | 外部二进制依赖，Loamwise 不引入。ContentScanGuard 用纯 regex 覆盖 |
+| Auto-install + cosign 验证 | 供应链安全机制，属于产品级运维，Loamwise 不需要 |
+| Approval flow (once/session/always/deny) | Hermes 的交互式审批是产品 UX，Loamwise 用 shadow/active mode 替代 |
+| YOLO mode (跳过所有审批) | 与 Loamwise 治理原则冲突，不引入 |
+| Trust-aware skill install policy | Loamwise 不做 skill marketplace，不需要 builtin/trusted/community 信任层 |
+| URL safety / SSRF prevention | 网络安全属于 runtime infra 层，不属于 content guard 范畴 |
+| Website blocklist / policy | 产品级 URL 策略，不属于 content guard |
+| Smart approval (auxiliary LLM auto-approve) | LLM 判定安全性不可靠，Loamwise 不引入 |
+
+## 与 LiYe Systems 分层关系
+
+```
+Layer 0: LiYe OS                Guard contract 定义（本 ADR + schema）
+         ├─ _meta/adr/           本文件
+         └─ _meta/contracts/     guard contract schema (future)
+
+Layer 1: Loamwise               Guard 实现位置
+         └─ govern/
+            ├─ guards/
+            │  ├─ content_scan_guard.ts
+            │  ├─ truth_write_guard.ts
+            │  └─ context_inject_guard.ts
+            └─ guard_chain.ts    串联入口
+
+Layer 2: Domain Engines          Guard 消费者（被 GuardChain 保护）
+         └─ engine 的 playbook 执行前/后经过 GuardChain
+
+Layer 3: Product Lines           不直接接触 Guard
+```
+
+Guards 运行在 Loamwise (Layer 1)，由 GuardChain 串联调用。Domain Engines (Layer 2) 通过 Loamwise dispatch 协议间接受到保护。Layer 0 只定义合约，不实现 Guard 逻辑。
+
+## Decision
+
+1. **实现 3 个 Guard**: ContentScanGuard, TruthWriteGuard, ContextInjectGuard，各自覆盖不同威胁面
+2. **Shadow mode first**: 所有 Guard 启动时 `mode: 'shadow'`，只记录审计日志不拦截。观测一段时间后手动升级为 `mode: 'active'`
+3. **GuardChain 串联**: 3 个 Guard 由 GuardChain 按顺序执行，任一 Guard 在 active mode 下判定 `block` 则中止管线
+4. **审计优先**: 每次 Guard 执行必须输出审计记录（含 trace_id, guard_id, timestamp, judgment, mode），无论 shadow 还是 active
+5. **Pattern 独立维护**: 每个 Guard 维护自己的 pattern 集合，不共享。从 Hermes 提取的 pattern 是起点，后续按 Loamwise 场景演化
+
+## Contract Sketch
+
+### 共享类型
+
+```typescript
+/** Guard 判定级别 */
+type JudgmentLevel = 'pass' | 'warn' | 'block';
+
+/** Guard 运行模式 */
+type GuardMode = 'shadow' | 'active';
+
+/** 单条检测发现 */
+interface Finding {
+  pattern_id: string;
+  severity: 'critical' | 'high' | 'medium' | 'low';
+  category: string;
+  matched_text: string;
+  description: string;
+}
+
+/** Guard 审计记录（所有 Guard 共享） */
+interface GuardAuditRecord {
+  trace_id: string;           // 关联到 Task Ledger 的 trace
+  guard_id: string;           // e.g. 'content_scan' | 'truth_write' | 'context_inject'
+  timestamp: string;          // ISO 8601
+  mode: GuardMode;            // shadow 模式下 judgment 仅记录，不拦截
+  judgment: JudgmentLevel;
+  findings: Finding[];
+  input_hash: string;         // SHA-256 of input content, for replay
+  execution_ms: number;       // Guard 执行耗时
+}
+```
+
+### ContentScanGuard
+
+```typescript
+/**
+ * ContentScanGuard — 通用内容威胁扫描
+ *
+ * 威胁面: 命令 payload 中的危险操作、数据外泄、混淆绕过
+ * 吸收来源: Hermes skills_guard.py THREAT_PATTERNS + approval.py DANGEROUS_PATTERNS
+ * 执行时机: engine playbook 执行前，扫描待执行的命令/代码内容
+ */
+interface ContentScanGuardInput {
+  content: string;            // 待扫描内容（命令、代码、payload）
+  content_type: 'command' | 'code' | 'text' | 'structured';
+  source_engine?: string;     // 来源 engine ID
+  task_id?: string;           // 关联的 Task Ledger task ID
+}
+
+interface ContentScanGuardOutput {
+  judgment: JudgmentLevel;    // pass: 无发现; warn: 有中低风险发现; block: 有 critical/high 发现
+  findings: Finding[];
+  audit: GuardAuditRecord;
+}
+
+/** ContentScanGuard 配置 */
+interface ContentScanGuardConfig {
+  mode: GuardMode;            // 默认 'shadow'
+  /** block 阈值: 达到此 severity 级别时 judgment 为 block */
+  block_threshold: 'critical' | 'high';
+  /** warn 阈值: 达到此 severity 级别时 judgment 为 warn */
+  warn_threshold: 'medium' | 'low';
+  /** 启用的 category 集合，可逐步开启 */
+  enabled_categories: Set<string>;
+}
+```
+
+### TruthWriteGuard
+
+```typescript
+/**
+ * TruthWriteGuard — 真相/记忆写入保护
+ *
+ * 威胁面: 通过写入 truth/memory/policy 实现持久化 prompt injection
+ * 吸收来源: Hermes memory_tool.py _MEMORY_THREAT_PATTERNS + _scan_memory_content()
+ * 执行时机: 任何对 T1/T2/T3 truth、learned_policy、memory_brief 的写操作前
+ */
+interface TruthWriteGuardInput {
+  content: string;            // 拟写入的内容
+  target: 'truth_t1' | 'truth_t2' | 'truth_t3' | 'learned_policy' | 'memory_brief';
+  operation: 'add' | 'replace' | 'remove';
+  author: 'human' | 'agent' | 'engine';  // 写入来源
+  task_id?: string;
+}
+
+interface TruthWriteGuardOutput {
+  judgment: JudgmentLevel;    // pass: 安全; warn: 可疑但允许; block: 检测到注入/外泄
+  findings: Finding[];
+  audit: GuardAuditRecord;
+}
+
+/** TruthWriteGuard 配置 */
+interface TruthWriteGuardConfig {
+  mode: GuardMode;            // 默认 'shadow'
+  /** human 来源是否跳过扫描（信任人类写入） */
+  trust_human_writes: boolean;
+  /** 启用 invisible unicode 检测 */
+  detect_invisible_unicode: boolean;
+  /** 启用的检测 category */
+  enabled_categories: Set<'injection' | 'exfiltration' | 'persistence'>;
+}
+```
+
+### ContextInjectGuard
+
+```typescript
+/**
+ * ContextInjectGuard — 上下文注入前扫描
+ *
+ * 威胁面: 外部文件/plugin 输出注入 prompt 时携带 prompt injection payload
+ * 吸收来源: Hermes prompt_builder.py _CONTEXT_THREAT_PATTERNS + _scan_context_content()
+ * 执行时机: engine_manifest 加载、外部 context file 注入、plugin 输出注入 prompt 前
+ */
+interface ContextInjectGuardInput {
+  content: string;            // 拟注入的上下文内容
+  source_file?: string;       // 来源文件路径
+  source_type: 'engine_manifest' | 'context_file' | 'plugin_output' | 'external';
+  task_id?: string;
+}
+
+interface ContextInjectGuardOutput {
+  judgment: JudgmentLevel;    // pass: 安全; warn: 可疑; block: 检测到注入
+  sanitized_content?: string; // 当 judgment 为 block 时提供替代内容（类似 Hermes 的 [BLOCKED: ...] 消息）
+  findings: Finding[];
+  audit: GuardAuditRecord;
+}
+
+/** ContextInjectGuard 配置 */
+interface ContextInjectGuardConfig {
+  mode: GuardMode;            // 默认 'shadow'
+  /** block 时是否提供 sanitized 替代内容（vs 直接拒绝） */
+  provide_sanitized_fallback: boolean;
+  /** 启用 HTML/hidden content 检测 */
+  detect_hidden_content: boolean;
+  /** 启用 invisible unicode 检测 */
+  detect_invisible_unicode: boolean;
+}
+```
+
+### GuardChain 编排
+
+```typescript
+/**
+ * GuardChain — Guard 串联执行器
+ *
+ * 按注册顺序执行 Guard。在 active mode 下，任一 Guard 返回 block 则中止管线。
+ * 在 shadow mode 下，所有 Guard 均执行完毕，结果仅记录不拦截。
+ */
+interface GuardChainConfig {
+  guards: Array<{
+    guard_id: string;
+    enabled: boolean;
+    config: ContentScanGuardConfig | TruthWriteGuardConfig | ContextInjectGuardConfig;
+  }>;
+  /** 全局 shadow override: true 时忽略各 guard 的 mode 设置，全部 shadow */
+  global_shadow: boolean;
+}
+
+interface GuardChainResult {
+  overall_judgment: JudgmentLevel;
+  guard_results: Array<{
+    guard_id: string;
+    judgment: JudgmentLevel;
+    mode: GuardMode;
+    findings_count: number;
+  }>;
+  audits: GuardAuditRecord[];
+  blocked_by?: string;        // 当 overall_judgment 为 block 时，记录是哪个 guard 触发的
+}
+```
+
+## 非目标
+
+本 ADR 不决定以下内容：
+
+1. **不决定具体 pattern 清单** — pattern 从 Hermes 提取后需要按 Loamwise 场景裁剪，属于实现阶段工作
+2. **不决定 shadow → active 的升级条件** — 需要观测期数据（false positive rate, coverage）后再定
+3. **不决定 Guard 与 KillSwitch 的联动方式** — KillSwitch 是独立 P1 能力，后续 ADR 定义联动
+4. **不决定网络安全 Guard** — SSRF prevention, URL safety 不在 P2 范围内
+5. **不决定 audit 存储方案** — GuardAuditRecord 输出格式已定义，存储后端（文件/DB/trace 系统）后续决定
+6. **不实现任何代码** — 本 ADR 仅产出 contract sketch
+
+## 后续实现入口
+
+P2 (B1 - Content Threat Detection) 的实现位置：`loamwise/govern/`
+
+```
+loamwise/govern/
+├── guards/
+│   ├── content_scan_guard.ts    ← ContentScanGuard 实现
+│   ├── truth_write_guard.ts     ← TruthWriteGuard 实现
+│   ├── context_inject_guard.ts  ← ContextInjectGuard 实现
+│   └── patterns/                ← 各 guard 的 pattern 定义（从 Hermes 提取后裁剪）
+│       ├── content_scan.ts
+│       ├── truth_write.ts
+│       └── context_inject.ts
+├── guard_chain.ts               ← GuardChain 串联编排
+└── types.ts                     ← 共享类型（JudgmentLevel, GuardMode, Finding, etc.）
+```
+
+**不要现在实现。** 等本 ADR 状态变更为 Accepted 后再开始 P2 编码。

--- a/_meta/adr/ADR-AGE-Wake-Resume.md
+++ b/_meta/adr/ADR-AGE-Wake-Resume.md
@@ -1,0 +1,698 @@
+---
+artifact_scope: meta
+artifact_name: AGE-Wake-Resume
+artifact_role: contract
+target_layer: 2
+is_bghs_doctrine: no
+supersedes: null
+superseded_by: null
+---
+
+# ADR — AGE Wake/Resume 唤醒恢复契约（P1-g，Layer 2）
+
+**Status**: Accepted
+**Date**: 2026-04-17
+**Accepted-Date**: 2026-04-17
+**Decision Makers**: LiYe
+
+## Meta Declaration
+
+| 字段 | 值 |
+|---|---|
+| artifact_role | contract |
+| target_layer | 2（AGE；同时给出 Layer 2 域引擎 wake/resume 的 reference pattern） |
+| is_bghs_doctrine | no |
+| 依赖 ADR | P1-Doctrine（`wake_resume_entrypoint` 字段）、P1-e（SessionEventStream / F1 / strict_truth）、P1-f（credential_bindings） |
+| 被依赖 | 后续任何 Layer 2 域引擎的 wake/resume 实现（复用本 ADR 的 ResourceContext 最小接口与 Preflight/Replay 契约） |
+| 写作重点 | **如何可靠恢复**（preflight、纯函数 replay、write-order、append-only、governance 保留、结果契约闭环）——不是如何优雅描述恢复 |
+
+---
+
+## 1. Context
+
+AGE 已落地完整的 wake/resume 机制，活实例跑了 3 个月、覆盖 3 个 store（STR-358D075EFC / STR-8105E71CE4 / STR-E438213024）：
+
+- **Event stream（权威）**: `artifacts/onboarding/{store_id}/state_transitions.jsonl`
+  - append-only，NDJSON，每行一个 `StateTransitionEvent`
+  - schema: `config/stores/_schema/state_event.schema.json`
+- **Derived snapshot（派生快照）**: `config/stores/stores/{store_id}/state.yaml`
+  - 文件开头 `_warning: "DERIVED..."`；**禁止手改**
+- **Replay**:
+  - CLI: `scripts/onboarding/replay_state.py`（默认 `--diff` 只读；`--apply` 原子写；`--from-scratch` 忽略 state.yaml 的 governance 字段）
+  - Core: `scripts/onboarding/_lib/persistence.py:replay_state_from_jsonl`
+
+**本 ADR 不发明新机制**，只把 AGE 现存机制硬化为 Layer 2 契约，并把它接入 P1-Doctrine 的 `wake_resume_entrypoint` 字段；同时补齐「恢复结果契约」（输入/输出/preflight 三端闭环）。
+
+---
+
+## 2. 吸收什么 / 不吸收什么
+
+### 2.1 吸收（提升为 Layer 2 契约）
+
+| # | 项 | 依据 |
+|---|---|---|
+| A1 | **jsonl 权威 / yaml 派生** 单向关系 | persistence.py 顶部注释 + state.yaml `_warning` 标记 |
+| A2 | **写序**：先 append jsonl 并 fsync → 后原子重写 state.yaml（tmp + rename 同目录） | `_append_transition_event` + `_atomic_write_state_yaml` |
+| A3 | **Replay 恒等律**：同一 jsonl + 同一 merge_base → 同一 state dict（纯函数） | `replay_state_from_jsonl` 无 IO 副作用，无网络，无时钟依赖 |
+| A4 | **结构严格校验 + 失败闭合**：每个事件过 `_validate_event_structure` | persistence.py `_validate_event_structure` |
+| A5 | **ReplayError vs PersistenceError 分离**：数据错误 vs IO 错误不混 | persistence.py 错误类型声明 |
+| A6 | **Governance 字段非派生**：`ops_mode / discovery_done / smoke_passed / record_provenance / confidence` 从 merge_base 保留或 defaults fallback | `_MERGE_GOVERNANCE_FIELDS` |
+| A7 | **稳定排序**：`(at asc, event_id asc)` 作为 replay 折叠顺序 | `events.sort(key=lambda e: (e["at"], e["event_id"]))` |
+| A8 | **Hop validation 与 collapsed 的关系**：非 collapsed 事件必须通过 `validate_provider_transition` | `replay_state_from_jsonl` 折叠分支 |
+
+### 2.2 不吸收
+
+| # | 项 | 原因 |
+|---|---|---|
+| N1 | ProviderStatus / StoreStatus / OpsMode 枚举 | AGE 业务语义，不提升为 Layer 0 契约 |
+| N2 | `validate_provider_transition` 具体转移图 | 业务决策图，不构成 doctrine |
+| N3 | state.yaml 的 YAML 布局、字段顺序 | AGE 实现细节，其他域引擎可选任何格式 |
+| N4 | `collapsed: true` + `[RECONSTRUCTED]` 补救机制 | 局部历史回填手段，非通用恢复契约 |
+| N5 | 自动修复 / optimistic resume / auto-heal | SNAPSHOT_DIVERGED 必须人工 `--apply`，见 §4.R3 |
+| N6 | AGE FailureCategory 枚举（`SESSION_ENV_ERROR` 等） | 是 AGE onboarding 的业务诊断，不与 ResumeFailureMode 混 |
+
+---
+
+## 3. BGHS 映射
+
+| Concern | 是否涉及 | 依据 |
+|---|---|---|
+| **B**rain | ✗ | resume 不做推理，只 replay + validate |
+| **G**overnance | ✓ | jsonl append-only + schema 校验 + replay 恒等 + write-order 是 governance 不变量 |
+| **H**ands | ✓ | `replay_state_from_jsonl` 与 `_atomic_write_state_yaml` 是 hand（执行动作） |
+| **S**ession | ✓ | `state_transitions.jsonl` **志在成为** SESSION_EVENT_STREAM（见 §7 + P1-e C4） |
+
+**primary_concern**: **Session**（这是 AGE 的权威状态事件流）；**secondary**: Governance。
+
+---
+
+## 4. Resume Rules（契约硬核：如何可靠恢复）
+
+**本节是契约不可分割部分**。任何 Layer 2 wake/resume 实现必须通过本节 5 条。违反 = 拒绝注册。
+
+### R1. Preflight Must Succeed Before Resume
+
+resume 必须在任何实际动作（包括写派生快照、触发后续流程）之前完成 8 项 preflight；任一失败 → `outcome = 'aborted'` 并填具体失败码：
+
+| 检查 | 失败码 | 是否允许 `from-scratch` 豁免 |
+|---|---|---|
+| jsonl 文件存在 | `MISSING_STREAM` | ✗ |
+| jsonl 非空 | `EMPTY_STREAM` | ✗ |
+| 所有事件通过结构校验（`_validate_event_structure` 等价） | `STRUCTURAL_INVALID` | ✗ |
+| 所有 provider-scope 非 collapsed 事件通过 hop validator | `ILLEGAL_TRANSITION` | ✗ |
+| snapshot 文件存在 | `MISSING_SNAPSHOT` | ✓（显式 `from-scratch` 可豁免） |
+| snapshot 文件可读且结构合法（含 `DERIVED` 标记） | `SNAPSHOT_UNREADABLE` | ✓（显式 `from-scratch` 可豁免） |
+| replay 输出与当前 snapshot 一致（`--diff` 为空）**或** 显式 `from-scratch` | `SNAPSHOT_DIVERGED` | ✓（显式 `from-scratch` 可豁免） |
+| `wake_resume_entrypoint.module_path:callable` 可 import | `ENTRYPOINT_UNRESOLVED` | ✗ |
+
+**豁免语义**：只有当 `WakeResumeRequest.mode == 'from-scratch'` 时，`MISSING_SNAPSHOT` / `SNAPSHOT_UNREADABLE` / `SNAPSHOT_DIVERGED` 允许被豁免——但**必须**伴随显式 governance defaults fallback（见 R4）。未声明 `from-scratch` → 三者任一失败即 abort。
+
+**禁止**：任何 preflight warning → 降级 → 继续的隐式路径。要么全过，要么 abort；`from-scratch` 是唯一显式豁免通道。
+
+### R2. Idempotent Replay（Replay 恒等律）
+
+- `replay(jsonl, merge_base)` 是**纯函数**：无网络、无文件系统写、无时钟读取（除记录事件生成时的 `at`；但 replay **不新生事件**）
+- 两次 replay 同一 jsonl + 同一 merge_base → 字段级完全一致的 state dict
+- `--diff` 模式下**禁止任何写**，包括 tmp 文件
+
+违反 → registration validator 拒收（`IMPURE_REPLAY_REJECTED`）。
+
+### R3. Write Order Invariant
+
+任何会推进状态的路径（不仅 resume，也包括正常 `advance_provider_status`）必须：
+
+1. `_append_transition_event` 成功（含 fsync）
+2. **再**原子重写 state.yaml（tmp + rename 同目录）
+
+失败模式：
+
+| 失败点 | 后果 | 恢复路径 |
+|---|---|---|
+| 步骤 1 失败 | yaml 未动，jsonl 未改 | 直接重试，safe |
+| 步骤 2 失败 | jsonl 已记，yaml 未改 → 下次 resume preflight 命中 `SNAPSHOT_DIVERGED` | 必须人工 `--apply` 修复；禁止自动 patch |
+
+### R4. Governance Field Preservation
+
+`ops_mode / discovery_done / smoke_passed / record_provenance / confidence` **不从事件派生**。resume 必须：
+
+- **默认路径**：读 state.yaml → 作为 `merge_base` 传入 → 保留这 5 字段
+- **`from-scratch` 路径**：显式声明 → fallback 到 defaults（`NOT_SET / False / False / absent / absent`）
+- **禁止**：在未声明 `from-scratch` 的情况下静默丢失任一 governance 字段
+
+### R5. Append-Only Immutability
+
+- `state_transitions.jsonl` 禁止 rewrite / truncate / 中间插入 / 旧事件字段修改
+- 历史数据错误必须通过**新事件**纠正（带 `[RECONSTRUCTED]` note + `collapsed: true`），不允许改旧行
+- 文件被删等价于丢失权威事实 → 视为 `STREAM_CORRUPTED`，**必须人工介入**，禁止从 state.yaml 反向重建（因为 yaml 是派生，不是 source of truth）
+
+---
+
+## 5. Contract Sketch
+
+### §5.0 顶层调用签名
+
+```typescript
+wake(entrypoint: WakeResumeEntrypoint, request: WakeResumeRequest): ResumeResult
+```
+
+- **输入**：`WakeResumeEntrypoint`（§5.1，注册期就绪）+ `WakeResumeRequest`（§5.2，每次调用构造）
+- **输出**：`ResumeResult`（§5.3）。**唯一**可被下游消费的恢复结果通道
+- **无副作用路径**：当 `request.mode == 'diff'` 时，`wake` 必须是只读纯函数（含禁止 tmp 写；见 §4 R2）
+
+### §5.1 `WakeResumeEntrypoint`
+
+Layer 0 contract（所有 Layer 2 wake_resume 实现必须实例化此结构）：
+
+```typescript
+interface WakeResumeEntrypoint {
+  // 身份
+  entrypoint_id: string                    // e.g. "age.onboarding.replay_state"
+  component_id: string                     // 声明方 component
+  declared_by_adr: string                  // 指向本 ADR 或扩展 ADR
+
+  // 模块解析（P1-Doctrine wake_resume_entrypoint 字段的具体形态）
+  module_path: string                      // e.g. "scripts.onboarding.replay_state"
+  callable: string                         // e.g. "main"
+
+  // 恢复源
+  stream_refs: StreamRef[]                 // 引用 P1-e SessionEventStream（或 provisional candidate）
+  snapshot_refs: SnapshotRef[]             // 引用 StateSnapshot，derived_from 必须 ⊆ stream_refs.stream_id
+
+  // 契约
+  preflight: PreflightContract             // 本 ADR §5.6
+  replay: ReplayContract                   // 本 ADR §5.7
+}
+
+interface StreamRef {
+  stream_id: string
+  ref_kind: 'session-event' | 'session-adjacent'
+  f1_compliant: boolean                    // false = provisional candidate（见 §7）
+}
+
+interface SnapshotRef {
+  snapshot_id: string
+  derived_from: string[]                   // stream_ids
+}
+```
+
+### §5.2 `WakeResumeRequest`（输入）
+
+每次 `wake()` 调用由调用方构造的请求包：
+
+```typescript
+interface WakeResumeRequest {
+  // 触发来源
+  invoked_by: string                       // "user:liye" | "system" | "orchestrator:<id>"
+  invoked_at: string                       // ISO 8601
+
+  // 恢复目标
+  resource_context: ResourceContext        // 见 §5.4（最小公共接口）
+
+  // 模式
+  mode: 'diff' | 'apply' | 'from-scratch'
+  diff_required_before_apply: boolean      // 必须 true（见 §4 R1 最后一列）
+}
+```
+
+**模式语义**：
+
+| mode | 作用 | snapshot 缺失/不可读/偏离 是否可豁免 | 允许写 |
+|---|---|---|---|
+| `diff` | 只读，对比 replay 输出 vs 当前 snapshot | ✗ | ✗（含 tmp） |
+| `apply` | 原子写 snapshot 以消除 DIVERGED | ✗ | ✓（仅 snapshot 原子重写） |
+| `from-scratch` | 显式声明忽略 snapshot；只靠 jsonl + defaults 构建 | ✓（豁免 `MISSING_SNAPSHOT` / `SNAPSHOT_UNREADABLE` / `SNAPSHOT_DIVERGED`） | 不默认允许；AGE 用 `--from-scratch --apply` 组合显式开写路径 |
+
+### §5.3 `ResumeResult` + `ResumeContext`（输出）
+
+**恢复结果契约**——下游消费者**只能**通过此结构获取恢复状态。
+
+```typescript
+interface ResumeResult {
+  outcome: 'ready' | 'aborted'
+  context: ResumeContext | null            // outcome='ready' 时必填；'aborted' 时必须 null
+  failure_code: ResumeFailureMode | null   // outcome='aborted' 时必填；'ready' 时必须 null
+  failure_reason: string | null            // 诊断文本（可含栈信息但禁敏感数据）
+  preflight_report: PreflightReport        // 无论 outcome 都必填，可追溯哪些 check 跑过、结果如何
+}
+
+interface ResumeContext {
+  // 身份
+  resource_context: ResourceContext        // §5.4
+
+  // 权威派生快照
+  latest_snapshot: StateSnapshot           // §5.5
+
+  // 事件流游标
+  event_cursor: EventCursor
+
+  // 恢复提示（下游决策辅助，非权威事实）
+  resume_hints: ResumeHint[]
+
+  // 联动工件（session-adjacent / receipt 等）
+  linked_artifacts: LinkedArtifact[]
+}
+
+interface EventCursor {
+  stream_id: string
+  last_event_id: string                    // jsonl 末事件 event_id
+  last_event_at: string                    // ISO 8601
+  total_events: number
+  replay_strategy: 'merge-base' | 'from-scratch'
+}
+
+interface ResumeHint {
+  kind: string                             // e.g. "next-action" | "stale-warning" | "governance-fallback"
+  severity: 'info' | 'warn'                // 硬性 abort 条件必须走 failure_code，不进 hints
+  safe_summary: string                     // 必须脱敏
+}
+
+interface LinkedArtifact {
+  artifact_class: string                   // P1-e ArtifactClass 值
+  artifact_id: string
+  role: string                             // e.g. "derived-index" | "query-audit"
+}
+
+interface PreflightReport {
+  checks_run: ResumeFailureMode[]          // 实际跑过的 check（按 PreflightContract.required_checks 顺序）
+  first_failure: ResumeFailureMode | null  // 首个失败的 check
+  bypassed: ResumeFailureMode[]            // 被 from-scratch 显式豁免的 check
+}
+```
+
+**硬约束**：
+
+| # | 规则 | 失败码 |
+|---|---|---|
+| O1 | `outcome='ready'` → `context != null` 且 `failure_code == null` | `RESULT_SHAPE_VIOLATION` |
+| O2 | `outcome='aborted'` → `context == null` 且 `failure_code != null` | `RESULT_SHAPE_VIOLATION` |
+| O3 | `PreflightReport` 必须与实际执行路径一致（不得伪造 checks_run） | `PREFLIGHT_REPORT_FALSIFIED` |
+| O4 | `ResumeHint.safe_summary` 必须满足 §5.4 C2 脱敏约束 | `RESUME_HINT_UNSAFE_SUMMARY` |
+| O5 | 下游消费者**不得**绕过 `ResumeResult` 直接读 jsonl / yaml / 内部状态 | `RESUME_RESULT_BYPASSED`（见 §10） |
+
+### §5.4 `ResourceContext`（最小公共接口，**禁止 Any**）
+
+所有 Layer 2 wake_resume_entrypoint 的**最小公共参数合约**。Layer 2 实现可以追加字段，但不能少，也不能以「可扩展字段」规避。
+
+```typescript
+interface ResourceContext {
+  resource_type: string                    // e.g. "store"（AGE onboarding 场景）
+  id: string                               // e.g. "STR-E438213024"
+  scope: string                            // e.g. "ads" | "spapi" | "store"
+  safe_summary: string                     // 人类可读、已脱敏摘要
+}
+```
+
+**Python 等价形态**：
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class ResourceContext:
+    resource_type: str
+    id: str
+    scope: str
+    safe_summary: str
+```
+
+**硬约束（validator 强制）**：
+
+| # | 禁止 | 拒收码 |
+|---|---|---|
+| C1 | 使用 `Any` / `object` / `dict[str, Any]` / `Record<string, unknown>` / `Map<string, object>` 或等价类型 | `RESOURCE_CONTEXT_ANY_TYPE` |
+| C2 | 在 `safe_summary` 里放 credential material / raw token / 完整 PII | `RESOURCE_CONTEXT_UNSAFE_SUMMARY` |
+| C3 | 省略 4 个必填字段任一 | `RESOURCE_CONTEXT_MISSING_FIELD` |
+| C4 | 使用可变字段集（`extra: Dict[str, Any]`、`metadata: object` 等）规避最小接口 | `RESOURCE_CONTEXT_ESCAPE_HATCH` |
+
+**C2 判定（非规范性指南）**：`safe_summary` 应通过 Loamwise Guard 的 content-scan（P1-d）；出现 token 形态（`^ya29\.`、`^Atza\|`、`Bearer `、bcrypt/argon 特征等）或完整 email / phone → 不安全。
+
+### §5.5 `StateSnapshot`
+
+```typescript
+interface StateSnapshot {
+  snapshot_id: string                      // 通常 = 文件路径或稳定标识
+  derived_from: string[]                   // stream_ids，必须非空
+  warning_marker: 'DERIVED'                // 文件必须含，validator 必须校验
+  last_replay_at: string                   // ISO 8601
+  total_events: number                     // 来自 replay 结果
+  governance_fields: GovernanceFields      // 不派生自事件
+}
+
+interface GovernanceFields {
+  ops_mode: string                         // 必须是明确 enum 值（不是 Any）
+  discovery_done: boolean
+  smoke_passed: boolean
+  record_provenance: string | null
+  confidence: string | null
+}
+```
+
+**硬约束**：snapshot 文件必须含 `DERIVED` 标记（AGE 当前用 `_warning: "DERIVED..."` 满足）。校验器检测不到 → 拒绝作为 snapshot 使用（失败码 `SNAPSHOT_MISSING_DERIVED_MARKER`）。
+
+### §5.6 `PreflightContract`
+
+静态声明型契约——注册期就固定哪些 check、哪些允许豁免、以什么顺序跑。`wake()` 执行期**不得**增减 required_checks。
+
+```typescript
+interface PreflightContract {
+  // 必跑的检查（按声明顺序执行）
+  required_checks: ResumeFailureMode[]
+
+  // 是否要求 snapshot（false = 该 entrypoint 可无 snapshot 运行）
+  snapshot_required: boolean
+
+  // 允许被 `from-scratch` 显式豁免的检查
+  // 必须 ⊆ required_checks；必须 ⊆ {MISSING_SNAPSHOT, SNAPSHOT_UNREADABLE, SNAPSHOT_DIVERGED}
+  allow_from_scratch_bypass: ResumeFailureMode[]
+
+  // 固定不变量（schema 层只允许 true）
+  diff_required_before_apply: true
+  abort_on_first_failure: true
+}
+```
+
+**硬约束（validator 强制，见 §5.8）**：
+
+| # | 规则 | 拒收码 |
+|---|---|---|
+| P1 | `required_checks` 必须 ⊆ 已知 `ResumeFailureMode` 枚举 | `PREFLIGHT_UNKNOWN_CHECK` |
+| P2 | `allow_from_scratch_bypass` 必须 ⊆ `required_checks` | `PREFLIGHT_BYPASS_NOT_REQUIRED` |
+| P3 | `allow_from_scratch_bypass` 必须 ⊆ `{MISSING_SNAPSHOT, SNAPSHOT_UNREADABLE, SNAPSHOT_DIVERGED}` | `PREFLIGHT_BYPASS_OUT_OF_SCOPE` |
+| P4 | `diff_required_before_apply` 必须 `true`（schema-level enum = [true]） | `PREFLIGHT_WEAK_DIFF_GUARD` |
+| P5 | `abort_on_first_failure` 必须 `true` | `PREFLIGHT_CONTINUE_ON_FAILURE` |
+| P6 | 若 `snapshot_required == true` 且 `MISSING_SNAPSHOT ∉ required_checks` → 拒收 | `PREFLIGHT_SNAPSHOT_CHECK_MISSING` |
+
+### §5.7 `ReplayContract`
+
+```typescript
+interface ReplayContract {
+  is_pure: true                            // schema-level 自证；validator 不接受 false（§5.8 C3）
+  stable_ordering_keys: string[]           // e.g. ['at', 'event_id']
+  declared_failure_modes: ResumeFailureMode[]   // 必须是枚举已知集合
+}
+
+type ResumeFailureMode =
+  // Stream 层
+  | 'MISSING_STREAM'
+  | 'EMPTY_STREAM'
+  | 'STRUCTURAL_INVALID'
+  | 'ILLEGAL_TRANSITION'
+  | 'STREAM_CORRUPTED'
+  | 'STREAM_NOT_REGISTERED'
+  // Snapshot 层
+  | 'MISSING_SNAPSHOT'
+  | 'SNAPSHOT_UNREADABLE'
+  | 'SNAPSHOT_DIVERGED'
+  | 'SNAPSHOT_MISSING_DERIVED_FROM'
+  | 'SNAPSHOT_DANGLING_DERIVED_FROM'
+  | 'SNAPSHOT_MISSING_DERIVED_MARKER'
+  // Entrypoint / Replay 层
+  | 'ENTRYPOINT_UNRESOLVED'
+  | 'IMPURE_REPLAY_REJECTED'
+  // ResourceContext 层
+  | 'RESOURCE_CONTEXT_ANY_TYPE'
+  | 'RESOURCE_CONTEXT_UNSAFE_SUMMARY'
+  | 'RESOURCE_CONTEXT_MISSING_FIELD'
+  | 'RESOURCE_CONTEXT_ESCAPE_HATCH'
+  // Preflight 层
+  | 'PREFLIGHT_UNKNOWN_CHECK'
+  | 'PREFLIGHT_BYPASS_NOT_REQUIRED'
+  | 'PREFLIGHT_BYPASS_OUT_OF_SCOPE'
+  | 'PREFLIGHT_WEAK_DIFF_GUARD'
+  | 'PREFLIGHT_CONTINUE_ON_FAILURE'
+  | 'PREFLIGHT_SNAPSHOT_CHECK_MISSING'
+  // Result shape 层
+  | 'RESULT_SHAPE_VIOLATION'
+  | 'PREFLIGHT_REPORT_FALSIFIED'
+  | 'RESUME_HINT_UNSAFE_SUMMARY'
+  | 'RESUME_RESULT_BYPASSED'
+```
+
+**禁止新增未枚举的失败码**；新失败模式必须走 ADR 修订。
+
+### §5.8 Registration Validator
+
+```python
+def register_wake_resume_entrypoint(wre: WakeResumeEntrypoint) -> RegisterResult:
+    # C1. 模块可 import
+    if not _can_import(wre.module_path, wre.callable):
+        return fail('ENTRYPOINT_UNRESOLVED')
+
+    # C2. stream_refs 每个都注册（或 provisional candidate 已登记）
+    for sr in wre.stream_refs:
+        if not _stream_registered_or_provisional(sr.stream_id):
+            return fail('STREAM_NOT_REGISTERED', sr.stream_id)
+
+    # C3. ReplayContract 必须纯
+    if not wre.replay.is_pure:
+        return fail('IMPURE_REPLAY_REJECTED')
+
+    # C4. Replay 失败码必须是已知枚举
+    unknown = set(wre.replay.declared_failure_modes) - KNOWN_FAILURE_MODES
+    if unknown:
+        return fail('UNKNOWN_FAILURE_MODES', sorted(unknown))
+
+    # C5. snapshot_refs derived_from ⊆ stream_refs
+    stream_ids = {s.stream_id for s in wre.stream_refs}
+    for sn in wre.snapshot_refs:
+        if not sn.derived_from:
+            return fail('SNAPSHOT_MISSING_DERIVED_FROM', sn.snapshot_id)
+        if set(sn.derived_from) - stream_ids:
+            return fail('SNAPSHOT_DANGLING_DERIVED_FROM', sn.snapshot_id)
+
+    # C6. PreflightContract 合规（本 ADR §5.6 P1-P6）
+    pf = wre.preflight
+    if set(pf.required_checks) - KNOWN_FAILURE_MODES:
+        return fail('PREFLIGHT_UNKNOWN_CHECK')
+    if set(pf.allow_from_scratch_bypass) - set(pf.required_checks):
+        return fail('PREFLIGHT_BYPASS_NOT_REQUIRED')
+    if set(pf.allow_from_scratch_bypass) - {
+        'MISSING_SNAPSHOT', 'SNAPSHOT_UNREADABLE', 'SNAPSHOT_DIVERGED'
+    }:
+        return fail('PREFLIGHT_BYPASS_OUT_OF_SCOPE')
+    if not pf.diff_required_before_apply:
+        return fail('PREFLIGHT_WEAK_DIFF_GUARD')
+    if not pf.abort_on_first_failure:
+        return fail('PREFLIGHT_CONTINUE_ON_FAILURE')
+    if pf.snapshot_required and 'MISSING_SNAPSHOT' not in pf.required_checks:
+        return fail('PREFLIGHT_SNAPSHOT_CHECK_MISSING')
+
+    # C7. ResourceContext schema 合规（本 ADR §5.4 C1-C4）
+    rc_check = _validate_resource_context_schema(wre.module_path, wre.callable)
+    if not rc_check.ok:
+        return fail(rc_check.code)
+
+    return ok()
+```
+
+---
+
+## 6. AGE 实例化（reference binding）
+
+### Component Declaration（AGE onboarding）
+
+```yaml
+component_id: age.onboarding.store_state
+layer: 2
+artifact_role: component
+primary_concern: Session
+credential_bindings: []                    # 本 component 不直接取用 credentials；OAuth/SP-API 凭据在上游 authz 组件里，按 P1-f 走
+wake_resume_entrypoint: age.onboarding.replay_state:main
+explicit_non_goals:
+  - '不自动修复 SNAPSHOT_DIVERGED，必须人工 --apply'
+  - '不跨 store 共享 state'
+  - '不替代 Layer 0 F1 合规判定'
+```
+
+### WakeResumeEntrypoint 实例
+
+```yaml
+entrypoint_id: age.onboarding.replay_state
+component_id: age.onboarding.store_state
+declared_by_adr: ADR-AGE-Wake-Resume
+module_path: scripts.onboarding.replay_state
+callable: main
+
+stream_refs:
+  - stream_id: age.stream.state_transitions
+    ref_kind: session-event
+    f1_compliant: false                    # 缺 prev_event_hash（见 §7）
+
+snapshot_refs:
+  - snapshot_id: age.snapshot.state_yaml
+    derived_from: [age.stream.state_transitions]
+
+preflight:
+  required_checks:
+    - MISSING_STREAM
+    - EMPTY_STREAM
+    - STRUCTURAL_INVALID
+    - ILLEGAL_TRANSITION
+    - MISSING_SNAPSHOT
+    - SNAPSHOT_UNREADABLE
+    - SNAPSHOT_DIVERGED
+    - ENTRYPOINT_UNRESOLVED
+  snapshot_required: true
+  allow_from_scratch_bypass:
+    - MISSING_SNAPSHOT
+    - SNAPSHOT_UNREADABLE
+    - SNAPSHOT_DIVERGED
+  diff_required_before_apply: true
+  abort_on_first_failure: true
+
+replay:
+  is_pure: true
+  stable_ordering_keys: [at, event_id]
+  declared_failure_modes:
+    - MISSING_STREAM
+    - EMPTY_STREAM
+    - STRUCTURAL_INVALID
+    - ILLEGAL_TRANSITION
+    - MISSING_SNAPSHOT
+    - SNAPSHOT_UNREADABLE
+    - SNAPSHOT_DIVERGED
+    - ENTRYPOINT_UNRESOLVED
+```
+
+### `wake()` 调用示例（AGE）
+
+```python
+# 构造 Request
+request = WakeResumeRequest(
+    invoked_by="user:liye",
+    invoked_at="2026-04-17T10:30:00Z",
+    resource_context=ResourceContext(
+        resource_type="store",
+        id="STR-E438213024",
+        scope="ads",                                    # "ads" | "spapi" | "store"
+        safe_summary="XMEDEN (US/MX/BR), ads VERIFIED, spapi VERIFIED, OPERATIONAL",
+    ),
+    mode="diff",
+    diff_required_before_apply=True,
+)
+
+# 调用
+result: ResumeResult = wake(age_entrypoint, request)
+
+# 消费（只允许通过 ResumeResult）
+if result.outcome == "ready":
+    assert result.context is not None
+    snapshot = result.context.latest_snapshot
+    cursor = result.context.event_cursor
+    # ... 下游决策
+else:
+    assert result.failure_code is not None
+    # 根据 failure_code 做 abort 路径
+```
+
+---
+
+## 7. 与 P1-e（Session Event Stream）的关系
+
+AGE `state_transitions.jsonl` 在 P1-e 分类法下是 **provisional authoritative candidate, not yet F1-compliant**：
+
+| F1 条件 | 现状 | 缺口 |
+|---|---|---|
+| F1.1 append-only | ✓ | — |
+| F1.2 持久结构化 | ✓（NDJSON + JSON schema） | — |
+| **F1.3 hash-chained** | ✗ | **事件 schema 无 `prev_event_hash` 字段** |
+| F1.4 权威 | ✓（yaml 派生自 jsonl，`_warning: "DERIVED..."`） | — |
+| F1.5 stream descriptor | 部分（schema 已在，但未登记到 P1-e §4 StreamRegistry） | 待登记 |
+
+**含义**：
+
+- **在 AGE 补齐 F1.3 之前**：
+  - `stream_refs[].ref_kind = 'session-event'`、`f1_compliant = false`
+  - **不得**进入 P1-e 的 strict_truth bucket 1（保持 bucket 3 或不入榜）
+  - resume 本身**仍然合法**——preflight + replay 足以自证；但其他组件不得把此流当 authoritative session fact 联合检索
+- **在 AGE 补齐 F1.3 之后**：
+  - 登记到 StreamRegistry 获 stream_id
+  - `f1_compliant = true`
+  - 可进入 strict_truth bucket 1
+
+**本 ADR 不强制 AGE 在 P1 期间补齐 hash chain**——这是 AGE 后续独立演进任务（见 §11 C6）。
+
+---
+
+## 8. 与其他 P1 ADR 的关系
+
+| ADR | 关系 |
+|---|---|
+| **P1-Doctrine** | 本 ADR 给出 Component Declaration `wake_resume_entrypoint: null \| string` 的具体形态 |
+| **P1-e** | `state_transitions.jsonl` 是 provisional SESSION_EVENT_STREAM 候选；snapshot 的 `derived_from` 与 P1-e `SessionAdjacentArtifact.derived_from` 同源语义 |
+| **P1-f** | resume 若需真实 API 调用（如 smoke 复核），凭据走 `credential_bindings`，产出 `CredentialAuditRecord`（P1-e SessionAdjacentKind.CREDENTIAL_AUDIT）；本 ADR **不重定义** |
+| **P1-b** | `LifecycleTransition` 也是 append-only + 显式 driver，与本 ADR 同源 discipline（事件流 + 纯函数 replay） |
+| **P1-c** | `MemoryAssemblyPlan` 冻结计划 + `declared_tiers` 写约束，与本 ADR R4 governance 字段保留同源纪律 |
+| **P1-d** | `safe_summary` 非规范性指南引用 G1 content-scan；但本 ADR 不硬绑 Guard 启用状态 |
+
+---
+
+## 9. Non-Goals
+
+- **不重写** AGE 任何现有代码；本 ADR 把现存机制硬化为契约
+- **不引入** 跨 store / 跨 domain 的聚合 resume；每次 resume 作用域 = 单 resource
+- **不引入** optimistic resume / auto-heal / 自动 patch；`SNAPSHOT_DIVERGED` 必须人工 `--apply`
+- **不替代** Layer 0 F1 合规判定（P1-e 职责）
+- **不处理** secrets（P1-f 职责）
+- **不开放** ResourceContext 的可扩展字段；未来新字段走本 ADR 修订
+- **不让** 下游直接读 jsonl / yaml / 内部状态；只能通过 `ResumeResult`
+
+---
+
+## 10. 禁止事项
+
+1. **禁止** 在 ResourceContext 使用 `Any` / `object` / 等价 escape hatch
+2. **禁止** 在 `safe_summary` 或 `ResumeHint.safe_summary` 写 credential material / raw token / 完整 PII
+3. **禁止** 把 state.yaml 当权威恢复源（派生快照，**不**是 source of truth）
+4. **禁止** 在 `diff` 模式写任何文件（含 tmp 文件）
+5. **禁止** 用 `collapsed: true` 规避 hop validation，除非 note 含 `[RECONSTRUCTED]` 且有独立 ADR / 人工审批背书
+6. **禁止** 跳过 preflight 进入 replay
+7. **禁止** 从 state.yaml 反向重建 state_transitions.jsonl（派生不能反推权威）
+8. **禁止** 在未显式 `from-scratch` 时静默丢失 governance 字段
+9. **禁止** 下游绕过 `ResumeResult` 直接读 jsonl / yaml / 内部状态（监测到 → `RESUME_RESULT_BYPASSED`）
+10. **禁止** 在 `outcome='aborted'` 时返回非空 `context`，或在 `outcome='ready'` 时返回非空 `failure_code`
+11. **禁止** 在 `wake()` 执行期偏离 `PreflightContract.required_checks` 声明
+
+---
+
+## 11. Adoption Checkpoints
+
+| # | 检查点 | 时机 | 通过条件 |
+|---|---|---|---|
+| C1 | 本 ADR 合版 | P1 批次 | P1 批次其余 7 份 ADR 全合版 |
+| C2 | AGE Component Declaration 补 `wake_resume_entrypoint` | P1 合版后 1 周 | `age.onboarding.replay_state:main` 可 import |
+| C3 | ResourceContext dataclass 在 AGE 落地 | P1 合版后 2 周 | AGE 导出 frozen dataclass；4 字段覆盖；禁用 Any 的静态检查过关 |
+| C4 | registration validator 可用 | P1 合版后 2 周 | Layer 0 `register_wake_resume_entrypoint` 实现；拒绝 `is_pure=false`、未知失败码、dangling derived_from、Any 类型、不合规 PreflightContract |
+| C5 | `ResumeResult` 结果契约落地 | P1 合版后 3 周 | AGE 侧 `wake()` 返回完整 `ResumeResult`；O1-O5 规则有单元测试覆盖 |
+| C6 | AGE D0→D1 升级门禁 | D1 发起 | 对全部 3 个活 store，`replay_state.py --diff` 输出 IN SYNC；任一 DIVERGED 必须 `--apply` 消除，不得绕过 |
+| C7 | F1.3 补齐（独立演进，本 ADR 不强制） | AGE 后续 ADR | `state_transitions.jsonl` 加 `prev_event_hash`；StreamRegistry 登记；`f1_compliant = true` |
+
+---
+
+## Appendix A — Doctrine 对齐
+
+- **P1-Doctrine Component Declaration** 中 `wake_resume_entrypoint: null | string`
+  - `null` 含义：**该 component 不支持恢复**；调用方必须 fail-closed 处理（**不得**退化为「尽力而为」）
+  - `string` 含义：`module_path:callable` 字符串；具体结构由本 ADR §5.1 定义
+- 本 ADR 的 ResourceContext（§5.4）是**所有 Layer 2 wake_resume_entrypoint 的最小公共参数合约**
+- 本 ADR 的 ResumeResult（§5.3）是**所有 Layer 2 wake_resume_entrypoint 的最小公共结果合约**；下游**只能**通过此结构消费恢复状态
+
+## Appendix B — 与 AGE 现存代码对应表（non-normative）
+
+| 本 ADR 概念 | AGE 代码位置 |
+|---|---|
+| Event stream | `artifacts/onboarding/{store_id}/state_transitions.jsonl` |
+| Event schema | `config/stores/_schema/state_event.schema.json` |
+| `StateTransitionEvent` | `scripts/onboarding/_lib/models.py:StateTransitionEvent` |
+| Snapshot | `config/stores/stores/{store_id}/state.yaml` |
+| Structural validator | `scripts/onboarding/_lib/persistence.py:_validate_event_structure` |
+| Hop validator | `scripts/onboarding/_lib/state_machine.py:validate_provider_transition` |
+| Replay function | `scripts/onboarding/_lib/persistence.py:replay_state_from_jsonl` |
+| CLI entrypoint | `scripts/onboarding/replay_state.py:main` |
+| Governance 字段清单 | `scripts/onboarding/_lib/persistence.py:_MERGE_GOVERNANCE_FIELDS` |
+| Write-order 不变量 | `scripts/onboarding/_lib/persistence.py:advance_provider_status` 步骤 4→6 |
+| `--diff` / `--apply` / `--from-scratch` 三模式 | `scripts/onboarding/replay_state.py:main` argparse |
+
+---
+
+**本 ADR 硬化的是 AGE 既有机制，不替 AGE 做任何业务决定**。任何偏离本契约的现存 AGE 代码必须在 C6 之前修正或显式豁免（豁免需独立 ADR）。

--- a/_meta/adr/ADR-Architecture-Doctrine-BGHS-Separation.md
+++ b/_meta/adr/ADR-Architecture-Doctrine-BGHS-Separation.md
@@ -1,0 +1,356 @@
+---
+artifact_scope: meta
+artifact_name: Architecture-Doctrine-BGHS-Separation
+artifact_role: doctrine
+target_layer: cross
+is_bghs_doctrine: yes
+---
+
+# ADR — Architecture Doctrine · BGHS Separation
+
+**Status**: Accepted
+**Date**: 2026-04-16
+**Accepted-Date**: 2026-04-17
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-Architecture-Doctrine-BGHS-Separation.md`
+**Supersedes**: —
+**Referenced by**: P1-a, P1-b, P1-c, P1-d, P1-e, P1-f, P1-g（所有其他 P1 ADR）
+
+---
+
+## Context
+
+LiYe Systems 的四层架构（Layer 0/1/2/3，见 `_meta/portfolio/SYSTEMS.md`）回答了"**组件住在哪里**"的问题（制度底座 / 编排中间层 / 域引擎 / 产品线）。
+
+但四层架构没有回答另一个维度的问题：
+
+> 一个组件**在本质上是什么**？
+> 它是随模型代际更替的 harness？
+> 还是跨模型代际不得放松的治理不变量？
+> 还是执行动作的桥梁？
+> 还是外部化的事件日志？
+
+没有这个正交维度，会出现三类退化：
+
+1. **Governance 被隐式折进 Brain**：治理规则写进 prompt，下次换模型就丢了
+2. **Session 被看作 Brain 的内存**：会话上下文泄漏到决策逻辑，replay 不可行
+3. **Hands 吃掉 Governance**：tool wrapper 里塞风控判断，调用方以为自己在调工具，实则绕过了治理
+
+Managed Agents（Anthropic，见 `_meta/portfolio/SYSTEMS.md` Architecture References 区块）提出 **Brain / Hands / Session** 三分法，是一个有效的起点。但它把 Governance 隐式交给 Brain 或 Hands，对于 LiYe Systems 这种治理驱动的系统不适用——治理必须**显式可见、不得随模型升级而放松**。
+
+本 Doctrine 将三分法升级为 **BGHS 四分法**，作为整个生态的裁判手册。
+
+---
+
+## 三问
+
+### 1. 上游核心做法
+
+**Managed Agents 三分法**（来源：`anthropic.com/engineering/managed-agents`）：
+
+| Concern | 上游定义 |
+|---------|---------|
+| **Brain** | 模型 + prompt + reasoning harness。随模型能力变化，开发者控制 |
+| **Hands** | 工具 / executor / adapter。与外部世界交互 |
+| **Session** | 对话上下文、事件序列。外部化、可持久化 |
+
+核心原则（上游贡献）：
+- **Session externalization**：会话状态不住在模型的上下文窗口里，必须外部化为可持久化的事件日志
+- **Harness replaceability**：当模型能力升级时，harness 应可替换而不改变系统契约
+- **Tool isolation**：tools 是可替换的桥梁，不承载决策逻辑
+
+### 2. 吸收什么，不吸收什么
+
+**吸收**：
+- Session 必须外部化（不住模型上下文）
+- Brain（harness）随模型代际可替换
+- Hands 与 Brain 解耦，不承载决策逻辑
+- 正交于 runtime 分层的"组件本质"视角
+
+**不吸收**：
+- **三分法本身**：三分法把 Governance 隐式塞进 Brain 或 Hands，LiYe Systems 拒绝这种隐式
+- **"Brain 即一切"的倾向**：不把治理退化为 prompt 工程
+- **单一 Session 存储假设**：authoritative session event streams 可多源并存（如 `data/traces/...` / `state_transitions.jsonl`）；**receipts 不是 session 本体，而是 session-adjacent**（见 P1-e 的 taxonomy 定义），多源聚合由 P1-e Federated Query 负责
+
+### 3. 最小落地 contract
+
+**四分类 + 三模板 + 裁决规则**，见下文 Contract Sketch。
+
+---
+
+## Decision
+
+### D1. 四种 Concern（BGHS）
+
+LiYe Systems 所有 **component**（codebase 条目 / Skill / Agent / Crew / 可运行模块）归属以下四种 concern 之一：
+
+| 代号 | 名称 | 一句话定义 | 更替信号 |
+|------|------|----------|---------|
+| **B** | Brain | 当前模型能力下的 harness 逻辑（prompt / reasoning pattern / decomposition strategy） | 模型代际升级 → 应可替换 |
+| **G** | Governance | 跨模型代际不得放松的治理不变量（contracts / policies / kill switch / audit schema） | 任何时候 → 不得因模型升级而弱化 |
+| **H** | Hands | 执行动作的 tools / executors / adapters（与外部世界交互） | 外部 API / 协议变化 → 更新实现 |
+| **S** | Session | 外部化、可 replay 的事件日志与 resume contract | session semantics / replay guarantees 变化 → Doctrine 或 contract 审查；具体格式 / schema 演进 → 对应 contract ADR（如 P1-e / P1-g） |
+
+### D2. BGHS 是视角，不是层级
+
+- BGHS **正交**于 Layer 0/1/2/3，不替换、不平行
+- 不得据 BGHS 创建目录（**禁止** `brain/`, `governance/`, `hands/`, `session/` 作为 runtime 目录名）
+- 不得据 BGHS 创建 runtime 层级
+- BGHS 只出现在**声明**（yaml frontmatter / declaration）里
+
+### D3. 每种 artifact 用对应 Declaration
+
+- **Component**（可运行）→ Component Declaration（含 primary_concern）
+- **Meta**（Doctrine / Contract / Harvest ADR）→ Meta Declaration（**不参与 BGHS 分类**）
+- **Reference**（外部概念 / fork / 论文 / 供应商文档）→ Reference Declaration（不参与 BGHS 分类）
+
+### D4. 混合组件允许，但必须声明拆分方向
+
+一个 component 可以同时承担 primary + secondary concern（例如：一个 Skill 主要是 Hands，但嵌入了小部分 Governance 检查）。但必须：
+
+- 在 Component Declaration 里声明 `secondary_concern`
+- 声明 `future_split_direction`（何时、按什么信号拆分）
+- 不得永久混合超过两种 concern
+
+### D5. Governance 修订的分层规则
+
+Doctrine 负责**元规则**，不做所有具体治理参数变更的瓶颈。修订按层级分流：
+
+| 修订类型 | 修订通道 | 例 |
+|---------|---------|----|
+| **Doctrine-level**：BGHS 分类本身、Declaration 模板字段、分类裁决规则、本 ADR 禁止事项 | 修本 Doctrine ADR（新 ADR supersede 旧条款） | 新增第 5 种 concern；`primary_concern` 改为多选 |
+| **具体 policy / contract / guard 的不变量**：单条 policy 门限、单个 contract schema 字段、单个 guard 判定级别 | 修其所属的 **contract ADR / policy ADR**（不碰本 Doctrine） | 修改 A3 写白名单条目；GuardChain 新增一个扫描规则 |
+
+**共同硬约束**（不分层级，永远成立）：
+- 不得**仅因模型升级**而放松 Governance invariant
+- 不得通过 prompt 或 harness 绕过已声明的 Governance
+- 任何 Governance 放松都必须 **显式 ADR 记录**（而不是静默删除）
+
+---
+
+## Contract Sketch
+
+### §1. 四种 Concern 的裁决规则（裁判手册）
+
+判定一个 component 的 primary_concern 时，按顺序问以下 5 个问题：
+
+```
+Q1: 如果模型代际从 Claude 4 升级到 Claude 5，这个组件是否"应该"被替换或重写？
+    YES → 候选 Brain
+    NO  → 进入 Q2
+
+Q2: 这个组件是否定义了"系统在任何模型下都不允许做某事"的规则？
+    YES → 候选 Governance
+    NO  → 进入 Q3
+
+Q3: 这个组件是否与外部世界（API / 文件系统 / 数据库 / 工具）交互？
+    YES → 候选 Hands
+    NO  → 进入 Q4
+
+Q4: 这个组件是否产出/消费"事件日志"或"状态快照"或"replay 契约"？
+    YES → 候选 Session
+    NO  → 混合组件（回到 Q1 重新判断 primary）
+
+Q5: 上述候选中，哪个是此组件的"存在理由"？
+    → primary_concern
+    其余 → secondary_concern 或不声明
+```
+
+**反例速查**（常见错判）：
+
+| 常见错误 | 正确判法 |
+|---------|---------|
+| 把 orchestrator prompt 判为 Governance | Prompt 随模型代际变化 → Brain |
+| 把 kill switch 规则判为 Hands（因为"会调 API 关停"） | 规则本身不变 → Governance；停机动作执行 → Hands |
+| 把 session retrieval 判为 Brain | 事件日志的读取契约 → Session；ranking prompt → Brain |
+| 把 HMAC 验证判为 Governance | 这是 Hands 内的实现细节；Governance 是"必须验证身份"这条规则本身 |
+
+### §2. Component Declaration（完整 schema）
+
+```yaml
+# 放在 Component 根目录 README.md / CLAUDE.md 头部，或独立 declaration.yaml
+artifact_scope: component        # 固定值
+component_name: string           # e.g., "loamwise-guard-chain"
+layer: 0 | 1 | 2 | 3             # LiYe Systems 分层
+primary_concern: Brain | Governance | Hands | Session
+secondary_concern: null | Brain | Governance | Hands | Session
+model_contingent_items:          # 随模型代际可能变化的部分（列表）
+  - string                       # e.g., "decomposer prompt template"
+model_independent_invariants:    # 跨模型不得放松的部分（列表）
+  - string                       # e.g., "kill switch must block within 100ms"
+session_source_of_truth: null | string
+  # 如果该 component 产出/消费 session，指向 SoT 路径
+  # e.g., "data/traces/<engine>/*/events.ndjson"
+credential_path: null | string
+  # 如果需要凭据，指向 CredentialBroker seam（见 P1-f）
+  # e.g., "cred://loamwise/age-executor"
+wake_resume_entrypoint: null | string
+  # 如果支持 wake/resume，指向恢复入口
+  # e.g., "src/runtime/resume_from_state.ts"
+explicit_non_goals:              # 显式不做的事
+  - string
+future_split_direction: null | string
+  # 如果是混合组件，声明拆分方向
+  # e.g., "secondary Governance checks will move to loamwise/govern/ in P2"
+```
+
+### §3. Meta Declaration（用于所有 ADR）
+
+```yaml
+artifact_scope: meta             # 固定值
+artifact_name: string            # e.g., "Hermes-Skill-Lifecycle"
+artifact_role: doctrine | contract | harvest
+target_layer: 0 | 1 | 2 | 3 | cross | none
+is_bghs_doctrine: yes | no       # 仅本 Doctrine = yes；其他 ADR = no
+```
+
+**artifact_role 语义**（当前枚举固定为三类）：
+
+| Role | 含义 | 例子 |
+|------|------|------|
+| `doctrine` | 定义架构原则的基础 ADR | 本 ADR |
+| `contract` | 定义机器可执行的接口/schema/状态机 | P1-e/f/g |
+| `harvest` | 从参考仓萃取 pattern 的决议 | P1-a/b/c/d |
+
+> 如未来出现既非原则、也非契约、也非萃取的单点决策需求，通过 Doctrine 修订扩展枚举；当前不预留占位。
+
+**target_layer 语义**：
+
+- `0|1|2|3`：ADR 主要约束某一层
+- `cross`：跨层 ADR（如 Session taxonomy 跨 Layer 0/1）
+- `none`：无 runtime 约束（罕见，一般是纯文档）
+
+### §4. Reference Declaration（用于外部概念/fork/论文）
+
+```yaml
+artifact_scope: reference        # 固定值
+artifact_name: string            # e.g., "Managed-Agents"
+source_kind: concept | fork | paper | vendor_doc
+source_uri: string               # URL 或本地路径
+```
+
+### §5. 禁止事项（硬约束，违反 = 架构违规）
+
+1. **不得据 BGHS 创建目录**
+   - ❌ `loamwise/brain/`, `loamwise/governance/`, `loamwise/hands/`, `loamwise/session/`
+   - ✅ `loamwise/govern/`, `loamwise/construct/`, `loamwise/align/`, `loamwise/reason/`（既有目录，按功能而非 concern 命名）
+
+2. **不得据 BGHS 创建 runtime 层级**
+   - ❌ "BGHS 是 Layer 0-3 之上的第 5 层"
+   - ✅ BGHS 是声明里的分类字段
+
+3. **Meta artifact 不参与 BGHS 分类**
+   - ❌ 给一份 ADR 写 `primary_concern: Governance`
+   - ✅ ADR 用 Meta Declaration，无 primary_concern
+
+4. **Governance 不得因模型升级放松**
+   - ❌ "新模型更聪明了，这条 policy 可以删"
+   - ✅ 要放松必须走显式 ADR（Doctrine-level 改本 Doctrine；具体 policy/contract/guard 改其所属 contract ADR，见 D5），并显式 supersede 旧条款
+
+5. **Session 不是单一存储，且 session-adjacent 不是 session 本体**
+   - ❌ "所有 session 必须写到一个中央 session store"
+   - ❌ "receipts 就是 session 的一部分，一起查就行"
+   - ✅ authoritative session event streams 可多源（如 `data/traces/<engine>/<trace-id>/events.ndjson`、AGE `state_transitions.jsonl`）
+   - ✅ **receipts 是 session-adjacent**（由 P1-e 给出 taxonomy 区分），不得与 session 本体混为一谈
+   - ✅ 多源聚合与跨类型联合检索由 P1-e Federated Query 负责
+
+6. **混合组件不得无限混合**
+   - ❌ `primary: Brain, secondary: Governance, tertiary: Hands`
+   - ✅ 最多 primary + secondary，且必须声明 `future_split_direction`
+
+### §6. 审查清单（新组件/新 ADR 入库检查项）
+
+新 **Component** 入库前：
+- [ ] Component Declaration 完整（所有必填字段）
+- [ ] primary_concern 通过 §1 裁决规则验证
+- [ ] 混合组件已声明 future_split_direction
+- [ ] model_independent_invariants 明确列出
+- [ ] 如果声称 Session，`session_source_of_truth` 指向 authoritative session event stream（不是 receipts / session-adjacent）
+
+新 **ADR** 入库前：
+- [ ] Meta Declaration 头部完整
+- [ ] `artifact_role` 与内容匹配（doctrine / contract / harvest）
+- [ ] 如果是 `doctrine`，`is_bghs_doctrine: yes`；其他所有 ADR `is_bghs_doctrine: no`
+- [ ] 如果 supersede 旧 ADR / 旧条款，明确标注
+- [ ] 不在 ADR 里创建新的 BGHS 派生概念（如 BGHS 子目录、BGHS 层）
+
+---
+
+## 与 LiYe Systems 四层的关系
+
+```
+              ┌─────────────────────────────────────────────┐
+              │  BGHS（分类视角，正交于 Layer）               │
+              │  Brain · Governance · Hands · Session        │
+              └─────────────────────────────────────────────┘
+                           ↕ 正交
+┌──────────┬──────────┬──────────┬──────────┐
+│ Layer 0  │ Layer 1  │ Layer 2  │ Layer 3  │
+│ LiYe OS  │ Loamwise │ Engines  │ Products │
+└──────────┴──────────┴──────────┴──────────┘
+```
+
+- Layer 回答"**住在哪里**"
+- BGHS 回答"**本质是什么**"
+- 两者正交、各自独立、不互相替换
+
+**典型组合示例**：
+
+| Component | Layer | Primary Concern | 说明 |
+|-----------|-------|----------------|------|
+| `_meta/contracts/` | 0 | Governance | 制度不变量 |
+| `src/runtime/orchestrator/` | 0 | Brain | harness 逻辑，随模型可替换 |
+| `data/traces/` | 0 | Session | 外部化事件日志 |
+| `src/control/a3-write-policy.ts` | 0 | Governance | 跨模型不变的写白名单规则 |
+| `src/adapters/t1/` | 0 | Hands | 外部 agent 适配器 |
+| `loamwise/govern/guards/` | 1 | Governance | GuardChain（待建） |
+| `loamwise/construct/` | 1 | Brain (secondary: Governance) | 学习 harness + quarantine 审核 |
+| `AGE state_transitions.jsonl` | 2 | Session | 引擎事件日志 |
+
+---
+
+## 非目标
+
+- **不定义 Brain/Governance/Hands/Session 的实现**（由各 component 各自实现）
+- **不替换四层架构**（Layer 0-3 保持不变）
+- **不规定技术栈**（TypeScript / Python / YAML 均可）
+- **不规定目录命名**（除 §5 禁止项外，具体目录由各 repo 自定）
+- **不规定 ADR 编号策略**（由 `_meta/adr/` 维护规则决定）
+- **不处理具体 Engine/Skill/Guard 契约**（交给后续 contract ADRs）
+
+---
+
+## 后续实现入口
+
+| 阶段 | ADR / 位置 | 作用 |
+|------|-----------|------|
+| P1-a | `ADR-OpenClaw-Capability-Boundary.md` | harvest：引用本 doctrine 为 Layer 0 能力边界分类 |
+| P1-b | `ADR-Hermes-Skill-Lifecycle.md` | harvest：引用本 doctrine 的 Brain (candidate) vs Governance (quarantine) 分离 |
+| P1-c | `ADR-Hermes-Memory-Orchestration.md` | harvest：引用本 doctrine 的 Session 概念定义 |
+| P1-d | `ADR-Loamwise-Guard-Content-Security.md` | harvest：引用本 doctrine 的 Governance 不变量原则 |
+| P1-e | `ADR-Session-and-Session-Adjacent-Taxonomy-Federated-Query.md` | contract：定义 session / session-adjacent taxonomy，落实本 doctrine §5.5（Session 多源 + receipts 作为 session-adjacent 的联合检索） |
+| P1-f | `ADR-Credential-Mediation.md` | contract：实现 Component Declaration 的 `credential_path` |
+| P1-g | `ADR-AGE-Wake-Resume.md` | contract：实现 Component Declaration 的 `wake_resume_entrypoint` |
+| 入库纪律 | `_meta/portfolio/SYSTEMS.md` 运维纪律 | 新 Component 必附 Component Declaration；新 ADR 必附 Meta Declaration |
+
+**本 ADR 不实施任何代码**。
+
+---
+
+## Appendix A: 修订协议
+
+修改本 Doctrine 必须遵守：
+
+1. 新 Doctrine ADR supersede 旧条款（显式标注 `Supersedes: ADR-...`）
+2. 不得通过修改 `_meta/portfolio/SYSTEMS.md` 的 "架构原则" 章节来偷改 Doctrine——SYSTEMS.md 只复述，Doctrine 才是 SSOT
+3. 修订触发：
+   - BGHS 四分类扩展（如引入第 5 种 concern）
+   - Declaration 模板字段变更（含 `artifact_role` 枚举扩展）
+   - 禁止事项增删
+   - 裁决规则修订
+   - D5 修订分层规则的调整（Doctrine-level vs contract/policy 层的分工边界）
+
+---
+
+**Version**: 1.0.0
+**Last Updated**: 2026-04-16

--- a/_meta/adr/ADR-Credential-Mediation.md
+++ b/_meta/adr/ADR-Credential-Mediation.md
@@ -1,0 +1,606 @@
+---
+artifact_scope: meta
+artifact_name: Credential-Mediation
+artifact_role: contract
+target_layer: cross
+is_bghs_doctrine: no
+---
+
+# ADR — Credential Mediation（P1-f）
+
+**Status**: Accepted
+**Date**: 2026-04-16
+**Accepted-Date**: 2026-04-17
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-Credential-Mediation.md`
+**References**:
+- `_meta/adr/ADR-Architecture-Doctrine-BGHS-Separation.md`（Governance invariants；Component Declaration `credential_path` 单 URI 字段——本 ADR 不覆写它，另立 `credential_bindings` 承载多绑定）
+- `_meta/adr/ADR-OpenClaw-Capability-Boundary.md`（§4 TrustBoundaryDecl.credential_path 指向 CredentialBroker seam）
+- `_meta/adr/ADR-Hermes-Memory-Orchestration.md`（凭据绝不进入 MemoryTier）
+- `_meta/adr/ADR-Loamwise-Guard-Content-Security.md`（TruthWriteGuard 捕获凭据泄漏）
+- `_meta/adr/ADR-Session-and-Session-Adjacent-Taxonomy-Federated-Query.md`（凭据值绝不出现在 session / session-adjacent，仅审计事件记录访问）
+
+---
+
+## Context
+
+LiYe Systems 的任何 component 都可能需要访问凭据（API key / OAuth token / HMAC secret / DB 密码 / LLM provider key / 上游 vendor 令牌）。当前状态：
+
+- **liye_os**：`LIYE_HMAC_SECRET` / `NOTION_API_KEY` / `NOTION_DATABASE_ID` / `GEMINI_API_KEY` / `SLACK_BOT_TOKEN` 等散落在各子包的 `.env`（已 gitignore）
+- **amazon-growth-engine**：Amazon Advertising API 凭据（Refresh Token + Client ID/Secret）由 AGE 自身管理
+- **Loamwise（目标态）**：需要协调多个 engine 的凭据，本身不应持有任何 engine 的原始凭据
+
+**问题**：
+1. 没有统一的"凭据如何被获取"契约——每个 component 自行读 env 变量
+2. 没有防止凭据流入 MemoryTier / session 的统一拦截点
+3. 没有凭据访问的审计轨迹
+4. 未来 Loamwise 调用 AGE 写操作时，不应该让 AGE 的凭据经过 Loamwise 上下文
+
+**但也不应走另一个极端**：
+- 不引入中心化 Vault 基础设施（违反 SYSTEMS.md "明确不做"清单）
+- 不引入服务网格级密钥管理
+- 不要求所有 component 立刻迁移到同一存储后端
+
+**解决方案**：定义 **CredentialBroker seam**——一个最小的中介契约。`EnvCredentialBroker` 作为默认实现（沿用现有 env 变量模式）。未来可在 seam 之下接入 HashiCorp Vault / AWS Secrets Manager / 1Password 等，**但本 ADR 不立项 vault**。
+
+本 ADR 是 **contract 类**，回答"凭据中介的最小接口 + 访问纪律"，不实施任何存储后端。
+
+---
+
+## 现状盘点
+
+### S1. 现有凭据来源
+
+| Component | 凭据获取方式 | 存储位置 |
+|-----------|------------|---------|
+| liye_os gateway (HMAC) | `process.env.LIYE_HMAC_SECRET` | 本地 `.env`（gitignore） |
+| liye_os Notion sync | `process.env.NOTION_API_KEY` | `tools/notion-sync/.env` |
+| liye_os Slack proxy | `process.env.SLACK_BOT_TOKEN` 等 3 项 | `Extensions/slack-proxy/.env` |
+| liye_os Information Radar | `env.GEMINI_API_KEY` 等 | Cloudflare Worker `wrangler secret` |
+| AGE | 自管 Amazon Advertising credentials | AGE 内部 config / env |
+| Loamwise (目标) | 调用 AGE 时不应见到 AGE 凭据 | **尚无契约** |
+
+### S2. 现有的"必须避免"教训
+
+- **不得**让凭据值进入 `data/traces/` 或 session-adjacent audit log（P1-e 硬约束）
+- **不得**让凭据值进入 MemoryTier 任一层（P1-c 硬约束）
+- **不得**让凭据出现在 prompt 或 LLM 响应（P1-d TruthWriteGuard 捕获）
+- **不得**把凭据 hardcode 进代码或 CLAUDE.md
+
+### S3. 上游参考启发（非 harvest）
+
+| 来源 | 启发 |
+|------|------|
+| OpenClaw `CLAUDE.md` / docs | Plugin 不直接持有凭据，通过 core API 取用 |
+| Hermes `secret management` | 使用 env 变量 + `.env` + fail-closed |
+| AWS SDK 的 credential chain 模式 | Broker 可链式回退（先查本地 env，再查文件，再查其他） |
+
+---
+
+## 吸收 / 不吸收
+
+| 编号 | 吸收 | 理由 |
+|------|------|------|
+| **A1** | **CredentialReference（seam URI）** — component 声明它需要的凭据"名字"，不持有值 | Governance 边界：component 不应知道凭据从哪里来 |
+| **A2** | **EnvCredentialBroker 作为默认实现** — 沿用现有 env 变量模式 | 避免一次性重写所有 component；兼容现状 |
+| **A3** | **Broker 可链式回退**（env → file → other） | 兼容从 `.env` 渐进迁移到更高级存储 |
+| **A4** | **每次凭据访问写 session-adjacent audit 事件**（仅记录访问行为，不记录值） | Session 治理可见性；与 P1-e 一致 |
+| **A5** | **凭据值永不进入 MemoryTier / session / prompt / trace payload** | 与 P1-c/d/e 一致 |
+| **A6** | **Component 必须在 Component Declaration 中声明所需凭据**（**新字段** `credential_bindings: CredentialBinding[]`；本 ADR 不覆写 Doctrine 的 `credential_path: null \| string`——后者保留为单 URI 指针） | 与 P1-Doctrine Component Declaration + P1-a TrustBoundaryDecl 对接；不在本 ADR 内偷改 Doctrine schema |
+
+| 编号 | 不吸收 | 理由 |
+|------|--------|------|
+| **R1** | **中心化 Vault 基础设施**（HashiCorp Vault / AWS Secrets Manager 作为必选） | SYSTEMS.md "明确不做"清单；vault 作为 seam 之下的可选 broker 可以，但不立项 |
+| **R2** | **统一凭据存储迁移**（强迫所有 component 一次性迁移） | 违反"多源共存"纪律；broker seam 允许每个 component 独立迁移 |
+| **R3** | **凭据租借 / 动态颁发**（如 STS AssumeRole） | 可作为未来 broker 实现之一，但本 ADR 不定义租借语义 |
+| **R4** | **凭据 rotation 自动化**（自动轮换 / 自动失效重签） | rotation 归 broker 实现自由；seam 只要求 broker 能响应 "refresh/invalidate" 信号 |
+| **R5** | **Broker 自己做 approval / policy decision** | broker 只做"取值 + 审计"；access policy 归 P1-a DecisionAuthority / policy ADR |
+| **R6** | **Multi-tenant 凭据隔离** | 本 ADR 不处理 tenant；若需 tenant scope，由后续 capability ADR 扩展 CredentialReference |
+| **R7** | **LLM-driven 凭据选择**（"模型决定用哪个 key"） | 凭据选择由 CredentialReference 静态声明；LLM 无权选择 |
+| **R8** | **把 CredentialBroker 做成 Loamwise 唯一入口** | broker 是 seam，不是中心；每个 component 可有自己的 broker 实例 |
+
+---
+
+## 与 LiYe Systems 分层与 BGHS 的映射
+
+> 不再定义 BGHS 规则——见 P1-Doctrine §1。
+
+| 概念 | LiYe 视角 primary concern | 在 LiYe Systems 的对应位置 |
+|------|--------------------------|--------------------------|
+| CredentialReference（seam URI 格式） | **Governance** | Layer 0 — 本 ADR §1 |
+| CredentialBroker interface | **Governance** (contract) | Layer 0 — 本 ADR §2 |
+| EnvCredentialBroker 实现 | **Hands** | Layer 1 / Layer 2 / Layer 0（各自实例），default 库可放 liye_os |
+| 访问 policy / 授权 | **Governance** | Layer 0 DecisionAuthority（P1-a）+ 后续 policy ADR |
+| 凭据访问审计 | **Session** (access audit events) + **Governance** (审计规则) | 审计事件是 SESSION_ADJACENT.credential-audit（新子类，下见） |
+| Redaction utility（脱敏凭据值） | **Hands** | Layer 1 共享 utility（P1-d GuardEvidence 脱敏的堂兄） |
+
+**Layer 归属**：
+- **Layer 0（liye_os）**：定义 CredentialReference / CredentialBinding / CredentialBroker interface / CredentialAuditRecord 规范；提供 EnvCredentialBroker 默认实现作为 reference library
+- **Layer 1（loamwise）**：使用 broker 的 caller；**不持有 engine 凭据**；自身可有自己的 broker（用于 Loamwise 本身需要的 secrets）
+- **Layer 2（engines）**：各 Engine 通过 broker 取自己需要的凭据；不向外暴露凭据值
+- **Layer 3（products）**：不直接使用 broker（通过 Layer 2 Engine 或 Layer 1 调度）
+
+**容易错判**：
+
+| 容易错判 | 正确判法 |
+|---------|---------|
+| 把 EnvCredentialBroker 判为 Governance（"它管 env 变量") | 具体存储后端 → Hands；"必须有 broker seam" 这条规则 → Governance |
+| 把凭据访问审计判为 Brain 输出（"它是推理产物") | 审计是事实 → Session (SESSION_ADJACENT.credential-audit) |
+| 把 CredentialReference / credential_bindings 字段判为 Hands（"它指向实际位置") | reference URI 与绑定声明 = Governance 契约；broker 解析过程 → Hands |
+
+---
+
+## Mediation Rules（裁判手册）
+
+### M1. 凭据流向三条硬底线
+
+**不得出现凭据值**的位置（fail-closed，违反 = 架构违规）：
+
+| 位置 | 约束来源 |
+|------|---------|
+| MemoryTier 任何一层 | P1-c §1 + §5 MemoryUsePolicy |
+| SessionEventStream.payload | P1-e F1 + 本 ADR M4 redaction |
+| SessionAdjacentArtifact 除 CREDENTIAL_AUDIT 外的任何子类 | 本 ADR M4 |
+| Prompt 装配（frozen snapshot） | P1-c O5 + P1-d ContextInjectGuard |
+| Code / CLAUDE.md / ADR / 任何版本化文件 | pre-commit hook（hands） + Guards |
+| Error message / log output（除显式脱敏） | 本 ADR M4 |
+
+**允许出现凭据值**的位置（仅此 3 处）：
+
+1. CredentialBroker 内部（受 broker 自身信任边界保护）
+2. 存储后端（env / file / vault / etc.）
+3. Consumer 的 in-memory 使用期（**短期、不持久化**，使用完毕立刻释放）
+
+### M2. Component 声明 credential_bindings，不直接读凭据
+
+- 任何 component 不得直接 `process.env.XXX_KEY` 读取凭据（例外见 M7）
+- Component 必须在 Component Declaration 的 **`credential_bindings` 字段**（本 ADR 新增；不覆写 Doctrine 既有的 `credential_path`）声明一个或多个 CredentialBinding
+- 运行时通过 CredentialBroker 解析 CredentialReference 获取凭据值
+- Doctrine 既有的 `credential_path: null | string` 字段保留为**单 URI 指针**语义；承载多绑定（带 purpose / broker_required）= 本 ADR 新增的 `credential_bindings`
+
+### M3. Broker 是 seam，每个 component 可有自己的 broker
+
+- LiYe Systems **不要求**所有 component 使用同一个 broker 实例
+- 允许 Loamwise 有自己的 broker（取 Loamwise 自己的 secrets）
+- 允许 AGE 有自己的 broker（取 Amazon Advertising 凭据）
+- Loamwise 调用 AGE 时**绝不代管 AGE 凭据**——AGE 在自己进程内用自己的 broker
+
+### M4. Redaction 是强制工具，不是可选优化
+
+- 凭据值在任何离开 broker 的路径上必须经过 redaction（hash / 截断 / masked placeholder）
+- Redaction 必须在**值离开 broker** 之前完成（而不是在下游 log sink 里补救）
+- Redaction 后的结果（如 `cred://liye-os/notion-api-key:***:sha256=abc...`）可出现在 SESSION_ADJACENT.credential-audit；**原始值永不出现**
+
+### M5. 每次凭据访问写 credential-audit 事件
+
+- 每次 `broker.resolve(ref)` 成功或失败都必须写一条 SESSION_ADJACENT.credential-audit 事件
+- 事件包含：`credential_path` / `requester_component_id` / `requested_at` / `outcome: 'resolved' | 'denied' | 'not-found' | 'broker-error'` / `redacted_value_hint`（永不包含值）
+- Audit 事件属 session-adjacent，append-only
+
+### M6. Broker 可链式回退，但每一跳都独立审计
+
+- Broker 可声明 fallback chain（如：env → file → parent-broker）
+- 每一跳都独立写 audit 事件，标注 `chain_step` 与 `chain_result`
+- 任何一跳返回值即终止；全链未命中 = fail-closed
+
+### M7. 引导期特权仅限 Layer 0 bootstrap
+
+- 仅有一类例外可直接读 env：**Layer 0 自身的 bootstrap**（创建第一个 broker 实例所需的 broker 自身配置，如 "broker 到哪里读 secrets"）
+- 此例外范围窄：**只读 "broker 自身配置"**，**不读任何 component 的业务凭据**
+- bootstrap 路径必须在 Layer 0 显式声明，并写入 audit
+- **所有 bootstrap access 的 audit 事件必须带固定 purpose 常量**：`purpose = "broker-bootstrap"`
+  - 便于后续查审计时把 bootstrap 类访问与普通 resolve 清晰分开
+  - 任何 `purpose = "broker-bootstrap"` 但 `requester_layer ≠ 0` 的 audit 事件 = 架构违规信号，validator / audit 扫描器应报警
+
+### M8. Broker policy 独立，不耦合进 broker 实现
+
+- Broker **只做**"取值 + 审计"
+- 是否允许某 component 访问某凭据 = **policy 决策**，归 P1-a DecisionAuthority
+- Broker 在 resolve 前调用 policy 接口（若 policy 拒绝 = 返回 denied + 审计）
+- 这样 broker 实现可独立演化，policy 也可独立演化
+
+### M9. 凭据值的生存期最短
+
+- Consumer 使用完凭据值应**立刻**从内存释放（置 null / overwrite buffer）
+- 长期持有凭据（如 HTTP client 持有 auth header）应尽量用短期 token（由 broker 或存储后端颁发）
+- Broker 可支持 `refresh` / `invalidate` 信号（R4 提到的不自动化 rotation，但 seam 允许接入）
+
+---
+
+## Contract Sketch
+
+### §1. CredentialReference（seam URI）
+
+```typescript
+// 格式：cred://<owner>/<name>[?<qualifier>=<value>&...]
+// 示例：
+//   cred://liye-os/notion-api-key
+//   cred://liye-os/hmac-secret
+//   cred://amazon-growth-engine/ads-api-refresh-token?marketplace=US
+//   cred://loamwise/internal-service-token
+
+type CredentialReference = string  // 形如 "cred://owner/name[?qualifier=value]"
+
+interface ParsedCredentialRef {
+  scheme: 'cred'                    // 固定
+  owner: string                     // 拥有此凭据的 component（注册时匹配 Component Declaration）
+  name: string                      // 凭据逻辑名（不是值，也不是存储后端的 key 名）
+  qualifiers: Record<string, string>
+}
+
+// 命名约束（validator 强制）：
+//   - owner 必须是一个已注册的 Component Declaration component_name
+//   - name 必须仅含 [a-z0-9-]，长度 3-64
+//   - 不得包含存储后端信息（如 env 变量名）—— 那是 broker 内部映射的事
+```
+
+### §2. CredentialBroker interface
+
+```typescript
+interface CredentialBroker {
+  broker_id: string                 // 本 broker 实例的唯一 id
+  declared_scope: BrokerScope       // 本 broker 服务哪些 owner
+
+  // 主入口
+  resolve(
+    ref: CredentialReference,
+    ctx: ResolutionContext,
+  ): Promise<ResolutionResult>
+
+  // 可选：rotation / invalidation 信号（不强制实现）
+  invalidate?(ref: CredentialReference): Promise<void>
+  refresh?(ref: CredentialReference): Promise<void>
+
+  // 审计注入点：broker 实现必须调用此接口写 SESSION_ADJACENT.credential-audit
+  // 具体接口由 audit 子系统提供（与 P1-e 对接）
+  readonly audit_sink: CredentialAuditSink
+}
+
+interface BrokerScope {
+  owners_served: string[]           // 本 broker 可服务的 owner 列表
+  layer: 0 | 1 | 2                  // broker 所在层（Layer 3 不应有 broker）
+}
+
+interface ResolutionContext {
+  requester_component_id: string    // 调用方 component（用于审计 + policy）
+  requester_layer: 0 | 1 | 2 | 3
+  purpose: string                   // 为什么要这个凭据（用于审计，可读）
+  authorization_ref: string | null  // 引用此次访问的授权证据（v1 允许 null）
+                                    //
+                                    // v1 可填入：
+                                    //   - 引用某 policy ADR / 应急流程 ADR 的路径
+                                    //   - 引用已有的 manual approval record id
+                                    //   - null（仅当后续 policy 接口判定不需要显式授权时）
+                                    //
+                                    // 未来（P1-a 扩展后）：引用 DecisionKind.CREDENTIAL_ACCESS
+                                    //   的 DecisionAuthority 记录——届时 null 不再可接受，
+                                    //   由 policy ADR 显式收紧为必填
+}
+
+type ResolutionResult =
+  | { outcome: 'resolved';    value: SecretValue;          audit_id: string }
+  | { outcome: 'denied';      denial_reason: string;       audit_id: string }
+  | { outcome: 'not-found';                                audit_id: string }
+  | { outcome: 'broker-error'; error: string;              audit_id: string }
+
+// SecretValue 是一个不可 stringify 的值包裹，强制 consumer 显式 reveal
+// 防止意外序列化 / 日志输出
+interface SecretValue {
+  reveal(): string                  // 显式调用才拿到真值
+  toJSON(): '***REDACTED***'        // JSON 序列化时自动脱敏
+  toString(): '***REDACTED***'      // 字符串化时自动脱敏
+}
+```
+
+### §3. EnvCredentialBroker（default 实现示意）
+
+```typescript
+class EnvCredentialBroker implements CredentialBroker {
+  broker_id: string
+  declared_scope: BrokerScope
+  readonly audit_sink: CredentialAuditSink
+
+  // Broker 内部维护一个静态映射：CredentialReference → env 变量名
+  // 这个映射由 broker 的构造参数提供，不暴露给 consumer
+  private env_map: Record<string, string>    // e.g., { "cred://liye-os/notion-api-key": "NOTION_API_KEY" }
+
+  async resolve(
+    ref: CredentialReference,
+    ctx: ResolutionContext,
+  ): Promise<ResolutionResult> {
+    // M8: 先查 policy
+    const policy = await checkPolicy(ref, ctx)
+    if (policy.denied) {
+      const audit_id = await this.audit_sink.append({
+        credential_path: ref,
+        requester_component_id: ctx.requester_component_id,
+        outcome: 'denied',
+        chain_step: 0,
+        chain_result: 'policy-denied',
+      })
+      return { outcome: 'denied', denial_reason: policy.reason, audit_id }
+    }
+
+    // 查 env 映射
+    const envKey = this.env_map[ref]
+    if (!envKey) {
+      const audit_id = await this.audit_sink.append({
+        credential_path: ref,
+        requester_component_id: ctx.requester_component_id,
+        outcome: 'not-found',
+        chain_step: 0,
+        chain_result: 'no-mapping',
+      })
+      return { outcome: 'not-found', audit_id }
+    }
+
+    const raw = process.env[envKey]
+    if (!raw) {
+      const audit_id = await this.audit_sink.append({
+        credential_path: ref,
+        requester_component_id: ctx.requester_component_id,
+        outcome: 'not-found',
+        chain_step: 0,
+        chain_result: 'env-unset',
+      })
+      return { outcome: 'not-found', audit_id }
+    }
+
+    // M4: redaction hint 写 audit（不写值本身）
+    const audit_id = await this.audit_sink.append({
+      credential_path: ref,
+      requester_component_id: ctx.requester_component_id,
+      outcome: 'resolved',
+      chain_step: 0,
+      chain_result: 'env-hit',
+      redacted_value_hint: `sha256:${sha256(raw).substring(0, 12)}...`,
+    })
+    return {
+      outcome: 'resolved',
+      value: wrapSecret(raw),
+      audit_id,
+    }
+  }
+}
+```
+
+### §4. CredentialAuditRecord（SESSION_ADJACENT 子类 CREDENTIAL_AUDIT）
+
+```typescript
+// 本 ADR 向 P1-e §1 SessionAdjacentKind 新增一个子类：CREDENTIAL_AUDIT
+
+// SessionAdjacentKind.CREDENTIAL_AUDIT = 'credential-audit'
+
+interface CredentialAuditRecord {
+  // SessionAdjacentArtifact 必填字段（P1-e §3）
+  artifact_id: string
+  adjacent_kind: 'credential-audit'
+  owner: { component_id: string; layer: 0 | 1 | 2 }
+  derived_from: ArtifactRef[]        // 必须非空，引用触发本次访问的 session event
+  audit_subject: null                // CREDENTIAL_AUDIT 不是 QUERY_AUDIT
+  storage_location: string
+  format_kind: 'ndjson' | 'json'
+  is_append_only: true
+  hash_self: string
+  created_at: string
+  registered_by_adr: 'ADR-Credential-Mediation'
+
+  // CREDENTIAL_AUDIT 专用 payload
+  credential_path: CredentialReference
+  requester_component_id: string
+  requester_layer: 0 | 1 | 2 | 3
+  purpose: string                    // 人类可读，不含 secret
+  outcome: 'resolved' | 'denied' | 'not-found' | 'broker-error'
+  chain_step: number                 // M6 fallback chain 中的第几跳
+  chain_result: string               // e.g., 'env-hit' / 'file-hit' / 'env-unset' / 'policy-denied'
+  redacted_value_hint: string | null // 仅 resolved 时填，且必须脱敏（hash 前缀 / masked placeholder）
+  authorization_ref: string | null   // 引用此次访问的授权证据（v1 允许 null，与 ResolutionContext.authorization_ref 一致）
+                                     // 未来 DecisionKind.CREDENTIAL_ACCESS 落地后由 policy ADR 收紧为必填
+
+  // 生命周期
+  broker_id: string
+  resolved_at: string
+}
+
+interface CredentialAuditSink {
+  append(r: Omit<CredentialAuditRecord, 'artifact_id' | 'hash_self' | 'created_at' | 'adjacent_kind' | 'owner' | 'storage_location' | 'format_kind' | 'is_append_only' | 'derived_from' | 'audit_subject' | 'registered_by_adr'>): Promise<string>
+  // 返回 audit_id
+}
+```
+
+### §5. 与 Component Declaration 对接（P1-Doctrine §2 + P1-a §4）
+
+**字段关系（不覆写 Doctrine）**：
+
+| 字段 | 所属 | 类型 | 语义 |
+|------|------|------|------|
+| `credential_path` | **P1-Doctrine Component Declaration（既有）** | `null \| string` | 单 URI 指针；指向一条 CredentialReference 或 broker seam 入口。**本 ADR 不覆写其类型** |
+| `credential_bindings` | **本 ADR 新增**（optional 字段） | `CredentialBinding[]` | 承载多绑定，每条带 `ref / purpose / broker_required` |
+
+Component 可二选一或并用：简单场景用 `credential_path`（单一凭据指针）；复杂场景用 `credential_bindings`（多绑定 + purpose）。两个字段共存时，`credential_bindings` 是**规范表达**，`credential_path` 仅作简写指针。
+
+**CredentialBinding schema**：
+
+```typescript
+interface CredentialBinding {
+  ref: CredentialReference              // 形如 cred://owner/name[?q=v]
+  purpose: string                       // 人类可读用途描述
+  broker_required: 'any' | string       // 'any' 或指向某个具体 broker_id
+}
+```
+
+```yaml
+# Component Declaration 中 credential_bindings 字段用法（示例）
+artifact_scope: component
+component_name: amazon-growth-engine
+layer: 2
+primary_concern: Hands
+# ...
+credential_path: null                   # Doctrine 既有字段；本示例不使用
+credential_bindings:                    # 本 ADR 新增字段
+  - ref: cred://amazon-growth-engine/ads-api-refresh-token
+    purpose: "Amazon Advertising API access"
+    broker_required: any                # 任何满足 declared_scope 的 broker
+  - ref: cred://amazon-growth-engine/ads-api-client-secret
+    purpose: "Amazon Advertising OAuth client"
+    broker_required: any
+# ...
+```
+
+**validator 强制**：
+- 若声明 `credential_bindings`，必须为 `CredentialBinding[]` 形式（数组）
+- 每个 binding 的 `ref.owner` 必须等于当前 `component_name`（不允许声明别人的凭据）
+- 对应的 broker 必须可 resolve（启动时 self-test，但不 reveal 值）
+- Doctrine 既有的 `credential_path` 字段保持 `null | string` 类型约束——本 ADR **不**把它改成数组
+
+### §6. SecretValue（防意外泄漏包装）
+
+**Contract-level 要求（语言中立）**：
+
+任何 broker 实现的 `ResolutionResult` 若返回 `outcome: 'resolved'`，其 `value` 必须满足：
+
+1. **默认序列化必须 redacted**：对应语言的默认 stringify / JSON serialize / debug-print / inspect 路径，产出必须是 masked placeholder（例如 `***REDACTED***`），**不得**产出原值
+2. **需显式 reveal 才能取值**：必须存在一个显式命名的方法（如 `reveal()` / `unwrap()` / `getSecret()`），consumer 调用该方法才能获得原值；没有该显式调用 = 拿不到原值
+3. **原值生存期最短**：reveal 返回的原值由 consumer 负责尽快释放（与 M9 一致）
+
+语言特定实现自行选择具体机制（可能是 class + override、proxy、struct + method 等）。**Contract 层不规定具体语言构造**。
+
+---
+
+**Implementation example (Node.js / TypeScript)**：
+
+```typescript
+function wrapSecret(raw: string): SecretValue {
+  return {
+    reveal: () => raw,
+    toJSON: () => '***REDACTED***' as const,
+    toString: () => '***REDACTED***' as const,
+    // 语言特定：Node.js util.inspect 自定义钩子
+    [Symbol.for('nodejs.util.inspect.custom')]: () => '***REDACTED***',
+  }
+}
+
+// Consumer 必须显式 reveal 才能拿到值（防止意外日志 / JSON 序列化泄漏）
+const result = await broker.resolve(ref, ctx)
+if (result.outcome === 'resolved') {
+  const secret = result.value.reveal()    // 显式取值
+  try {
+    await useSecret(secret)               // 短期使用（M9）
+  } finally {
+    // Consumer 有责任在使用后尽快丢弃引用
+  }
+}
+```
+
+Python / Rust / Go 等语言有各自的 default-repr 机制（如 Python `__repr__` / `__str__`，Rust `Debug` / `Display` trait），实现必须在本语言内覆盖这些默认路径，达到上述 Contract-level 要求。
+
+### §7. Validator
+
+```typescript
+function validateCredentialRef(ref: string): ParsedCredentialRef {
+  const m = ref.match(/^cred:\/\/([a-z0-9-]+)\/([a-z0-9-]{3,64})(\?.*)?$/)
+  if (!m) throw new Error('invalid_cred_ref_format')
+  // 进一步：owner 必须是已注册的 component_name
+  if (!componentRegistry.hasComponent(m[1])) throw new Error('unknown_owner')
+  return { scheme: 'cred', owner: m[1], name: m[2], qualifiers: parseQualifiers(m[3]) }
+}
+
+function validateComponentDeclaration(decl: ComponentDeclaration): void {
+  // Doctrine 既有字段 credential_path: null | string —— 仅校验格式，不展开数组
+  if (decl.credential_path) {
+    const parsed = validateCredentialRef(decl.credential_path)
+    if (parsed.owner !== decl.component_name) {
+      throw new Error('credential_path_owner_must_match_component_name')
+    }
+  }
+  // 本 ADR 新增字段 credential_bindings: CredentialBinding[]
+  if (decl.credential_bindings) {
+    for (const cb of decl.credential_bindings) {
+      const parsed = validateCredentialRef(cb.ref)
+      if (parsed.owner !== decl.component_name) {
+        throw new Error('credential_binding_owner_must_match_component_name')
+      }
+      if (!cb.purpose || cb.purpose.length === 0) {
+        throw new Error('credential_binding_purpose_required')
+      }
+    }
+  }
+}
+```
+
+---
+
+## Non-goals
+
+- **不实施 §1-§7 的代码**——本 ADR 仅定义 seam contract
+- **不立项 Vault 基础设施**（R1 + SYSTEMS.md "明确不做"）
+- **不定义 STS / AssumeRole / 短期 token 颁发语义**（R3）
+- **不定义 rotation 自动化**（R4）
+- **不处理 multi-tenant 凭据隔离**（R6）
+- **不定义具体存储后端**（除 EnvCredentialBroker 默认实现外，file / vault / OAuth 等都不立项）
+- **不修改任何 component 的现有 env 读取代码**——迁移由各 component 在 `credential_bindings` 声明入库时自行推进
+- **不定义 CredentialBroker 之间的"代理 / 联邦"**——broker seam 明示允许每个 component 独立 broker
+
+---
+
+## Adoption Checkpoints
+
+| Checkpoint | 触发时机 | 验证项 |
+|-----------|---------|-------|
+| **C1. 本 ADR + P1-a/b/c/d/e 六件就位** | 本 ADR 通过后 | 六份 ADR 互引一致；SYSTEMS.md 引用本 ADR 为 Credential Mediation SSOT |
+| **C2. CredentialReference 格式冻结** | 第一个 component 声明 `credential_bindings` 时 | `cred://<owner>/<name>[?<qualifier>=<value>]` 格式由 schema 强制；validator 就绪 |
+| **C3. EnvCredentialBroker default 库就位** | Loamwise / AGE 任一 component 迁移前 | liye_os 提供 reference impl；`env_map` 由 broker 配置注入，不出现在 component 代码 |
+| **C4. SessionAdjacentKind.CREDENTIAL_AUDIT 入 P1-e 枚举** | **本 ADR 通过同时（同批 commit）执行 P1-e companion patch** | P1-e §1 SessionAdjacentKind 扩展一项 `CREDENTIAL_AUDIT`；由本 P1-f（contract ADR）驱动 P1-e 的小修订（**不修 Doctrine**；两份 ADR 不得对同一枚举表述不一致） |
+| **C5. SecretValue 包装强制** | 任何 broker 实现 resolve 时 | 返回值必须经 wrapSecret；默认 stringify / serialize 必须 redacted（具体语言机制见 §6 implementation example） |
+| **C6. Component Declaration `credential_bindings` 格式收紧** | 任何 component 首次声明 credential_bindings 时 | validator 强制 owner 匹配 + ref 格式正确 + purpose 非空 + broker 可 resolve（self-test）；Doctrine 既有 `credential_path: null \| string` 仅做格式校验，不展开数组 |
+| **C7. 现有硬编码 env 读取渐进迁移** | 各 component 自行推进 | 不强制 deadline；但新增 component 必须走 broker；老 component 在重大改动时迁移 |
+
+**本 ADR 不实施任何代码**。
+
+---
+
+## Appendix A: 与 P1-a / P1-c / P1-e 的对接（明示）
+
+### 与 P1-a 对接
+
+| P1-a 字段 | 本 ADR 对应 |
+|----------|------------|
+| `TrustBoundaryDecl.credential_path: string \| null` | 本 ADR §1 CredentialReference；格式 `cred://...` |
+| `DecisionAuthority` kind 中**未列出** credential access | 访问授权归 P1-a DecisionAuthority 的后续扩展（新增 DecisionKind.CREDENTIAL_ACCESS 属 contract ADR 范围，不改 Doctrine） |
+
+### 与 P1-c 对接
+
+- 凭据值**永不进入** MemoryTier 任一层（P1-c §1 + 本 ADR M1）
+- `redacted_value_hint` 可出现在 audit 但**不是** memory
+
+### 与 P1-e 对接
+
+- 本 ADR 向 P1-e §1 SessionAdjacentKind 新增 `CREDENTIAL_AUDIT = 'credential-audit'` 子类
+- CREDENTIAL_AUDIT 的 `derived_from` 必须非空（与 QUERY_AUDIT 不同，后者可为空）
+- CREDENTIAL_AUDIT 的 `audit_subject` 必为 null（QUERY_AUDIT 专用）
+
+### 与 P1-d 对接
+
+- TruthWriteGuard 在扫描 authoritative 写入时**必须检测凭据泄漏模式**（sk-... / secret_... / Bearer ... 等）
+- Guard 命中凭据泄漏 = dangerous verdict（硬 block）
+- Guard 不得把捕获的凭据写入 GuardEvidence payload——必须 redact
+
+---
+
+## Appendix B: 现有资产迁移路径（NON-NORMATIVE）
+
+| Component | 当前凭据 | 未来 CredentialReference | 迁移优先级 |
+|-----------|---------|-------------------------|-----------|
+| liye_os gateway | `LIYE_HMAC_SECRET` | `cred://liye-os/hmac-secret` | 中（已隔离在 .env） |
+| liye_os Notion sync | `NOTION_API_KEY`, `NOTION_DATABASE_ID` | `cred://liye-os/notion-api-key`, `cred://liye-os/notion-database-id` | 低 |
+| liye_os Slack proxy | `SLACK_BOT_TOKEN` 等 3 项 | `cred://liye-os/slack-bot-token` 等 | 低 |
+| liye_os Information Radar | `GEMINI_API_KEY` 等 | `cred://liye-os/gemini-api-key` 等 | 低（已在 Cloudflare secret） |
+| AGE | Ads API Refresh Token + Client ID/Secret | `cred://amazon-growth-engine/ads-api-refresh-token`, `cred://amazon-growth-engine/ads-api-client-secret`, `cred://amazon-growth-engine/ads-api-client-id` | 高（D0→D1 时应完成） |
+| Loamwise（目标） | 未定 | `cred://loamwise/internal-service-token`（自己的 secrets） | 新建即按此 |
+
+**迁移不要求一次完成**。任何 component 的下次重大改动是合适的迁移窗口。
+
+---
+
+**Version**: 1.0.0
+**Last Updated**: 2026-04-16

--- a/_meta/adr/ADR-Hermes-Memory-Orchestration.md
+++ b/_meta/adr/ADR-Hermes-Memory-Orchestration.md
@@ -1,0 +1,521 @@
+---
+artifact_scope: meta
+artifact_name: Hermes-Memory-Orchestration
+artifact_role: harvest
+target_layer: 1
+is_bghs_doctrine: no
+---
+
+# ADR — Hermes Memory Orchestration（P1-c）
+
+**Status**: Accepted
+**Date**: 2026-04-16
+**Accepted-Date**: 2026-04-17
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-Hermes-Memory-Orchestration.md`
+**References**:
+- `_meta/adr/ADR-Architecture-Doctrine-BGHS-Separation.md`（必读前置）
+- `_meta/adr/ADR-OpenClaw-Capability-Boundary.md`（capability 边界）
+- `_meta/adr/ADR-Hermes-Skill-Lifecycle.md`（lifecycle 治理参照）
+- **Forward ref**: `_meta/adr/ADR-Session-and-Session-Adjacent-Taxonomy-Federated-Query.md`（P1-e，提供 session / adjacent 分类与 federated query）
+**Source**: `/Users/liye/github/hermes-agent/`（fork 自 `NousResearch/hermes-agent`，只读参考）
+
+---
+
+## Context
+
+LLM-driven 系统的"记忆"不是单一概念。它至少包含：
+- 当前会话的事件流（session 本体）
+- 上一轮决策留下的回执（session-adjacent）
+- 跨会话沉淀的笔记 / 摘要（user/MEMORY 文件）
+- 跨会话索引可检索的历史（FTS / 向量）
+- 治理性常驻物（contracts / policies / ADRs / verdicts）
+
+Hermes Agent 提供了一套相对成熟的 memory orchestration 实现：provider 抽象、lifecycle hooks、per-turn prefetch、frozen snapshot、tool-based 检索路由。它的"如何把记忆装配进上下文"这一面值得吸收。
+
+但 Hermes 的产品形态把"记忆"几乎等同于"用户对话历史 + 用户画像"，这是 chat agent 的合理选择，**不适用于 LiYe Systems**——LiYe 的决策必须以**结构化真相**（contracts / policies / verdicts / authoritative events）为准，会话文本永远是辅助。
+
+本 ADR 萃取 Hermes 的 orchestration discipline，回答**编排**问题：
+- 记忆何时被装配进上下文
+- 哪些记忆能参与决策、哪些只能做提示材料
+- 检索 / 摘要 / 压缩的决策权归谁
+- 编排的 lifecycle 谁负责
+
+**本 ADR 不重新定义 session vs session-adjacent 的分类**——那是 P1-e 的领地。本 ADR 假定 P1-e 的 taxonomy 已存在，只描述编排接口。
+
+---
+
+## 上游核心做法（Hermes 的 orchestration 模型）
+
+### H1. MemoryProvider 抽象 + lifecycle hooks
+
+`/Users/liye/github/hermes-agent/agent/memory_provider.py` 定义 `MemoryProvider` ABC：
+
+```
+initialize() → prefetch() → sync_turn() → shutdown()
+```
+
+可选 hooks：`on_pre_compress` / `on_memory_write` / `on_delegation`。每个 provider 在不同生命周期点接收事件并贡献内容。
+
+### H2. MemoryManager 中心编排
+
+`/Users/liye/github/hermes-agent/agent/memory_manager.py` 实现 manager：
+- 注册 provider
+- 编排 lifecycle 调用顺序
+- 路由 tool 调用到对应 provider
+- 实施 context fencing（防止 provider A 的内容污染 provider B 的上下文）
+
+### H3. Per-turn prefetch + frozen snapshot
+
+`run_agent.py` 在每轮开始时调用 `prefetch()`，把"本轮要用的记忆内容"冻结为 snapshot 注入 system prompt。**snapshot 在该轮内不可变**——这是 prefix cache 稳定性的前提。
+
+### H4. MemoryStore 文件后端 + 安全扫描
+
+`/Users/liye/github/hermes-agent/tools/memory_tool.py`：
+- bounded 文件后端（MEMORY.md / USER.md，带大小上限）
+- 写入时做 injection / exfiltration 扫描
+- 原子写（temp file → fsync → rename）
+
+### H5. session_search_tool（FTS5 + LLM 摘要）
+
+`/Users/liye/github/hermes-agent/tools/session_search_tool.py`：
+- FTS5 全文索引跨会话搜索
+- 检索结果交 LLM 做 summarization
+- 感知 delegation chain（subagent 调用 chain）
+
+### H6. Honcho provider（用户建模 / dialectic Q&A）
+
+`/Users/liye/github/hermes-agent/plugins/memory/honcho/__init__.py`：
+- 维护 user 心智模型
+- 提供 3 种 recall mode
+- 暴露 peer cards（多用户）
+
+**全部为 Hermes 产品形态服务，与 LiYe Systems 决策结构错配**——见 R1-R2。
+
+### H7. 系统提示装配顺序（system prompt assembly）
+
+`run_agent.py` 严格的装配顺序：
+- 静态 system instructions
+- provider prefetch 内容
+- 当前任务上下文
+- tool definitions
+
+顺序固定，避免不同来源相互覆盖。
+
+---
+
+## 吸收什么
+
+| 编号 | 吸收项 | 理由 |
+|------|-------|------|
+| **A1** | **Provider 抽象**（统一接口 + 可插拔后端） | Brain harness 解耦于具体 store；新来源只需实现 interface |
+| **A2** | **Lifecycle hooks**（initialize / prefetch / sync / shutdown / on_pre_compress / on_memory_write） | 编排点显式化，便于 Governance 在 hook 上挂检查 |
+| **A3** | **Per-turn prefetch + frozen snapshot** | prefix cache 稳定性 + 决策可 replay 的前提（同一轮看到同一份记忆） |
+| **A4** | **Context fencing**（provider 之间不互相串） | 防止 context-only 记忆污染 decision-support 通道 |
+| **A5** | **写入时 injection / exfiltration 扫描** | Governance 落点：所有记忆写入必须经 GuardChain（与 P1-d 对接） |
+| **A6** | **Bounded 文件后端 + 原子写** | Hands 实现的最小契约；防止部分写入污染 |
+| **A7** | **System prompt assembly 顺序固定** | Brain harness 的合理纪律，避免顺序不定带来的不确定性 |
+
+---
+
+## 不吸收什么
+
+| 编号 | 不吸收项 | 理由 |
+|------|---------|------|
+| **R1** | **Honcho 重用户建模**（dialectic Q&A / peer cards） | LiYe Systems 的"用户"不是 chat 终端用户；产品形态错配，且与 SYSTEMS.md "明确不做"清单一致 |
+| **R2** | **"Chat history first" 检索默认** | LiYe 决策检索默认 **truth-first**：结构化真相 → 事件流 → 摘要笔记 → 会话文本（最后） |
+| **R3** | **LLM summarization 作为权威输出** | 摘要只能进入 `decision-support` 或 `context-only` 通道，不得提升为 `authoritative`（见 §Orchestration Rules O3） |
+| **R4** | **Smart routing**（"模型自己决定查哪里"） | 检索路由由 MemoryAssemblyPlan 静态声明 + Governance 校验，不允许由 LLM 自由探索 |
+| **R5** | **Auto-merge / auto-rewrite memory** | 任何对 authoritative 记忆的修改都必须走对应 contract / ADR；普通 provider 不得改写 authoritative |
+| **R6** | **per-turn sync 直接落盘 user-modeling 状态** | sync 只能写入 session-adjacent receipts，不得在轮内改写跨会话的"用户画像" |
+| **R7** | **Tool-driven 任意检索**（agent 用工具想搜哪就搜哪） | 检索必须在 MemoryAssemblyPlan 声明的范围内；越界 = GuardChain 拒绝 |
+| **R8** | **Hermes "memory tool" 同时承担读 / 写 / 删** | 写入必须走专门的 MemoryWriteRequest（带 PromotionDecision 等同地位的 audit） |
+
+---
+
+## 与 LiYe Systems 分层与 BGHS 的映射
+
+> 不再定义 BGHS 规则——见 P1-Doctrine §1。本节给出 Hermes memory 组件在 LiYe 视角下的归类。
+
+| Hermes 组件 | LiYe 视角 primary concern | 在 LiYe Systems 的对应位置 |
+|------------|--------------------------|--------------------------|
+| MemoryProvider ABC（抽象接口） | **Brain** | Loamwise `align/` 的 harness 接口契约 |
+| MemoryManager（编排器） | **Brain** (secondary: Governance) | Loamwise `align/orchestrator/` |
+| Per-turn prefetch + frozen snapshot | **Brain** | Loamwise harness，但 frozen snapshot 字段约束属 Layer 0 contract |
+| MemoryStore（文件后端） | **Hands** | Layer 1/2 各 component 自己的存储 adapter |
+| 写入时安全扫描 | **Governance** | Layer 1 GuardChain（由 P1-d 落地） |
+| session_search_tool（FTS5） | **Hands** | Loamwise `align/retrieval/` 的实现适配器 |
+| LLM summarization 决策 | **Brain** | Loamwise harness |
+| Honcho user modeling | — | **不吸收**（R1） |
+| Memory tier classification（authoritative/decision-support/context-only） | **Governance** | Layer 0 — 本 ADR Contract Sketch §1 定义 |
+| Memory use policy（哪种 tier 能驱动哪种决策） | **Governance** | Layer 0 — 本 ADR + 后续 policy ADR |
+
+**Layer 归属（与 SYSTEMS.md 一致）**：
+- **Layer 0（liye_os）**：定义 `MemoryTier` 枚举、`MemoryRecord` schema、`MemoryUsePolicy` 契约、检索 priority 接口
+- **Layer 1（loamwise）**：实施 MemoryManager、provider 编排、retrieval 路由、frozen snapshot 装配
+
+**容易错判的点**：
+
+| 容易错判 | 正确判法 |
+|---------|---------|
+| 把"会话历史摘要"判为 `authoritative`（"摘要是事实"） | 摘要 = LLM 输出 = `decision-support` 上限；`authoritative` 仅给 contracts / verdicts / authoritative events |
+| 把 MemoryProvider 接口本身判为 Governance（"它管所有 provider 怎么接"） | 接口形状是 harness（Brain）；"必须有 provider 抽象"这条规则 → Governance |
+| 把 frozen snapshot 判为 Session（"它是历史快照啊"） | snapshot 是**装配产物**，是 Brain 的 prefix cache 工具；session 本体 + receipts 由 P1-e 定义 |
+
+---
+
+## Orchestration Rules（裁判手册）
+
+### O1. 三层 MemoryTier，决策权按层分配
+
+记忆按"能否驱动决策"分三层：
+
+| Tier | 含义 | 能驱动决策？ |
+|------|------|-------------|
+| `authoritative` | 治理常驻物 + authoritative session events（由 P1-e 定义） | **能** — 但其本身的产生必须经 contract / ADR / event-stream 入库 |
+| `decision-support` | 摘要 / 检索结果 / 跨会话索引 / 历史 outcomes | **不能直接驱动**，只能作为决策输入材料；最终决策必须由 authoritative 兜底 |
+| `context-only` | 会话文本 / scratchpad 笔记 / 草稿 | **不能** — 仅供 harness 理解上下文 |
+
+### O2. 检索优先级默认 truth-first（与 P1-Doctrine §5.5 一致）
+
+"truth-first" 是检索原则；在 contract 字段上对应 `query_mode = 'strict_truth'`（见 §3）。
+
+任何检索请求的默认顺序：
+1. **authoritative** 层：contracts / policies / verdicts / authoritative session events
+2. **decision-support** 层：traces / receipts / 索引摘要
+3. **context-only** 层：会话文本
+
+`context-only` 必须**最后**检索且**永远不能单独**回答决策性问题。检索引擎可以并行查所有层，但**结果聚合时按 priority 排序**，并标注每个 fragment 的 tier。
+
+唯一允许偏离 `strict_truth` 的场景是 `query_mode = 'balanced_recency'`（诊断 / 排查），其白名单与触发条件由 **P1-e** 定义。
+
+### O3. 摘要 / 派生内容不得提升 tier
+
+- LLM 对 `decision-support` 内容做摘要 → 仍是 `decision-support`
+- LLM 对 `context-only` 内容做摘要 → 仍是 `context-only`
+- **任何路径都不允许把派生内容标记为 `authoritative`**——`authoritative` 只能由 contract / ADR / authoritative event stream 入库时直接赋予
+
+### O4. 写入受 GuardChain 强制（与 P1-d 对接）
+
+- 任何 MemoryWriteRequest 必须经 GuardChain（P1-d）的 ContentScanGuard 与 TruthWriteGuard
+- 写入 `authoritative` 通道：**禁止由普通 provider / agent 直接写入**——必须走对应 contract ADR 或 event-stream append-only
+- 写入 `decision-support` / `context-only`：经 GuardChain shadow / active 检查
+
+### O5. Per-turn frozen snapshot 是 Brain 决策的稳定性前提
+
+- 一轮内（一次 LLM 调用 + 后续工具循环），prefetch 装配的 snapshot **不可变**
+- 即使在该轮内有新事件写入 session，本轮仍使用 frozen snapshot——下一轮才看到新内容
+- 这一规则是 **prefix cache 稳定性** 与 **决策可 replay** 的前提
+
+### O6. Provider 之间 context fencing
+
+- Provider A 注入的内容**不得被 Provider B 直接读取**
+- 跨 provider 共享必须经 MemoryAssemblyPlan 显式声明
+- 防止"chat history provider 偷偷把 user 笔记带给 truth provider"等串味
+
+### O7. Retrieval routing 是静态声明，不是 LLM 自由决定
+
+- MemoryAssemblyPlan 在编排开始前**确定要查哪些 provider / 哪些 tier / 用什么 query mode**
+- LLM 可以在 plan 范围内**触发**检索（如选择查 ADR or 查 trace），但**不能扩展 plan 之外**的检索路径
+- 越界检索由 GuardChain 拒绝
+
+### O8. 编排接口（Layer 0 契约）vs 编排实现（Layer 1）
+
+- **Layer 0**：定义 MemoryTier / MemoryRecord / MemoryRetrievalRequest / MemoryAssemblyPlan / MemoryUsePolicy 的 schema 与最小语义
+- **Layer 1（Loamwise）**：实施 MemoryManager、provider lifecycle、frozen snapshot 装配、retrieval 路由
+- **Layer 2（Engine）**：可作为 provider 注册（提供领域记忆），但不实施编排
+
+---
+
+## Contract Sketch
+
+### §1. MemoryTier（决策权分层枚举）
+
+```typescript
+enum MemoryTier {
+  AUTHORITATIVE    = 'authoritative',     // 可驱动决策；必须有原始 contract / ADR / authoritative event 来源
+  DECISION_SUPPORT = 'decision-support',  // 决策输入材料；最终决策必须由 authoritative 兜底
+  CONTEXT_ONLY     = 'context-only',      // harness 上下文；不进入决策路径
+}
+
+// Tier 升级（promotion）禁止：派生 / 摘要 / 跨 tier 复制都不能改 tier
+// 只有"独立通过 contract / ADR / event-stream 入库"的内容才能获得 AUTHORITATIVE
+```
+
+### §2. MemoryRecord（记忆条目最小 schema）
+
+```typescript
+interface MemoryRecord {
+  // 标识
+  record_id: string                        // UUIDv7
+  tier: MemoryTier                         // §1
+  content_kind: string                     // e.g., "contract.adr", "trace.event", "summary.session", "note.scratchpad"
+  content_hash: string                     // sha256(payload)
+
+  // 来源（fail-closed：缺少 = 拒绝）
+  // 角色约定（schema 注释，validator 强制）：
+  //   - Layer 0：authoritative source publisher
+  //              （contracts / policies / ADR-derived compiled records / authoritative event stream sink）
+  //   - Layer 1：provider / retrieval backend / orchestration write
+  //              （Loamwise 的 MemoryManager 与 provider 实现）
+  //   - Layer 2：Domain Engine 作为 provider，可发起 sync_turn 写入（受 §5 policy 约束）
+  //   - Layer 3：**不直接写入 memory records**（fail-closed）
+  source: {
+    provider_id: string                    // 写入时的 provider id
+    layer: 0 | 1 | 2
+    upstream_ref: string | null            // 若派生自其他 record / event
+    trace_id: string                       // 指向产生此 record 的 session event
+  }
+  created_at: string                       // ISO 8601
+
+  // 安全审计
+  guard_evidence: GuardEvidenceRef[]       // P1-d GuardChain 的扫描结果
+  redaction_applied: boolean
+
+  // 内容（按 content_kind 决定结构；不在 Layer 0 写死）
+  payload: unknown                         // 由各 content_kind 的 sub-schema 约束
+}
+```
+
+### §3. MemoryRetrievalRequest（检索请求）
+
+```typescript
+interface MemoryRetrievalRequest {
+  request_id: string
+
+  // 查询参数
+  query: string | StructuredQuery          // string = LLM-style；structured = exact filters
+  tiers_allowed: MemoryTier[]              // 必须显式列出；空 = 拒绝
+  providers_allowed: string[]              // 必须显式列出；空 = 拒绝（O7 强制）
+  query_mode: 'strict_truth' | 'balanced_recency'
+                                           // 默认 'strict_truth'（与 P1-e Federated Query 命名口径一致）
+                                           // 'balanced_recency' 仅诊断 / 排查场景；语义与白名单由 P1-e 定义
+  max_fragments_per_tier: Record<MemoryTier, number>
+
+  // 触发上下文
+  triggered_by: {
+    component: string                       // 谁触发的检索
+    purpose: 'decision' | 'context' | 'audit'
+    plan_id: string                        // 必须引用一个有效 MemoryAssemblyPlan（O7）
+  }
+}
+
+interface RetrievalResult {
+  request_id: string
+  fragments: RetrievalFragment[]            // 按 tier priority 排序
+  truncated: boolean
+  retrieved_at: string
+}
+
+interface RetrievalFragment {
+  record: MemoryRecord
+  rank_in_tier: number
+  match_evidence: string                    // 匹配理由（必须可解释）
+}
+```
+
+### §4. MemoryAssemblyPlan（装配计划，编排开始前敲定）
+
+```typescript
+interface MemoryAssemblyPlan {
+  plan_id: string
+  intended_for: 'decision' | 'context' | 'audit'
+
+  // 静态声明：要查哪些 provider / tier
+  retrieval_specs: RetrievalSpec[]
+
+  // 装配顺序（与 O5 frozen snapshot 配合）
+  assembly_order: AssemblyStep[]
+
+  // 写入计划（如果本轮会写入新 memory）
+  write_specs: MemoryWriteSpec[]           // 每条引用一个 MemoryUsePolicy（§5）
+
+  // 创建与 lifecycle
+  created_at: string
+  expires_at: string                       // plan 失效时间，过期 = 必须重新装配
+  frozen: boolean                          // 一旦标 frozen，本轮内不可修改（O5）
+}
+
+interface RetrievalSpec {
+  provider_id: string
+  tiers: MemoryTier[]
+  query_template: string                   // 模板化，避免任意 string
+  max_results: number
+}
+
+interface AssemblyStep {
+  step: 'system-prompt' | 'tool-context' | 'memory-fence'
+  fragments: string[]                      // record_id 列表
+  fence_boundary: string | null            // O6 fencing
+}
+
+interface MemoryWriteSpec {
+  target_tier: MemoryTier
+  content_kind: string
+  use_policy_id: string                    // 必须引用一个 MemoryUsePolicy
+}
+```
+
+### §5. MemoryUsePolicy（决策权 / 写入权的 Governance 契约）
+
+```typescript
+interface MemoryUsePolicy {
+  policy_id: string
+  tier: MemoryTier
+
+  // 谁能读（在哪些 plan_purpose 下）
+  read_allowed_for: ('decision' | 'context' | 'audit')[]
+
+  // 谁能写（critical：authoritative 写入受最严格约束）
+  write_allowed_by: WriteActorRule[]
+
+  // 哪些决策能消费此 tier 作为兜底
+  // 强约束（schema + registration validator 双重强制）：
+  //   - tier === AUTHORITATIVE     → decision_consumers 必须非空
+  //   - tier !== AUTHORITATIVE     → decision_consumers 必须为空 ([])
+  // DecisionKind 见 P1-a §3
+  decision_consumers: DecisionKind[]
+
+  // 派生规则（防止 tier 提升）
+  derivation_rule: {
+    can_summarize_to: MemoryTier[]         // 只能 ≤ 当前 tier
+    can_index_into: MemoryTier[]           // 同上
+  }
+
+  // 撤销 / 失效
+  revocation_path: string                  // 指向撤销 ADR / kill switch 入口
+}
+
+// Validator 伪代码（注册时强制）
+function validateUsePolicy(p: MemoryUsePolicy): ValidationResult {
+  if (p.tier === MemoryTier.AUTHORITATIVE && p.decision_consumers.length === 0) {
+    return fail('authoritative_must_declare_decision_consumers')
+  }
+  if (p.tier !== MemoryTier.AUTHORITATIVE && p.decision_consumers.length > 0) {
+    return fail('non_authoritative_must_have_empty_decision_consumers')
+  }
+  // 其他校验……
+  return ok()
+}
+
+interface WriteActorRule {
+  actor_kind: 'contract-adr' | 'event-stream' | 'engine-cosign' | 'policy-engine' | 'human-maintainer'
+  guard_chain_required: ('content-scan' | 'truth-write')[]   // 必经 P1-d guards
+}
+```
+
+**默认 MemoryUsePolicy（NON-NORMATIVE 示意）**：
+
+| Tier | read_allowed_for | write_allowed_by | decision_consumers |
+|------|-----------------|-----------------|-------------------|
+| `authoritative` | decision, audit | contract-adr / event-stream / engine-cosign + truth-write guard | 全部 DecisionKind |
+| `decision-support` | decision, context, audit | engine-cosign / policy-engine / human + content-scan | （空）— 仅作输入 |
+| `context-only` | context, audit | 任何 in-process provider + content-scan | （空）— 永不入决策 |
+
+> 上表仅展示**严格度的相对关系**，具体生效规则由后续 policy ADR 给出。
+
+### §6. Orchestration Lifecycle（与 Hermes 对齐但口径收紧）
+
+```typescript
+interface MemoryProvider {
+  provider_id: string
+
+  // 当前字段语义优先约束**写入**：此 provider 通过 sync_turn / on_memory_write
+  // 只能写入 declared_tiers 之内的 tier。
+  // **读权限**由 MemoryAssemblyPlan.providers_allowed + tiers_allowed 进一步限定，
+  // 不直接从 declared_tiers 推导。后续 contract ADR 可拆分为
+  // declared_read_tiers / declared_write_tiers。
+  declared_tiers: MemoryTier[]
+
+  // Lifecycle hooks（Loamwise 调用）
+  initialize(ctx: ProviderContext): Promise<void>
+  prefetch(req: MemoryRetrievalRequest): Promise<MemoryRecord[]>
+  sync_turn(events: TurnEvent[]): Promise<MemoryWriteResult[]>   // 受 §5 policy 约束
+  shutdown(): Promise<void>
+
+  // 可选 hooks
+  on_pre_compress?(snapshot: FrozenSnapshot): Promise<void>     // 不得写入 authoritative
+  on_memory_write?(write: MemoryWriteRequest): Promise<void>    // 仅观察，不得改写
+  on_delegation?(chain: DelegationChain): Promise<void>
+}
+
+interface FrozenSnapshot {
+  snapshot_id: string
+  plan_id: string
+  fragments: ReadonlyArray<RetrievalFragment>
+  frozen_at: string
+  // 一旦创建：immutable（O5）
+}
+```
+
+---
+
+## Non-goals
+
+- **不实施 §1-§6 的代码**——本 ADR 仅定义 contract 草图与编排规则，运行时实现归 Loamwise
+- **不重新定义 BGHS 分类规则**——见 P1-Doctrine
+- **不定义 session vs session-adjacent 的具体 taxonomy**——交给 P1-e
+- **不定义 federated query 的具体路由策略**——交给 P1-e
+- **不定义 GuardChain 内部实现**——交给 P1-d；本 ADR 只声明"必经 GuardChain"
+- **不引入 user modeling / dialectic Q&A / peer cards**——R1
+- **不引入 LLM-driven smart routing**——R4
+- **不实施 prefix cache 优化策略**——只声明 frozen snapshot 不可变，缓存策略由 Loamwise 自定
+- **不修改 Hermes 上游代码**——上游 fork 仅作只读参考
+
+---
+
+## Adoption Checkpoints
+
+| Checkpoint | 触发时机 | 验证项 |
+|-----------|---------|-------|
+| **C1. 本 ADR + P1-Doctrine + P1-a/b 一致就位** | 本 ADR 通过后 | 四份 ADR 互引一致；SYSTEMS.md 引用本 ADR 为 memory orchestration SSOT |
+| **C2. MemoryTier 三层落入 contract schema** | P1-e 入库前 | `_meta/contracts/memory/tier.schema.yaml` 建立；schema 强制三种 tier；禁止派生提升 |
+| **C3. MemoryAssemblyPlan 静态声明强制** | Loamwise `align/` 实施时 | 任何检索必须引用有效 plan_id；越界检索被 validator 拒绝 |
+| **C4. Frozen snapshot 不可变性** | Loamwise harness 实施时 | snapshot 写入后 immutable；replay 验证可读出原 snapshot |
+| **C5. 写入路径 GuardChain 强制** | P1-d Guards 落地后 | 任何 MemoryWriteRequest 必经 ContentScanGuard + TruthWriteGuard |
+| **C6. 现有 ADR-006 supersede** | 本 ADR 通过后立即 | `ADR-006-Hermes-Memory-Orchestration.md` 标注 `Superseded by: ADR-Hermes-Memory-Orchestration.md`。**主题级 supersede，不要求物理删除** |
+
+**本 ADR 不实施任何代码**。Adoption checkpoints 是后续阶段的入库门，不在本轮执行。
+
+---
+
+## Appendix A: 与 P1-e 的边界（明示）
+
+本 ADR 与 P1-e 的分工必须清晰，否则会出现两种错位：
+1. P1-c 越界自定义 session vs session-adjacent → P1-e 失去存在理由
+2. P1-c 把 federated query 路由策略写死 → P1-e 修订时被本 ADR 阻塞
+
+**分工**：
+
+| 维度 | 本 ADR (P1-c) | P1-e |
+|------|--------------|------|
+| 关注 | **如何编排记忆**（assembly / retrieval order / lifecycle hooks） | **什么是 session 本体 / 什么是 session-adjacent** + **federated query 接口** |
+| 输出 | MemoryTier / MemoryRecord / MemoryAssemblyPlan / MemoryUsePolicy | SessionEventStream / SessionAdjacentArtifact taxonomy / FederatedQueryInterface |
+| 引用 | 假定 P1-e 的 taxonomy 已存在（forward ref） | 引用本 ADR 的 MemoryTier 作为消费侧约束 |
+
+**当本 ADR 与 P1-e 冲突时**：
+- session / session-adjacent 分类的最终定义以 **P1-e 为准**
+- memory 编排（assembly / retrieval / lifecycle）的最终定义以 **本 ADR 为准**
+
+**不得双重定义（硬约束）**：
+
+> 同一概念不得在 P1-c 与 P1-e 中被双重定义。如必须交叉引用，**P1-c 只引用 taxonomy label，不重述 taxonomy semantics**；P1-e 只引用 MemoryTier label，不重述 tier 决策权语义。
+
+> 评审时若发现重复定义，以**所属 ADR 的定义为准**（taxonomy 归 P1-e；tier 决策权归 P1-c），另一份必须改为 label-only 引用并 commit。
+
+---
+
+## Appendix B: 与 ADR-006（旧版）的关系
+
+旧 `ADR-006-Hermes-Memory-Orchestration.md` 写于 2026-04-14（P1-Doctrine 之前），结构正确但缺少：
+1. Meta Declaration 头部
+2. BGHS 分类映射
+3. 三层 MemoryTier 与 MemoryUsePolicy 的显式 schema
+4. 与 P1-a CapabilityKind / P1-b Skill Lifecycle / P1-d GuardChain / P1-e Session taxonomy 的对接
+
+**ADR-006 处置**：保留为历史记录（同 ADR-004 / 005），主题以本 ADR 为准。
+
+---
+
+**Version**: 1.0.0
+**Last Updated**: 2026-04-16

--- a/_meta/adr/ADR-Hermes-Skill-Lifecycle.md
+++ b/_meta/adr/ADR-Hermes-Skill-Lifecycle.md
@@ -1,0 +1,547 @@
+---
+artifact_scope: meta
+artifact_name: Hermes-Skill-Lifecycle
+artifact_role: harvest
+target_layer: cross
+is_bghs_doctrine: no
+---
+
+# ADR — Hermes Skill Lifecycle（P1-b）
+
+**Status**: Accepted
+**Date**: 2026-04-16
+**Accepted-Date**: 2026-04-17
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-Hermes-Skill-Lifecycle.md`
+**References**:
+- `_meta/adr/ADR-Architecture-Doctrine-BGHS-Separation.md`（必读前置）
+- `_meta/adr/ADR-OpenClaw-Capability-Boundary.md`（capability 边界，本 ADR 把 skill lifecycle 嫁接其上）
+**Source**: `/Users/liye/github/hermes-agent/`（fork 自 `NousResearch/hermes-agent`，只读参考）
+
+---
+
+## Context
+
+Skill 是 LiYe Systems 中"可被调度的能力单元"——它可能由开发者编写，也可能由 agent 在运行时生成（learning loop 的产物），还可能从外部 hub / marketplace 引入。这三个来源的"信任水位"不同，**但都不应该一进入系统就直接可执行**。
+
+Hermes Agent 提供了一套相对完整的 skill 生命周期实现，特别是：
+- **trust 分层**（builtin / trusted / community / agent-created）
+- **scan + verdict 分级**（safe / caution / dangerous）
+- **quarantine 隔离**（外部 skill 进入前的检疫区）
+- **progressive disclosure**（按需加载）
+
+但 Hermes 的"agent-created skill 扫描通过即激活"这条捷径**不能照搬**——LiYe Systems 必须 quarantine-first：**scan pass ≠ trust，是准入的必要条件，不是充分条件**。
+
+本 ADR 萃取 Hermes 的 lifecycle discipline，落成 LiYe Systems 的 skill 生命周期治理契约。**本 ADR 不写 Hermes 功能介绍，只写状态转换、准入纪律、quarantine 边界**。Skill 生命周期的运行时属于 Loamwise（Layer 1，`/Users/liye/github/loamwise/construct/`），Layer 0 只定义契约。
+
+---
+
+## 上游核心做法（Hermes 的 lifecycle 实现）
+
+### H1. 四级 trust 分层
+
+Hermes 把所有 skill 按来源分四级（`/Users/liye/github/hermes-agent/tools/skills_guard.py`）：
+
+| Trust Level | 来源 | 默认行为 |
+|------------|------|---------|
+| `builtin` | 仓库内自带 | 直接信任，skip 扫描 |
+| `trusted` | 用户显式信任的源 | 安装时扫描，运行时跳过 |
+| `community` | 公共 hub 拉取 | 强制扫描 + caution 默认隔离 |
+| `agent-created` | agent 在运行时创建 | 创建后立即扫描 + 通过即激活 |
+
+### H2. 扫描器三级 verdict
+
+`skills_guard.py` 内置 ~80 条 regex 威胁模式，覆盖 7 类：
+- shell command injection、网络外联、密钥读取、文件系统越界、prompt injection、auth/token bypass、import-time side effect
+
+输出三级 verdict：
+- `safe`：通过
+- `caution`：可疑，需人工 review
+- `dangerous`：拒绝
+
+### H3. 外部 skill quarantine 流程
+
+`/Users/liye/github/hermes-agent/tools/skills_hub.py` 实现：
+
+```
+download → quarantine 目录 → scan → 通过则 install → 写入 lock.json + audit.log
+```
+
+quarantine 目录与正式 skill 目录物理隔离，未通过的 skill 不会出现在 active path。Provenance（来源 / 哈希 / 时间戳）写入 `lock.json`，操作链写入 `audit.log`。
+
+### H4. Agent-created skill 的"scan pass 即激活"捷径（**不吸收，见 R1**）
+
+`/Users/liye/github/hermes-agent/tools/skill_manager_tool.py` 允许 agent 在运行时调用 `create_skill()`，写入文件后立即触发 `skills_guard` 扫描，**通过即激活**——无需人工 review。
+
+这是 Hermes 在"agent-as-product"场景下的合理取舍，但 **LiYe Systems 拒绝这条路径**——它把"scan pass"误等于"trust"，绕过了 quarantine 纪律。
+
+### H5. Progressive disclosure（按需加载）
+
+`/Users/liye/github/hermes-agent/tools/skills_tool.py` 把 skill 元数据分三层（list / detail / body），按 agent 需要逐层暴露，避免一次性加载全部 skill 内容污染上下文。
+
+### H6. Frontmatter metadata + 原子写
+
+每个 skill 文件头部用 YAML frontmatter 声明 `name / description / platform / version / requires` 等字段。`skill_manager_tool.py` 写入采用"临时文件 → fsync → atomic rename"原子模式。
+
+---
+
+## 吸收什么
+
+| 编号 | 吸收项 | 理由 |
+|------|-------|------|
+| **A1** | **Trust 分层 + verdict 分级**（但口径更严，见 R3） | Layer 0 必须有可声明的 trust matrix；plugin / engine 不得自行声明 trust |
+| **A2** | **Quarantine 物理隔离**（quarantine 目录与 active 目录分离） | Governance：未通过准入的 candidate 不得出现在执行路径上 |
+| **A3** | **Provenance 追踪**（来源 / 哈希 / 创建者 / 时间戳 / source_trace_id） | Session：所有 skill candidate 的来源必须可追溯到原始事件 |
+| **A4** | **Frontmatter metadata** + **原子写入** | Hands 执行边界的最小契约 |
+| **A5** | **Progressive disclosure 三层（list / detail / body）** | Brain harness 的合理优化，不影响 Governance |
+| **A6** | **审计日志 append-only**（audit.log 模式） | Session：lifecycle 转换必须留痕，且不可改写 |
+
+---
+
+## 不吸收什么
+
+| 编号 | 不吸收项 | 理由 |
+|------|---------|------|
+| **R1** | **Agent-created skill scan-pass 即激活** | LiYe Systems 强制 quarantine-first：**scan pass ≠ trust**，扫描通过只是准入的**必要条件**，不是充分条件 |
+| **R2** | **`builtin` 跳过扫描** | 即使 builtin 也要走 lifecycle（首次入库时扫描 + 标注），只是后续运行时可不重复扫描 |
+| **R3** | **trust 分层口径**（4 级 + community 自动 caution） | LiYe 重新定义 trust 来源（见 §Lifecycle Rules L3）；不把 community 默认归为可执行 |
+| **R4** | **Auto-repair / auto-rewrite skill** | 任何对 active skill 的修改 = 新 candidate，必须重走 lifecycle |
+| **R5** | **强行覆盖（force install / force activate）** | Controlled transitions only：旁路状态机 = 拒绝（见 L1） |
+| **R6** | **scan 通过 = 默认安全** | scan 是 deterministic pattern match，对未知威胁不构成保证；scan 失败 = 必拒，scan 通过 = 仅清除已知模式 |
+| **R7** | **Skill 由 agent 直接调度执行**（无 promotion 决策） | 所有 active skill 的调度必须经 Loamwise dispatch，agent 不直接调用 candidate |
+| **R8** | **"smart routing" / "auto skill repair" / Honcho 用户建模** | 与 SYSTEMS.md 已声明的"明确不做清单"一致 |
+
+---
+
+## 与 LiYe Systems 分层与 BGHS 的映射
+
+> 不再定义 BGHS 规则——见 P1-Doctrine §1。本节给出 Hermes skill 系统组件在 LiYe 视角下的归类。
+
+| Hermes 组件 | LiYe 视角 primary concern | 在 LiYe Systems 的对应位置 |
+|------------|--------------------------|--------------------------|
+| skill 文件本身（frontmatter + body） | **Hands** | Loamwise（Layer 1）/ Engine（Layer 2）的 skill 实现 |
+| skill_manager_tool（创建 / 编辑） | **Brain** | Loamwise `construct/` 的 candidate generation harness |
+| skills_guard（扫描器） | **Governance** (secondary: Hands) | Layer 0 capability — 由 P1-d Loamwise Guard 落地 |
+| skills_hub（quarantine + install 流程） | **Governance** | Loamwise `construct/quarantine/`（执行）+ Layer 0 lifecycle contract（本 ADR） |
+| skills_tool（progressive disclosure） | **Brain** | Loamwise harness 优化（不影响 Governance） |
+| audit.log + lock.json | **Session** | session-adjacent（receipts，参见 P1-Doctrine §5.5 + P1-e） |
+| trust matrix | **Governance** | Layer 0 — 本 ADR Contract Sketch §3 定义；Loamwise 消费 |
+
+**Layer 归属**（与 SYSTEMS.md 既有声明一致）：
+- **Layer 0（liye_os）**：定义 `SkillLifecycleState` 枚举、`SkillCandidateRecord` schema、`PromotionDecision` 契约、trust matrix 结构
+- **Layer 1（loamwise）**：实现 candidate 接收、quarantine 目录管理、扫描调度、promotion 执行、lifecycle log 写入
+
+**容易错判的点**：
+
+| 容易错判 | 正确判法 |
+|---------|---------|
+| 把 "scan pass" 判为 ACTIVE 状态 | scan pass 只是准入必要条件；ACTIVE 需 PromotionDecision（Governance）+ scan pass + quarantine 期满 |
+| 把 "agent-created skill" 判为 Brain 范畴（"agent 创造的当然归 harness 管"） | 创造过程是 Brain；但 candidate 一旦写入文件系统 = Hands artifact；准入决策 = Governance |
+| 把 "quarantine 目录" 判为 Session（"反正都是临时存放"） | quarantine 是 isolation 边界（Governance），不是事件日志 |
+
+---
+
+## Lifecycle Rules（裁判手册）
+
+### L1. Controlled transitions + append-only history（无旁路）
+
+- 状态转换必须沿 §1 的 ALLOWED_TRANSITIONS 白名单进行（**controlled transition graph**，非随意可达）
+- 转换历史 **append-only**：不允许 update / delete 已写入的 LifecycleTransition
+- **任何转换都必须有显式 driver**（PromotionDecision 或 QuarantineDecision），无 driver 的转换 = 拒绝写入
+- 不允许"直接写入 active 目录" / "原地改写状态字段" 等旁路操作
+- "撤销"通过追加新 transition 实现（如 ACTIVE → QUARANTINED → 新 PromotionDecision → CANDIDATE），不改写历史
+
+### L2. Quarantine-first（不可绕过的硬约束）
+
+- 任何 candidate（无论来源是开发者 / agent / 外部 hub），在进入 ACTIVE 之前**必须经过 CANDIDATE 状态**
+- CANDIDATE 期间：物理路径属于 quarantine root（isolation），不出现在 dispatcher 可见的 active path
+- **scan pass ≠ promotion**——scan 是准入的必要条件，不是充分条件
+- 至少需要一个**显式 PromotionDecision**（有签名 / approver_id）才能转 ACTIVE
+
+### L3. Trust 来源是声明，不是推断
+
+- Trust 不是"扫描通过就给"——Trust 是 Layer 0 trust matrix 中明示的来源属性
+- LiYe Systems 的 trust 来源（与 Hermes 4 级不同，重新口径）：
+
+| Trust Source | 含义 | 默认 promotion 路径 |
+|-------------|------|-------------------|
+| `internal-vetted` | LiYe 仓库内已 review 过的 skill | 仍走 lifecycle，但 PromotionDecision 可由维护者审批 |
+| `engine-published` | Domain Engine 通过 engine_manifest 发布 | 仍走 lifecycle，PromotionDecision 由 Engine + Loamwise 双签 |
+| `agent-generated` | learning loop 产出 | **永远** 进 quarantine，需人工或 policy-defined approver |
+| `external` | 来自 hub / marketplace / 用户上传 | **永远** 进 quarantine，需人工 + scan + grace-period |
+
+**没有 `community-default-caution` 这种自动信任**（R3）。
+
+### L4. Scan 是 fail-closed，不是 trust generator
+
+- scan dangerous → **必拒**（不可 override）
+- scan caution → **必入 QUARANTINED**，不进 CANDIDATE 主队列
+- scan safe → **进 CANDIDATE**，等待 PromotionDecision（不自动 ACTIVE）
+
+### L5. Active skill 不可原地修改
+
+- 对 ACTIVE skill 的任何修改 = 新版本的 CANDIDATE
+- 旧版本进入 DEPRECATED 后保留可读，但 dispatcher 拒绝调度
+- 禁止 `force-edit` / `hot-patch` 类操作（R4 + R5）
+
+### L6. Provenance 与 lifecycle 日志强制
+
+- 每个 SkillCandidateRecord 必须有：`source_trace_id`、`source_kind`、`generated_by`、`created_at`、`content_hash`
+- 每次 LifecycleTransition 必须 append-only 写入 lifecycle log（属 session-adjacent，由 P1-e 定义存储位置）
+- 缺少 provenance = 拒绝接收（fail-closed）
+
+### L7. Lifecycle 治理 contract 由 Layer 0 定义，运行时由 Loamwise 实现
+
+- 状态机定义、字段 schema、transition 准入规则 → **Layer 0**（本 ADR 与未来 contract ADR）
+- candidate 接收、quarantine 目录管理、scan 调度、promotion 执行、lifecycle log 写入 → **Layer 1（Loamwise）**
+- Engine（Layer 2）只能**提交 candidate** 与**消费 active skill**，不参与 promotion 决策
+
+---
+
+## Contract Sketch
+
+### §1. SkillLifecycleState（状态枚举）
+
+```typescript
+enum SkillLifecycleState {
+  // DRAFT 是可选前置工作态：在首次 candidate 提交之前，skill 草稿可在 git
+  // 工作目录或 IDE 中存在，未必进入 lifecycle 注册存储。一旦 submit，必须
+  // 直接进 CANDIDATE。实现方可以选择不持久化 DRAFT 状态。
+  DRAFT        = 'draft',
+  CANDIDATE    = 'candidate',     // 已通过最小接收检查，允许等待 promotion 的候选态
+  QUARANTINED  = 'quarantined',   // 被显式阻断、不得进入 promotion 队列的隔离态
+  ACTIVE       = 'active',        // 已 promote，dispatcher 可调度
+  DEPRECATED   = 'deprecated',    // 计划下线，dispatcher 拒绝新调度，保留可读
+  REVOKED      = 'revoked',       // 硬删除（仅元数据残留）
+}
+
+// 允许的转换（白名单）
+const ALLOWED_TRANSITIONS: Record<SkillLifecycleState, SkillLifecycleState[]> = {
+  draft:        ['candidate'],
+  candidate:    ['active', 'quarantined', 'revoked'],
+  quarantined:  ['candidate', 'revoked'],          // 修复后可重提
+  active:       ['deprecated', 'quarantined'],     // 紧急隔离也合法
+  deprecated:   ['revoked'],
+  revoked:      [],                                // 终态
+}
+```
+
+**CANDIDATE vs QUARANTINED 的行为语义（必须区分）**：
+
+| 维度 | CANDIDATE | QUARANTINED |
+|------|-----------|-------------|
+| 在 promotion 队列中？ | **是** — 可被 PromotionDecision 调度 promote | **否** — 不进 promotion 队列 |
+| 接收新决策？ | 接受 PromotionDecision（→ ACTIVE）或 QuarantineDecision（→ QUARANTINED） | 仅接受 PromotionDecision（→ CANDIDATE，视为重新准入）或 QuarantineDecision（→ REVOKED） |
+| `release_blocked_until` 是否生效？ | 不适用 | 生效；到期前任何 → CANDIDATE 的尝试拒绝 |
+| 谁可写入这里？ | Loamwise 接收 channel | 仅 Loamwise quarantine controller（接收人工或 policy 触发） |
+
+**物理隔离要求**（行为语义层，目录命名归 Loamwise 实现，不在本 ADR 写死）：
+
+- 二者**可共享同一个 quarantine root**（与 active 目录物理分离）
+- 但必须位于**不同子域 / 不同行为队列**，例如：
+  - CANDIDATE 子域 → 进 promotion scheduler 的 watch list
+  - QUARANTINED 子域 → 不进任何 scheduler，仅供 review / inspection
+
+dispatcher 与 promotion scheduler **均不可访问 QUARANTINED 子域**。
+
+### §2. SkillCandidateRecord（candidate 元数据，Loamwise 接收时写入）
+
+```typescript
+interface SkillCandidateRecord {
+  // 标识
+  candidate_id: string                    // UUIDv7 推荐
+  skill_id: string                        // 形如 "amazon-growth-engine:bid_recommend"
+  version: string                         // SemVer
+  content_hash: string                    // sha256(skill body + frontmatter)
+
+  // 来源（L6 强制）
+  source_trace_id: string                 // 指向产生此 candidate 的 session event
+  source_kind: TrustSource                // 见 §3
+  generated_by: {
+    component: string                     // e.g., "loamwise:construct.learning-loop"
+    layer: 1 | 2                          // Layer 0 不产 candidate
+  }
+  created_at: string                      // ISO 8601
+  expires_at: string | null               // CANDIDATE 状态的 grace period 截止
+
+  // 风险与扫描
+  risk_class: 'low' | 'medium' | 'high' | 'unknown'   // 由 scan + heuristic 标注
+  scan_results: ScanResultRef[]           // 指向扫描记录（多次扫描可累积）
+
+  // 当前状态
+  state: SkillLifecycleState
+  state_changed_at: string
+
+  // Capability 绑定（与 P1-a 的 CapabilityRegistration 关联）
+  capability_kind: string                 // 必须是 P1-a CapabilityKindRegistry 已注册的 kind
+  capability_registration_id: string | null  // ACTIVE 后填入
+}
+
+interface ScanResultRef {
+  scanner_id: string                      // e.g., "loamwise:guard.content-scan.v1"
+  scanned_at: string
+  verdict: 'safe' | 'caution' | 'dangerous'
+  evidence_path: string                   // 指向扫描详情（脱敏后的 hits）
+}
+```
+
+### §3. TrustSource（trust matrix，L3 落地）
+
+```typescript
+enum TrustSource {
+  INTERNAL_VETTED   = 'internal-vetted',   // 仓库内已 review
+  ENGINE_PUBLISHED  = 'engine-published',  // Domain Engine 发布
+  AGENT_GENERATED   = 'agent-generated',   // learning loop 产出
+  EXTERNAL          = 'external',          // hub / marketplace / 上传
+}
+
+interface PromotionPolicy {
+  source: TrustSource
+  required_approvers: ApproverRule[]       // 至少满足其一
+  required_grace_period_seconds: number    // CANDIDATE 最短停留时间
+  allowed_target_states: SkillLifecycleState[]  // 通常 ['active']，紧急情况可有限制
+}
+
+interface ApproverRule {
+  approver_kind: 'human-maintainer' | 'engine-cosign' | 'policy-rule'
+  policy_path?: string                     // 若 kind = policy-rule，指向 policy ADR
+}
+```
+
+**Illustrative baseline PromotionPolicy（NON-NORMATIVE，仅作语义示意）**：
+
+下表展示了 4 种 TrustSource 应有的相对严格程度差异（external > agent > engine > internal），**具体数值与规则不构成规范**。生效值由后续 policy ADR 给出。
+
+| Source | required_approvers (示意) | grace_period (示意) | 允许目标 |
+|--------|-------------------|--------------|---------|
+| `internal-vetted` | 1× human-maintainer | `policy-defined`（baseline: 0） | active |
+| `engine-published` | 1× human-maintainer + 1× engine-cosign | `policy-defined`（baseline: ~minutes） | active |
+| `agent-generated` | 1× human-maintainer | `policy-defined`（baseline: ≥ minutes） | active |
+| `external` | 1× human-maintainer + scan-result.verdict=safe | `policy-defined`（baseline: ≥ longer） | active |
+
+> 本表只展示**严格度的相对关系**，不约束具体秒数。grace_period / approver 数量等具体生效规则由后续 policy ADR 给出（与 P1-Doctrine D5 一致：具体不变量改 contract/policy ADR，不修 Doctrine）。
+
+### §4. PromotionDecision（promote 类转换的授权工件）
+
+```typescript
+interface PromotionDecision {
+  decision_id: string
+  candidate_id: string
+  from_state: SkillLifecycleState
+  to_state: SkillLifecycleState
+  decided_at: string
+
+  // 决策证据（缺一不入库 = fail-closed）
+  approvers: ApproverEvidence[]            // 满足 PromotionPolicy.required_approvers
+  scan_evidence: ScanResultRef[]
+  policy_evaluations: PolicyEvalResult[]   // 引用了哪些 policy ADR
+
+  // 可逆性
+  rollback_policy: RollbackPolicy
+
+  // 决策者签名（防止匿名 promotion）
+  decided_by: {
+    actor_id: string                       // human user id 或 service id
+    actor_kind: 'human' | 'service' | 'policy-engine'
+    signature: string                      // 至少 HMAC，更高级别可数字签名
+  }
+}
+
+interface ApproverEvidence {
+  approver_kind: 'human-maintainer' | 'engine-cosign' | 'policy-rule'
+  approver_id: string
+  approved_at: string
+  evidence_ref: string                     // 指向批准证据（PR / message / policy result）
+}
+
+interface RollbackPolicy {
+  on_drift_detected: 'auto-quarantine' | 'alert-only'
+  on_kill_switch: 'auto-revoke' | 'auto-quarantine'
+}
+```
+
+### §5. QuarantineReason + QuarantineDecision（隔离/撤销的授权工件）
+
+```typescript
+enum QuarantineReason {
+  SCAN_DANGEROUS         = 'scan.dangerous',
+  SCAN_CAUTION           = 'scan.caution',
+  PROMOTION_REJECTED     = 'promotion.rejected',
+  DRIFT_DETECTED         = 'drift.detected',         // active 期间发现行为漂移
+  POLICY_VIOLATION       = 'policy.violation',       // 触发 policy ADR 中的红线
+  KILL_SWITCH            = 'kill-switch',            // 紧急全局隔离
+  EXTERNAL_REPORT        = 'external.report',        // 用户 / 上游报告问题
+  GRACE_PERIOD_EXPIRED   = 'grace-period.expired',   // 长期未 promote 自动隔离
+}
+
+// QuarantineDecision 是状态转换的授权工件（与 PromotionDecision 同等地位），
+// 不是事后日志记录。任何 → QUARANTINED 或 → REVOKED 的转换都必须有 QuarantineDecision。
+interface QuarantineDecision {
+  decision_id: string
+  candidate_id: string
+  from_state: SkillLifecycleState
+  to_state: SkillLifecycleState              // 通常 'quarantined' 或 'revoked'
+  reason: QuarantineReason
+  reason_detail: string                      // 具体描述
+  reason_evidence: string[]                  // 证据指针
+  decided_at: string
+  release_blocked_until: string | null       // 何时之前不允许重新提交（NULL = 永久封禁，需新 decision 解锁）
+
+  // 决策者签名（与 PromotionDecision 对称，防止匿名隔离）
+  decided_by: {
+    actor_id: string
+    actor_kind: 'human' | 'service' | 'policy-engine' | 'kill-switch'
+    signature: string
+  }
+}
+```
+
+### §6. LifecycleTransition（append-only 日志条目）
+
+```typescript
+interface LifecycleTransition {
+  transition_id: string
+  candidate_id: string
+  from_state: SkillLifecycleState
+  to_state: SkillLifecycleState
+  transitioned_at: string
+  // 所有状态转换都必须有显式决策工件（无匿名 / 无隐式转换）
+  // - promote 类（→ ACTIVE / → DEPRECATED）：PromotionDecision
+  // - quarantine / revoke 类（→ QUARANTINED / → REVOKED）：QuarantineDecision
+  // - candidate 重提（QUARANTINED → CANDIDATE）：PromotionDecision（视为重新准入）
+  driver: PromotionDecision | QuarantineDecision
+  prev_transition_id: string | null               // 形成 hash chain（参见 P1-e）
+}
+```
+
+**写入规则**：
+- append-only（不允许 update / delete）
+- 每个 candidate 形成 append-only hash chain（每条 transition 包含 `sha256(prev_transition_id || transition_payload)`）
+- 物理位置由 P1-e Session-adjacent taxonomy 定义（lifecycle log 属 session-adjacent，不是 session 本体）
+
+**驱动工件统一原则**：
+- 任何 LifecycleTransition 必须由 `PromotionDecision` 或 `QuarantineDecision` 之一驱动
+- **无 driver 的 transition = 拒绝写入**（fail-closed，防止旁路）
+- 两类决策工件地位对称：都需 approver / evidence / signature；都不允许"事后补登记"
+
+### §7. 状态机图
+
+```
+              [submit]
+   DRAFT  ────────────────►  CANDIDATE
+                                  │
+                ┌─────────────────┼─────────────────┐
+                │                 │                 │
+        [PromotionDecision]    [scan caution    [scan dangerous
+         valid + grace pass]    or rejected]      or policy violation]
+                │                 │                 │
+                ▼                 ▼                 ▼
+              ACTIVE         QUARANTINED         QUARANTINED
+                │                 │                 │
+        [drift / kill]            │           [release_blocked_until 到期 + 修复]
+                │                 │                 │
+                ▼                 ▼                 ▼
+            QUARANTINED     CANDIDATE          CANDIDATE
+                │              (重新走流程)
+        [planned EOL]
+                │
+                ▼
+          DEPRECATED
+                │
+        [cleanup]
+                │
+                ▼
+            REVOKED
+```
+
+### §8. 准入纪律（注册时的 fail-closed 检查）
+
+```typescript
+function acceptCandidate(rec: SkillCandidateRecord): AcceptResult {
+  // L6: provenance 强制
+  if (!rec.source_trace_id || !rec.generated_by || !rec.content_hash) {
+    return fail('missing_provenance')
+  }
+  // L2: 必须从 CANDIDATE 起步（不允许直接 ACTIVE）
+  if (rec.state !== 'candidate') {
+    return fail('initial_state_must_be_candidate')
+  }
+  // L7 + P1-a B1: capability_kind 必须由 Layer 0 已注册
+  if (!capabilityKindRegistry.has(rec.capability_kind)) {
+    return fail('unknown_capability_kind')
+  }
+  // L7: layer 限制（Layer 0 不产 candidate）
+  if (rec.generated_by.layer === 0) {
+    return fail('layer_0_cannot_produce_candidate')
+  }
+  // L4: 等待 scan 结果
+  return ok({ candidate_id: rec.candidate_id })
+}
+
+function promoteCandidate(decision: PromotionDecision): PromoteResult {
+  const policy = lookupPromotionPolicy(decision.candidate.source_kind)
+  // L1: transition 必须在白名单
+  if (!ALLOWED_TRANSITIONS[decision.from_state].includes(decision.to_state)) {
+    return fail('illegal_transition')
+  }
+  // L3: approver 必须满足 policy
+  if (!satisfies(decision.approvers, policy.required_approvers)) {
+    return fail('insufficient_approvers')
+  }
+  // L2: grace period
+  if (now() < decision.candidate.created_at + policy.required_grace_period_seconds) {
+    return fail('grace_period_not_elapsed')
+  }
+  // L4: scan 证据必须 safe
+  if (!hasSafeVerdict(decision.scan_evidence)) {
+    return fail('scan_not_safe')
+  }
+  // L6: 写 LifecycleTransition + 关联 P1-a CapabilityRegistration
+  return ok({ transition_id: ... })
+}
+```
+
+---
+
+## Non-goals
+
+- **不实施 §1-§8 的代码**——本 ADR 仅定义状态机与 contract 草图，运行时实现归 Loamwise
+- **不重新定义 BGHS 分类规则**——见 P1-Doctrine
+- **不规定 scan 引擎的具体实现**——交给 P1-d Loamwise Guard Content Security
+- **不规定 lifecycle log 的物理存储格式**——交给 P1-e Session-adjacent taxonomy
+- **不规定 PromotionDecision 的 UI / 工具流**——人审界面归 Loamwise / Operator console
+- **不实现 Hermes skill 体系的 1:1 移植**——只吸收 lifecycle discipline，不吸收 repo 组织 / progressive disclosure 实现 / agent-created auto-activate 路径
+- **不修改 Hermes 上游代码**——上游 fork 仅作只读参考
+
+---
+
+## Adoption Checkpoints
+
+| Checkpoint | 触发时机 | 验证项 |
+|-----------|---------|-------|
+| **C1. 本 ADR + P1-Doctrine + P1-a 三件就位** | 本 ADR 通过后 | 三份 ADR 互引一致；SYSTEMS.md 引用本 ADR 为 skill lifecycle SSOT |
+| **C2. SkillLifecycleState 状态机落入 contract schema** | 第一个 contract ADR 引用 lifecycle 时 | `_meta/contracts/skill/lifecycle-state.schema.yaml` 建立；ALLOWED_TRANSITIONS 由 schema 强制 |
+| **C3. Quarantine 目录隔离生效** | Loamwise `construct/` 实施时 | quarantine 目录与 active 目录物理分离；dispatcher 仅扫描 active |
+| **C4. PromotionPolicy 默认集落地** | 任何 candidate 准备 promote 时 | 4 种 TrustSource 各有默认 PromotionPolicy；缺失 = 拒绝 promote |
+| **C5. Lifecycle log hash chain 强制** | P1-e Session taxonomy 落地时 | 每条 LifecycleTransition append-only + hash chain；篡改可被 replay 检出 |
+| **C6. 现有 ADR-005 supersede** | 本 ADR 通过后立即 | `ADR-005-Hermes-Skill-Lifecycle.md` 标注 `Superseded by: ADR-Hermes-Skill-Lifecycle.md`。**主题级 supersede，不要求物理删除旧文件** |
+
+**本 ADR 不实施任何代码**。Adoption checkpoints 是后续阶段的入库门，不在本轮执行。
+
+---
+
+## Appendix A: 与 ADR-005（旧版）的关系
+
+旧 `ADR-005-Hermes-Skill-Lifecycle.md` 写于 2026-04-14（P1-Doctrine 之前），结构正确但缺少：
+1. Meta Declaration 头部
+2. BGHS 分类映射
+3. 显式状态机（旧版用文字描述）
+4. PromotionDecision / QuarantineDecision / LifecycleTransition 的 schema
+5. 与 P1-a CapabilityKind 的对接
+
+**ADR-005 处置**：保留为历史记录（同 ADR-004），主题以本 ADR 为准。
+
+---
+
+**Version**: 1.0.0
+**Last Updated**: 2026-04-16

--- a/_meta/adr/ADR-Loamwise-Guard-Content-Security.md
+++ b/_meta/adr/ADR-Loamwise-Guard-Content-Security.md
@@ -1,0 +1,478 @@
+---
+artifact_scope: meta
+artifact_name: Loamwise-Guard-Content-Security
+artifact_role: harvest
+target_layer: 1
+is_bghs_doctrine: no
+---
+
+# ADR — Loamwise Guard Content Security（P1-d）
+
+**Status**: Accepted
+**Date**: 2026-04-16
+**Accepted-Date**: 2026-04-17
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-Loamwise-Guard-Content-Security.md`
+**References**:
+- `_meta/adr/ADR-Architecture-Doctrine-BGHS-Separation.md`（必读前置）
+- `_meta/adr/ADR-OpenClaw-Capability-Boundary.md`（capability 边界 + DecisionAuthority）
+- `_meta/adr/ADR-Hermes-Skill-Lifecycle.md`（lifecycle 治理 + ContentScanGuard 引用）
+- `_meta/adr/ADR-Hermes-Memory-Orchestration.md`（memory 编排 + ContentScanGuard + TruthWriteGuard 引用）
+- **Forward ref**: `_meta/adr/ADR-Session-and-Session-Adjacent-Taxonomy-Federated-Query.md`（P1-e，提供 GuardEvidence 写入位置）
+**Source**: `/Users/liye/github/hermes-agent/`（fork 自 `NousResearch/hermes-agent`，只读参考）
+
+---
+
+## Context
+
+LLM-driven 系统在 4 个位置存在内容级威胁面：
+
+1. **上下文注入**（ingest）：恶意内容混入 system prompt / context，劫持模型推理
+2. **危险命令 / 工具 payload**（execution）：模型输出含危险 shell / API 调用
+3. **记忆写入投毒**（memory write）：恶意内容写入持久记忆，跨会话长期影响
+4. **技能供应链**（skill / capability registration）：恶意 skill / capability 进入注册表（已由 P1-b 处理）
+
+Hermes Agent 在前 3 个位置都有 regex / heuristic 级实现，体量适中、模式可读、容易移植。但 Hermes 的 guard 普遍是**默认 hard block + 单点扫描**；LiYe Systems 必须**先 shadow mode**（与 SYSTEMS.md P2 硬约束一致），再按证据 escalate 到 active 拦截。
+
+更关键的是：**Guards 是 Governance**——它们是跨模型代际不放松的不变量；它们的实现是 Hands。**Guards 不产生 truth，只分类威胁**——它们的 verdict 不能被任何路径提升为 authoritative（与 P1-c §1 derivation_rule 对齐）。
+
+本 ADR 萃取 Hermes 的内容安全 patterns，落成 LiYe Systems 的 GuardChain contract——**回答"哪些路径必经 guard、guard verdict 如何进入治理链"，不写扫描器功能目录**。
+
+Guard contract 由 Layer 0 定义；GuardChain 与各 Guard 实现由 Loamwise（Layer 1）落地，路径在 `loamwise/govern/guards/`。
+
+---
+
+## 上游核心做法（Hermes 的内容安全实现）
+
+### H1. 上下文注入扫描（ingest 路径）
+
+`/Users/liye/github/hermes-agent/agent/prompt_builder.py`：
+- `_CONTEXT_THREAT_PATTERNS` 列出已知 prompt injection 标志（如"忽略上述指令"、"系统提示"伪装等）
+- `_scan_context_content()` 在文件 / context 进入 system prompt **之前**扫描
+- 命中 = 阻断该 fragment 进入 prompt（不静默）
+
+### H2. 危险命令检测（execution 路径）
+
+`/Users/liye/github/hermes-agent/tools/approval.py`：
+- `DANGEROUS_PATTERNS`（35+ 条）覆盖 shell / API / 凭据外泄 / fs 越界
+- **Unicode normalization** 在匹配前执行，防止字符变形绕过
+- 命中 → 转 approval flow（用户确认）
+
+### H3. 外部二进制扫描器（Tirith）
+
+`/Users/liye/github/hermes-agent/tools/tirith_security.py`：
+- 调用外部二进制 `tirith` 做扫描
+- exit-code → verdict（allow / block / warn）
+- **fail-open 配置**（二进制不存在时跳过）
+
+### H4. 记忆写入保护（memory write 路径）
+
+`/Users/liye/github/hermes-agent/tools/memory_tool.py`：
+- `_MEMORY_THREAT_PATTERNS` 针对持久化记忆的特殊威胁（如自我引用 prompt 注入、token 泄漏）
+- `_scan_memory_content()` 在 MEMORY.md / USER.md 写入前扫描
+
+### H5. Skill 供应链扫描（已在 P1-b 覆盖）
+
+`/Users/liye/github/hermes-agent/tools/skills_guard.py`（80+ 条规则、4 级 trust、3 级 verdict）——本 ADR 不重复 P1-b 已覆盖的内容，仅在必要时复用其扫描结果作为 ContentScanGuard 的实现一部分。
+
+---
+
+## 吸收什么
+
+| 编号 | 吸收项 | 理由 |
+|------|-------|------|
+| **A1** | **三类内容威胁分层（context-inject / dangerous-command / memory-write）** | 与 LiYe 4 个治理位点直接对齐，命名与 P1-b/c 一致 |
+| **A2** | **Regex / heuristic pattern-based scanning** + **可解释的命中证据** | 模式可读、可审计；非 ML 黑盒，符合 Governance 可解释要求 |
+| **A3** | **Unicode normalization 反绕过** | 任何输入扫描前必先 NFC 归一 + 非可见字符剔除 |
+| **A4** | **Pre-write scanning**（写入前扫描，不是事后审计） | 与 P1-c MemoryUsePolicy 的 guard_chain_required 对接 |
+| **A5** | **Per-fragment 命中证据 + 脱敏后留痕** | guard verdict 必带 evidence；evidence 可被 replay 验证 |
+
+---
+
+## 不吸收什么
+
+| 编号 | 不吸收项 | 理由 |
+|------|---------|------|
+| **R1** | **默认 hard block**（无 shadow 阶段） | 违反 SYSTEMS.md P2 硬约束；新 guard 必须**先 shadow（只观测不拦截）**，按证据再 escalate |
+| **R2** | **Tirith 外部二进制扫描器** | 增加不可见依赖 + fail-open 默认 = 信任假设错误；LiYe 内置 guard，外部扫描器作为可选 supplement，**不在 default chain** |
+| **R3** | **Approval UX flow**（"用户确认"作为唯一兜底） | LiYe 的 approval 走 Loamwise approval-state-machine 与 P1-b PromotionDecision，不再拼装新 UX |
+| **R4** | **YOLO mode / global bypass switch** | 任何 guard 都不允许全局 bypass；需要绕过必须 ADR + 审计签名 |
+| **R5** | **Smart routing**（"模型自己决定要不要扫"） | guard 路径由 GuardChain 静态声明 + Governance 校验 |
+| **R6** | **Heuristic verdict 提升为 authoritative truth** | guard verdict 永远是**威胁分类**，不是 truth；不得进入 P1-c authoritative tier |
+| **R7** | **Fail-open 默认**（扫描器不可用 = 放行） | LiYe Systems 一律 **fail-closed**：guard 不可用 = 拒绝相应操作 |
+| **R8** | **单点扫描**（一次过完事） | 关键路径需 GuardChain（多 guard 串/并联），并且不同 guard 可独立 shadow / active |
+| **R9** | **把 Loamwise Guard 写成"万能内容安全平台"** | Guards 只覆盖 P1-d 显式声明的 4 个治理位点；不主动扩展到 anti-malware / DLP / SIEM 等领域 |
+
+---
+
+## 与 LiYe Systems 分层与 BGHS 的映射
+
+> 不再定义 BGHS 规则——见 P1-Doctrine §1。
+
+| Hermes 组件 | LiYe 视角 primary concern | 在 LiYe Systems 的对应位置 |
+|------------|--------------------------|--------------------------|
+| `prompt_builder._scan_context_content` | **Governance** (rule) + **Hands** (impl) | Layer 0 contract（ContextInjectGuard 定义）+ Layer 1 实现（`loamwise/govern/guards/context-inject/`） |
+| `approval.DANGEROUS_PATTERNS` | **Governance** (规则集) | Layer 0 contract（ContentScanGuard 的 dangerous-command 规则集） |
+| `memory_tool._scan_memory_content` | **Governance** + **Hands** | Layer 1 — TruthWriteGuard 的实现一部分 |
+| `tirith_security`（外部二进制） | — | **不吸收**（R2） |
+| `skills_guard`（80+ 规则） | **Governance** (规则) | 已由 P1-b 覆盖；本 ADR 不重复 |
+| Unicode normalization 流程 | **Hands** | Layer 1 — 所有 Guard 共享 utility |
+| Verdict 分级 (safe/caution/dangerous) | **Governance** | Layer 0 contract（GuardVerdict 枚举） |
+| Pattern 命中 evidence 收集 | **Session** (脱敏后的命中记录) | session-adjacent，由 P1-e 定义存储位置 |
+
+**Layer 归属**：
+- **Layer 0（liye_os）**：定义 GuardKind / GuardVerdict / GuardEvidence / GuardEnforcementMode / GuardChain spec、各 Guard 的 input/output 接口、threat catalog 模式
+- **Layer 1（loamwise）**：实施各 Guard 的扫描器、Guard 串/并联编排（GuardChain runtime）、shadow → active escalation runtime、Unicode normalization utility
+
+**容易错判**：
+
+| 容易错判 | 正确判法 |
+|---------|---------|
+| 把 Guard 实现判为 Governance（"它管安全"） | 实现随模式集 / 引擎演化 → Hands；"必须有 guard 拦截"这条规则 → Governance |
+| 把 GuardVerdict 判为 truth（"它说危险就是危险"） | Verdict 是**威胁分类**，不是 truth；不得进入 P1-c authoritative tier（R6） |
+| 把 shadow mode 判为 Brain（"它是观察模式"） | shadow / active 是 enforcement mode（Governance 视角下的部署阶段），不是 harness 选择 |
+
+---
+
+## Guard Rules（裁判手册）
+
+### G1. 三类内容 Guard（与 P1-b/c 命名严格对齐）
+
+**仅以下三种 Guard 进入 default GuardChain**（不允许平行命名 / 隐式新增）：
+
+| GuardKind | 主关注位点 | 触发路径 |
+|-----------|----------|---------|
+| `ContentScanGuard` | 通用内容扫描（dangerous command / 凭据 / 已知 prompt injection 标志） | skill candidate 提交 / memory write / context ingest（共享 scanner pool） |
+| `TruthWriteGuard` | 写入 authoritative tier 的额外保护 | 任何 → MemoryTier.AUTHORITATIVE 的写入 / authoritative session event 写入 |
+| `ContextInjectGuard` | system prompt / frozen snapshot 装配前的注入扫描 | MemoryAssemblyPlan 装配 frozen snapshot 之前 |
+
+新增 GuardKind 必须经 Layer 0 后续 contract ADR（与 P1-Doctrine D5 一致：具体决策/不变量改 contract ADR，不修 Doctrine）。
+
+### G2. 必经 Guard 的路径清单（白名单）
+
+以下路径**必经** GuardChain（不可绕过）：
+
+| 路径 | 必经 Guard 集 | 来源 |
+|------|--------------|------|
+| Skill candidate 提交（任意 source） | `ContentScanGuard` | P1-b §8 acceptCandidate |
+| Skill promotion（→ ACTIVE） | `ContentScanGuard`（重新扫描）+ `TruthWriteGuard`（如声明 authoritative capability） | P1-b §4 PromotionDecision |
+| Memory write to `decision-support` / `context-only` | `ContentScanGuard` | P1-c §5 MemoryUsePolicy.write_allowed_by |
+| Memory write to `authoritative` | `ContentScanGuard` + `TruthWriteGuard` | P1-c §5 |
+| MemoryAssemblyPlan 装配 frozen snapshot | `ContextInjectGuard`（对每个 fragment） | P1-c §4 |
+| 任何 Engine / Skill 的 capability registration | `ContentScanGuard`（针对 declaration / metadata） | P1-a §2 register() |
+
+**未在白名单内的路径不强制经 Guard**——但任何想引入新路径都必须扩展本表（Layer 0 contract ADR）。
+
+### G3. Shadow mode FIRST，按证据再 escalate（SYSTEMS.md P2 硬约束）
+
+任何 Guard 上线必须按以下阶段：
+
+| 阶段 | mode | 行为 | escalation 条件 |
+|------|------|------|----------------|
+| 1. **Shadow** | `shadow` | 只观测、写 GuardEvidence；**不拦截、不影响调用方** | 累计 N 次（policy-defined）以上 caution+ verdict + 无误报 → 进 advisory |
+| 2. **Advisory** | `advisory` | 写 evidence + 在调用方 response 内附 warning；**仍不拦截** | M 次以上无规避 / 无破坏性 false-positive → 进 active |
+| 3. **Active** | `active` | dangerous → block（fail-closed）；caution → escalate to approval；safe → pass | — |
+
+**降级方向**（active → advisory / shadow）：仅在出现高频 false-positive 或线上事故时由 Guard owner + Loamwise maintainer 双签 ADR 触发。
+
+### G4. Verdict 是威胁分类，不是 truth
+
+- GuardVerdict 永远不进入 P1-c authoritative tier
+- GuardVerdict 永远不直接驱动 P1-a DecisionKind 决策（除非显式 policy ADR 引用 verdict 作为决策输入）
+- Verdict 只能作为**否决信号**（active mode block）或**证据信号**（写入 GuardEvidence）
+
+### G5. Fail-closed 默认（与 R7 对齐）
+
+- Guard 实现不可用 / 超时 / 异常 → 该路径**拒绝放行**（fail-closed）
+- 例外：shadow mode 下 fail-open 是允许的（不拦截，仅写"扫描失败"evidence），但 advisory / active 必须 fail-closed
+- 全局 fail-open 开关 = **禁止存在**（R4）
+
+### G6. Pattern 集合是 Governance；扫描器实现是 Hands
+
+- **威胁 pattern catalog**（regex / heuristic 模式集）是 Governance：增删需经 contract ADR 或 policy ADR
+- **扫描器实现**（如何高效执行匹配 / 是否引入 ML 模型）是 Hands：可在 Loamwise 自由演化
+- 实现升级**不允许放松**已声明的 pattern（R-不放松准则）
+
+### G7. Evidence 必须脱敏 + append-only
+
+- GuardEvidence 写入 session-adjacent 存储（位置由 P1-e 定义）
+- 命中片段 **必须脱敏**（如凭据 hash / 长片段截断）后写入；原文不进 evidence
+- Evidence append-only，不可改写
+- Evidence 包含：`guard_id` / `guard_kind` / `mode` / `verdict` / `redacted_snippet` / `pattern_id` / `scanned_at` / `trace_id`
+
+### G8. GuardChain 是静态声明，不是动态拼接
+
+- 每条受保护路径在 Layer 0 contract 里**显式声明** GuardChain 组成（哪些 Guard、串/并联、各自 mode）
+- Loamwise runtime **不允许在运行时插入 / 删除 / 重排** GuardChain 顺序
+- 修改 GuardChain 必须经 contract ADR
+
+---
+
+## Contract Sketch
+
+### §1. GuardKind（三种内容 Guard，固定枚举）
+
+```typescript
+enum GuardKind {
+  CONTENT_SCAN     = 'content-scan',     // 通用内容扫描（dangerous command / credentials / prompt injection markers）
+  TRUTH_WRITE      = 'truth-write',      // authoritative tier 写入保护
+  CONTEXT_INJECT   = 'context-inject',   // system prompt / frozen snapshot 装配前注入扫描
+}
+
+// 扩展通道：新增 GuardKind 必须经 Layer 0 后续 contract ADR
+// 当前不预留占位
+```
+
+### §2. GuardVerdict（威胁分级，固定枚举）
+
+```typescript
+enum GuardVerdict {
+  SAFE       = 'safe',         // 未命中已知威胁模式
+  CAUTION    = 'caution',      // 命中可疑模式，证据不充分
+  DANGEROUS  = 'dangerous',    // 命中已知危险模式
+}
+
+// Verdict 只能由 Guard 实现产生；不得由其他 component 自行声明
+// Verdict 不进入 P1-c authoritative tier（G4）
+// Verdict 不可被外部修改（append-only）
+```
+
+### §3. GuardEnforcementMode（部署阶段，shadow → active 演进）
+
+```typescript
+enum GuardEnforcementMode {
+  SHADOW     = 'shadow',       // 观测 + 写 evidence，不拦截
+  ADVISORY   = 'advisory',     // 观测 + 写 evidence + 调用方 response 附 warning，不拦截
+  ACTIVE     = 'active',       // dangerous = block；caution = escalate；safe = pass
+}
+
+// 任何 Guard 必须从 SHADOW 起步（G3 + SYSTEMS.md P2 硬约束）
+// SHADOW 阶段允许 fail-open；ADVISORY / ACTIVE 必须 fail-closed（G5）
+```
+
+### §4. GuardEvidence（命中证据，脱敏 append-only）
+
+```typescript
+interface GuardEvidence {
+  evidence_id: string                     // UUIDv7
+  guard_id: string                        // 具体 guard 实例 id
+  guard_kind: GuardKind
+  mode: GuardEnforcementMode              // 当时的 mode
+  verdict: GuardVerdict
+  scanned_at: string                      // ISO 8601
+
+  // 关联
+  trace_id: string                        // 指向触发扫描的 session event
+  scanned_path: ScannedPath               // 被扫描的对象（见下）
+
+  // 命中详情（必须脱敏）
+  hits: HitDetail[]
+  scanner_version: string
+  pattern_catalog_version: string
+
+  // fail-closed 状态（如果扫描失败）
+  scanner_failed: boolean                 // 仅 SHADOW 模式可为 true
+  failure_reason: string | null
+}
+
+interface ScannedPath {
+  path_kind: 'skill-candidate' | 'memory-write' | 'frozen-snapshot-fragment' | 'capability-registration'
+  target_ref: string                      // 被扫描对象的 reference（candidate_id / record_id / etc.）
+}
+
+interface HitDetail {
+  pattern_id: string                      // pattern catalog 内的稳定 id
+  category: string                        // 'dangerous-command' / 'credential-leak' / 'prompt-injection' / etc.
+  redacted_snippet: string                // 必须脱敏：凭据 hash / 长片段截断 / 二进制摘要
+  position_hint: string | null            // line / offset 等定位（不含原文）
+  severity_score: number                  // 0..1
+}
+```
+
+### §5. GuardChain（静态声明的 guard 编排）
+
+```typescript
+interface GuardChain {
+  chain_id: string
+  protected_path: ProtectedPath           // 此 chain 保护哪条路径（必须在 G2 白名单内）
+
+  // 静态声明：哪些 guard、什么顺序、各自什么 mode
+  steps: GuardChainStep[]
+
+  // 全局 enforcement override（仅诊断用，需双签 ADR）
+  global_shadow: false                    // 默认禁止；启用必须 ADR 显式注明
+
+  declared_at: string
+  declared_by_adr: string                 // 必须引用具体 ADR
+}
+
+interface GuardChainStep {
+  step_id: string
+  guard_kind: GuardKind
+  mode: GuardEnforcementMode
+  parallel_with: string[] | null          // 与哪些 step_id 并联（默认串联）
+  on_verdict: VerdictRouting              // 不同 verdict 触发的下游行为
+
+  // 非 SHADOW 起步必须显式指向一条 escalation / policy ADR（不是仅靠 chain.declared_by_adr）
+  // SHADOW step：必须为 null
+  // ADVISORY / ACTIVE step：必须非空，且指向一份明确解释为何此 step 已离开 shadow 阶段的 ADR
+  non_shadow_allowed_by: string | null
+}
+
+interface VerdictRouting {
+  on_safe: 'pass'
+  on_caution: 'pass-with-warning' | 'escalate-approval' | 'block'
+  on_dangerous: 'block' | 'escalate-approval'    // 'pass' 永远禁止
+}
+
+enum ProtectedPathKind {
+  SKILL_CANDIDATE_SUBMIT      = 'skill.candidate-submit',
+  SKILL_PROMOTION             = 'skill.promotion',
+  MEMORY_WRITE_NON_AUTH       = 'memory.write.non-authoritative',
+  MEMORY_WRITE_AUTH           = 'memory.write.authoritative',
+  ASSEMBLY_FRAGMENT_INGEST    = 'assembly.fragment-ingest',
+  CAPABILITY_REGISTRATION     = 'capability.registration',
+}
+
+interface ProtectedPath {
+  kind: ProtectedPathKind
+  required_guard_kinds: GuardKind[]       // G2 白名单约束（validator 强制）
+}
+```
+
+### §6. Default GuardChain（NON-NORMATIVE 示意）
+
+下表展示 G2 白名单 6 条路径的默认 chain 组成，**具体 mode 应按 G3 阶段推进**（新部署起点为 SHADOW）。
+
+| Protected Path | Default Chain |
+|---------------|---------------|
+| `skill.candidate-submit` | `ContentScanGuard(shadow)` |
+| `skill.promotion` | `ContentScanGuard(active)` → `TruthWriteGuard(shadow)` if authoritative capability |
+| `memory.write.non-authoritative` | `ContentScanGuard(shadow → advisory → active)` |
+| `memory.write.authoritative` | `ContentScanGuard(active)` ∥ `TruthWriteGuard(shadow → active)`（并联）|
+| `assembly.fragment-ingest` | `ContextInjectGuard(shadow)` per fragment |
+| `capability.registration` | `ContentScanGuard(shadow)` against declaration metadata |
+
+> 每条 chain 的 mode 推进按 G3 阶段制：SHADOW → ADVISORY → ACTIVE，由 policy ADR 给出 escalation 条件与触发证据阈值。
+
+### §7. Validator（注册 / 调用时强制）
+
+```typescript
+function registerGuardChain(chain: GuardChain): RegisterResult {
+  // G2: protected_path 必须在白名单内
+  if (!PROTECTED_PATHS_WHITELIST.has(chain.protected_path.kind)) {
+    return fail('path_not_in_whitelist')
+  }
+  // G2: required_guard_kinds 必须被 chain.steps 完全覆盖
+  const stepKinds = new Set(chain.steps.map(s => s.guard_kind))
+  for (const required of chain.protected_path.required_guard_kinds) {
+    if (!stepKinds.has(required)) return fail(`missing_required_guard_${required}`)
+  }
+  // G3: 每个 step 起步必须 SHADOW；非 SHADOW step 必须 step 级 escalation ADR 显式授权
+  // （仅 chain.declared_by_adr 不够 —— 整条 chain 的 ADR 不能为单个 step 的 mode 升级背书）
+  for (const step of chain.steps) {
+    if (step.mode === GuardEnforcementMode.SHADOW) {
+      if (step.non_shadow_allowed_by !== null) {
+        return fail('shadow_step_must_have_null_non_shadow_allowed_by')
+      }
+    } else {
+      // ADVISORY / ACTIVE 必须有 step 级 escalation 引用
+      if (!step.non_shadow_allowed_by) {
+        return fail('non_shadow_step_requires_escalation_adr_per_step')
+      }
+      // 进一步可校验：non_shadow_allowed_by 指向的 ADR 必须存在 + role = contract|harvest（不是任意笔记）
+    }
+  }
+  // VerdictRouting: on_dangerous 不允许 pass
+  for (const step of chain.steps) {
+    if ((step.on_verdict.on_dangerous as string) === 'pass') {
+      return fail('dangerous_pass_forbidden')
+    }
+  }
+  return ok({ chain_id: chain.chain_id })
+}
+
+function executeGuardStep(step: GuardChainStep, input: ScanInput): StepResult {
+  let evidence: GuardEvidence
+  try {
+    evidence = runScanner(step.guard_kind, input)
+  } catch (e) {
+    if (step.mode === GuardEnforcementMode.SHADOW) {
+      // G5: SHADOW 允许 fail-open + 写"扫描失败"evidence
+      return { verdict: GuardVerdict.SAFE, evidence: failEvidence(e), passed: true }
+    }
+    // ADVISORY / ACTIVE: fail-closed
+    return { verdict: GuardVerdict.DANGEROUS, evidence: failEvidence(e), passed: false }
+  }
+  appendEvidence(evidence)        // G7 append-only
+  return routeVerdict(step, evidence)
+}
+```
+
+---
+
+## Non-goals
+
+- **不实施 §1-§7 的代码**——本 ADR 仅定义 contract 草图与 Guard Rules
+- **不重新定义 BGHS 分类规则**——见 P1-Doctrine
+- **不重述 P1-b skill scan 规则集**——P1-b 已覆盖；本 ADR 仅复用其扫描结果作为 ContentScanGuard 实现来源之一
+- **不定义 session 与 session-adjacent 分类**——交给 P1-e；本 ADR 只声明"GuardEvidence 写 session-adjacent"
+- **不规定具体 pattern 内容**（不在 ADR 里粘 regex）——pattern catalog 由后续 contract ADR / policy ADR 维护，单独冻结版本
+- **不引入外部二进制扫描器（Tirith 等）作为 default chain**（R2）——可作为可选 supplementary scanner，不替代内置 guard
+- **不引入 Approval UX flow**——approval 走 Loamwise approval-state-machine + P1-b PromotionDecision
+- **不引入 ML / 模型驱动的内容判定**——Layer 0 不接受 ML 黑盒作为 Governance verdict 来源；如要引入需 Doctrine 修订
+- **不修改 Hermes 上游代码**——上游 fork 仅作只读参考
+
+---
+
+## Adoption Checkpoints
+
+| Checkpoint | 触发时机 | 验证项 |
+|-----------|---------|-------|
+| **C1. 本 ADR + P1-Doctrine + P1-a/b/c 一致就位** | 本 ADR 通过后 | 五份 ADR 互引一致；SYSTEMS.md 引用本 ADR 为 GuardChain SSOT |
+| **C2. GuardKind 枚举固定到 contract schema** | 第一个 contract ADR 引用 Guard 时 | `_meta/contracts/guard/guard-kind.schema.yaml` 建立；新增 kind 必须经 Layer 0 ADR |
+| **C3. Shadow mode 起点强制** | Loamwise `govern/guards/` 实施时 | 任何 Guard 默认 `mode: SHADOW`；非 SHADOW 起步必须引用 escalation ADR |
+| **C4. G2 白名单完整覆盖** | P1-b/c 任何 contract 字段引用 Guard 时 | 所有 guard_chain_required / 必经 guard 的字段都对应 G2 白名单条目；validator 强制 |
+| **C5. Evidence append-only + 脱敏** | P1-e 落地后 | GuardEvidence 写入 session-adjacent；hits 通过自动脱敏 utility |
+| **C6. Fail-closed 默认强制** | ADVISORY / ACTIVE 第一次启用时 | runtime 异常 / 超时 = block；全局 fail-open 开关不存在 |
+| **C7. 现有 ADR-007 supersede** | 本 ADR 通过后立即 | `ADR-007-Loamwise-Guard-Content-Security.md` 标注 `Superseded by: ADR-Loamwise-Guard-Content-Security.md`。**主题级 supersede，不要求物理删除** |
+
+**本 ADR 不实施任何代码**。Adoption checkpoints 是后续阶段的入库门，不在本轮执行。
+
+---
+
+## Appendix A: 与 P1-b / P1-c 的命名对齐（明示）
+
+本 ADR 严格使用 P1-b / P1-c 已点名的 Guard 命名，**不发明平行命名**：
+
+| 来源 | 引用的 Guard | 在本 ADR 的对应 |
+|------|-------------|----------------|
+| P1-b §8 acceptCandidate | "scan_evidence" / 扫描结果 | `ContentScanGuard` 输出的 GuardEvidence |
+| P1-b §4 PromotionDecision | "scan_evidence: ScanResultRef[]" | 同上；promotion 时若涉及 authoritative capability，加 `TruthWriteGuard` |
+| P1-c §4 MemoryWriteSpec | "guard_chain_required: ('content-scan' \| 'truth-write')[]" | `ContentScanGuard` / `TruthWriteGuard`（命名对齐） |
+| P1-c §4 MemoryAssemblyPlan | snapshot 装配前扫描 | `ContextInjectGuard` per fragment |
+| P1-c §6 MemoryProvider | `on_memory_write` hook | guard 在 hook 之前执行（write 必经 guard） |
+
+**冲突解决**：
+- 命名以本 ADR 为准（GuardKind 枚举值）
+- 协议字段（如 P1-c 的 `guard_chain_required`）必须使用本 ADR 的字符串值（`'content-scan'` / `'truth-write'` / `'context-inject'`）
+
+---
+
+## Appendix B: 与 ADR-007（旧版）的关系
+
+旧 `ADR-007-Loamwise-Guard-Content-Security.md` 写于 2026-04-14（P1-Doctrine 之前），结构正确（已含 3 guard 接口 + shadow mode 字段），但缺少：
+1. Meta Declaration 头部
+2. BGHS 分类映射
+3. Shadow → Advisory → Active 三阶段 escalation rule（旧版只有 shadow / active 二分）
+4. G2 白名单（哪些路径必经哪些 guard）作为 schema 强制
+5. 与 P1-b / P1-c / P1-a 的命名 / 字段对齐声明
+6. Validator 伪代码
+7. Pattern catalog 与 scanner 实现的 Governance vs Hands 分离
+
+**ADR-007 处置**：保留为历史记录（同 ADR-004/005/006），主题以本 ADR 为准。
+
+---
+
+**Version**: 1.0.0
+**Last Updated**: 2026-04-16

--- a/_meta/adr/ADR-OpenClaw-Capability-Boundary.md
+++ b/_meta/adr/ADR-OpenClaw-Capability-Boundary.md
@@ -1,0 +1,407 @@
+---
+artifact_scope: meta
+artifact_name: OpenClaw-Capability-Boundary
+artifact_role: harvest
+target_layer: 0
+is_bghs_doctrine: no
+---
+
+# ADR — OpenClaw Capability Boundary（P1-a）
+
+**Status**: Accepted
+**Date**: 2026-04-16
+**Accepted-Date**: 2026-04-17
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-OpenClaw-Capability-Boundary.md`
+**References**: `_meta/adr/ADR-Architecture-Doctrine-BGHS-Separation.md`（必读前置）
+**Source**: `/Users/liye/github/openclaw/`（fork 自 `openclaw/openclaw`，只读参考）
+
+---
+
+## Context
+
+LiYe Systems 的 Layer 0（LiYe OS）是制度底座，负责定义"能力边界"——什么是平台核心 contract，什么是可替换的实现，什么是 plugin 不得越界的特权。
+
+OpenClaw 是个人 AI 助手平台，把"plugin 主权 vs capability contract"做成了清晰的运行时模型。本 ADR 萃取它的 boundary discipline，用来加固 LiYe Layer 0 的能力注册边界——**不吸收**它的产品形态、不吸收它的 native-plugin 信任假设、不吸收"多 channel 个人助手"世界观。
+
+本 ADR 严格遵守 P1-Doctrine 的 BGHS 分类规则与 Meta Declaration 模板。**本 ADR 不重新发明 Doctrine**，只引用并落实其在 Layer 0 能力边界场景下的约束。
+
+---
+
+## 上游核心做法（OpenClaw 的 boundary 模型）
+
+### O1. Plugin 是 ownership boundary，Capability 是 core contract
+
+OpenClaw 把"谁拥有代码"和"系统能做什么"这两件事**显式分开**：
+
+- **Plugin**：所有权单位（一家供应商、一个功能整合）
+- **Capability**：核心定义的公共接口契约（11 项，固定枚举）
+
+文档原话见 `/Users/liye/github/openclaw/docs/plugins/architecture.md:25-44`、`:223-280`。一个 plugin 可注册多个 capabilities（如 `openai` plugin 同时提供 text/speech/image/media-understanding），但**capability 的契约本身只能由 core 定义，plugin 不得新增 capability 类别**。
+
+### O2. 中心化注册 + 重复注册拒绝
+
+- Plugin 通过 `api.registerProvider()`、`api.registerChannel()`、`api.registerHook()` 等向 core registry 注册
+- 同名 provider/channel/hook 重复注册被显式拒绝，记录 `PluginDiagnostic`，加载继续但该注册被忽略
+- 注册方法清单与防护点定位见 `/Users/liye/github/openclaw/src/plugins/types.ts:1869-1957` 与 `/Users/liye/github/openclaw/src/plugins/registry.ts:241,470,522`
+
+意义：plugin 不能"覆盖"另一个 plugin，core 是唯一的仲裁者。
+
+### O3. 核心保留的不可下沉职责
+
+OpenClaw 把以下能力**保留在 core**，不开放给 plugin：
+
+| 核心保留 | 位置 |
+|---------|------|
+| Session / message dispatch | `/Users/liye/github/openclaw/src/gateway/server-channels.ts` |
+| Manifest 验证与 enablement 决策 | `/Users/liye/github/openclaw/src/plugins/loader.ts` |
+| Capability registry 本身（plugin 不能新增 capability 类别） | `/Users/liye/github/openclaw/src/plugins/registry.ts` |
+| Tool safety policy（allow/deny + owner-only） | `/Users/liye/github/openclaw/src/agents/tool-policy.ts:19-150` |
+| Gateway operator scope（`operator.admin/write/read`） | `/Users/liye/github/openclaw/src/plugins/types.ts:1906-1910` |
+| Plugin 文件系统访问边界（`api.resolvePath()` 限定 plugin root） | core API |
+
+**Plugin 可观察、可贡献、不可改写**这些核心决策。
+
+### O4. Hook 系统是观察+变异点，不是控制点
+
+- 23+ 个 lifecycle hooks（`before_model_resolve` / `inbound_claim` / `message_sending` / `gateway_start` 等），见 `/Users/liye/github/openclaw/src/plugins/hook-types.ts:55-84`
+- Hook 执行顺序由 registry 控制，plugin **不能阻止其他 plugin 的 hook 运行**
+- Hook 用于观察与最小变异（如 normalize model id、override prompt），不是控制流接管
+
+### O5. 信任边界与沙箱缺口（OpenClaw 的取舍）
+
+- **Native plugin 无沙箱**：与 core 同进程同信任边界（`/Users/liye/github/openclaw/docs/plugins/architecture.md:442-452`）
+- **Workspace plugin 可 shadow bundled plugin**：开发/补丁场景的有意设计
+
+这是 OpenClaw 在"个人助手 / 单用户 / 单进程"上下文下的合理取舍，**但不适用于 LiYe Systems**——见下文 §不吸收。
+
+---
+
+## 吸收什么
+
+| 编号 | 吸收项 | 理由 |
+|------|-------|------|
+| **A1** | "Plugin = ownership boundary, Capability = core contract" 这条**根本分类原则** | 直接对应 P1-Doctrine 的 Governance（capability contract）vs Hands（plugin 实现）分离 |
+| **A2** | **Capability 类别只能由 core 定义**（plugin 不得新增 capability kind） | Layer 0 制度底座的本职职责，不可下放 |
+| **A3** | **重复注册显式拒绝 + 诊断记录**（不静默接受、不允许覆盖） | Governance invariant：注册边界单调（plugin 不能改写他人） |
+| **A4** | **核心保留 dispatch / registry / policy / auth 决策**（plugin 只能 observe + 最小变异） | 防止"agent loop / approval / scope 检查被 plugin 拦截改写"的越界 |
+| **A5** | **Plugin 文件系统访问受 root 限定**（不允许任意访问 host fs） | Hands 的执行边界，必须有 capability path scope |
+| **A6** | **Gateway operator scope 三级**（admin / write / read） | Layer 0 暴露 gateway 时的最小权限模型 |
+
+---
+
+## 不吸收什么
+
+| 编号 | 不吸收项 | 理由 |
+|------|---------|------|
+| **R1** | **Native plugin 无沙箱**（与 core 同信任边界） | LiYe Systems 的 Domain Engine 与 Loamwise plugin 必须有显式信任边界，不得共享 host 进程的所有特权 |
+| **R2** | **Workspace plugin shadow bundled plugin** 机制 | 在开发期合理，但生产期会绕过 contract 验证。LiYe 用 quarantine + ADR 替代 shadow |
+| **R3** | **23+ 个 lifecycle hook 的细粒度** | 这是 model-contingent harness 设计（Brain 范畴），会随模型/用例变化。LiYe 只在 Layer 0 暴露最小 hook 集合，hook 扩张归 Loamwise |
+| **R4** | **"个人助手 + 多 channel 接入"产品形态** | OpenClaw 的 channel/provider 抽象服务于个人 AI 助手；LiYe 的 Layer 0 不接 channel，channel 概念归 Layer 3 产品线 |
+| **R5** | **Hook 注入决策逻辑（如 `before_model_resolve`）** | LiYe Governance 不允许把决策走 prompt/hook 注入；决策必须在 contract / policy ADR 明文 |
+| **R6** | **`api.registerSecurityAuditCollector(collector)` 的"plugin 自报审计"模式** | 审计写入路径必须由 core 控制（见 P1-e Session taxonomy）；plugin 不得自己声明"审计已生成" |
+| **R7** | **Gateway 作为单一 control plane** | LiYe 是分层架构（Layer 0/1/2/3），不存在唯一 gateway 集中所有 control。OpenClaw 的 operator scope 模型可吸收，gateway 一元化不可吸收 |
+
+---
+
+## 与 LiYe Systems 分层与 BGHS 的映射
+
+> 本节不再定义 BGHS 规则——参见 P1-Doctrine §1 裁决规则与 §2 Component Declaration。本节只把 OpenClaw 的具体组件映射为 LiYe 视角下的分类，作为"哪些类别需要 Layer 0 capability boundary 保护"的参照。
+
+| OpenClaw 组件 | LiYe 视角的 primary concern | 在 LiYe Systems 的对应位置 |
+|--------------|---------------------------|--------------------------|
+| Capability registry（11 项 capability 契约） | **Governance** | Layer 0 — `_meta/contracts/` 与本 ADR 的 Contract Sketch |
+| Plugin loader（manifest-first 验证） | **Governance** (secondary: Hands) | Layer 0 — capability registration gate（待建） |
+| Plugin runtime（jiti 加载） | **Hands** | Layer 1 / Layer 2 — Loamwise 与各 Engine 的实现 |
+| Lifecycle hook 集合 | **Brain** | Layer 1 — Loamwise 的 harness（不在 Layer 0） |
+| Tool policy（allow/deny / owner-only） | **Governance** | Layer 0 — 现有 `src/control/a3-write-policy.ts` 的扩展 |
+| Gateway operator scope | **Governance** | Layer 0 — `src/gateway/openclaw/hmac.ts` 已有，待扩展 scope 三级 |
+| Session/thread bookkeeping | **Session** | Layer 0 — `data/traces/`（authoritative session event streams，参见 P1-Doctrine §5.5） |
+| Native plugin（无沙箱） | — | **不吸收**（见 R1） |
+
+**容易错判的点**（按 P1-Doctrine §1 反例速查的格式补充）：
+
+| 容易错判 | 正确判法 |
+|---------|---------|
+| 把 "capability contract" 判为 Hands（"反正最后是要被调用的"） | Contract 跨模型代际不变 → Governance；调用实现 → Hands |
+| 把 "lifecycle hook 列表" 判为 Governance（"它管 plugin 怎么挂钩"） | hook 列表随 harness 演化 → Brain；"必须有 hook 边界"这条规则 → Governance |
+| 把 "plugin 注册接口" 判为 Brain（"是 API 设计"） | 注册边界是制度（不可被 plugin 改写）→ Governance；接口的具体形状 → Hands 实现细节 |
+
+---
+
+## Boundary Rules（裁判手册）
+
+以下规则适用于 LiYe Systems 任何"能力 / 注册 / 插件 / 扩展"相关决策。**违反 = 架构违规**。
+
+### B1. Capability 类别由 Layer 0 独占定义
+
+- **新 capability 类别**（如"价格情报"、"广告写操作"、"会话检索"）的契约必须在 Layer 0 `_meta/contracts/` 中定义
+- **任何 Layer 1/2/3 组件不得自行声明新的 capability kind**——只能实现 Layer 0 已定义的 kind
+- 新 capability kind 的引入必须经独立 contract ADR
+
+> 对应 OpenClaw 的 A1/A2
+
+### B2. 注册边界单调，禁止覆盖
+
+- 任何 capability / engine / skill 的注册一旦成立，**其他注册者不得覆盖**
+- 同名重复注册必须**显式失败 + 诊断写入 session log**（不是静默接受、不是 last-write-wins）
+- 替换注册必须经"撤销旧注册 → 验证一致性 → 新注册"三步，不允许原地改写
+
+> 对应 OpenClaw 的 A3。**禁止**继承 OpenClaw 的 workspace shadow（R2）
+
+### B3. 决策面与执行面分离
+
+以下决策**不得下沉到 plugin / tool wrapper / hook**：
+
+| 决策类型 | 必须由 |
+|---------|--------|
+| **Capability 准入** | Layer 0 capability registration gate |
+| **Approval 判定** | Loamwise approval-state-machine 或 Layer 0 policy ADR |
+| **Tool safety policy 判定** | Layer 0 tool-policy（如 `src/control/a3-write-policy.ts`） |
+| **Operator scope 判定** | Layer 0 gateway 层 |
+| **Session 写入路径** | Layer 0 session contract（参见 P1-e）；**plugin 不得自行声明"审计完成"** |
+
+Plugin / Engine 可**观察**这些决策（通过最小 hook 集合），可**贡献输入**（如 candidate 元数据），但**不得拦截改写**。
+
+> 对应 OpenClaw 的 A4，并修补 R6（plugin 不得自报审计）
+
+### B4. 信任边界显式，禁止"原地特权扩散"
+
+- Plugin / Engine 必须有显式 trust boundary 声明（最低权限默认）
+- **不得继承 host 进程的所有特权**（这是 R1 的反命题）
+- 文件系统访问受 capability path scope 限定（对应 A5）；网络访问受 capability 声明限定
+- 没有显式声明的能力 = 没有该能力（fail-closed，不是 fail-open）
+
+### B5. Hook 集合最小化，并归属 Brain
+
+- Layer 0 仅暴露**结构性 hook**（capability lifecycle: register / activate / deactivate / unregister）
+- **决策 hook（如 `before_model_resolve` 类）不在 Layer 0**——归 Loamwise harness（Brain）
+- Hook 的扩张必须经 Loamwise 的 harness contract，不得偷偷扩到 Layer 0
+
+> 对应 R3、R5
+
+### B6. Gateway 不是唯一 control plane
+
+- Layer 0 gateway（如 `src/gateway/openclaw/`）只暴露**与 Layer 0 capability 相关**的 RPC
+- 其他控制权限属于其他层（Loamwise 调度、Engine 内部 control）
+- **不得把所有控制集中到一个 gateway**——这是 R7
+
+> Operator scope 三级（admin / write / read）可吸收（A6），gateway 一元化不可吸收
+
+---
+
+## Contract Sketch
+
+### §1. CapabilityKind Registry（Layer 0 独占定义）
+
+```typescript
+// 位置：_meta/contracts/capability/capability-kind.schema.yaml （待建）
+// 由 Layer 0 维护；Layer 1/2/3 只能引用，不能新增
+
+type CapabilityKind = string  // 形如 "engine.write.amazon-ads-bid"
+                              //      "session.event-stream.v1"
+                              //      "guard.content-scan.v1"
+                              //
+                              // 注：本 ADR 仅给出命名示例。具体的命名模式
+                              // （如三段式 grammar / regex 校验）留给后续
+                              // contract schema 定义；不在本 ADR 内写死。
+
+interface CapabilityKindRegistration {
+  kind: CapabilityKind
+  layer_introduced: 0           // 永远是 0；非 Layer 0 不能新增
+  contract_adr: string          // 必填，指向定义此 kind 的 ADR
+  contract_schema: string       // 必填，指向 schema 文件
+  introduced_at: string         // ISO 8601
+  superseded_by: string | null  // 若被替代，指向新 kind
+  status: 'proposed' | 'active' | 'frozen' | 'superseded'
+}
+```
+
+**入库规则**：
+
+- 新增 `CapabilityKind` 必须经独立 contract ADR
+- `layer_introduced` 字段固定为 `0`（registration validator 强制 + schema 默认值约束）
+- `contract_adr` 与 `contract_schema` 缺一不入库
+
+### §2. CapabilityRegistration（注册条目，由 Layer 1/2/3 提交）
+
+```typescript
+// 任何 Engine / Skill / Guard / Adapter 注册"我能做什么"时使用
+
+interface CapabilityRegistration {
+  capability_id: string         // 形如 "amazon-growth-engine:bid_write"
+  kind: CapabilityKind          // 必须引用已注册的 kind（B1）
+  owner: {
+    layer: 1 | 2 | 3            // Layer 0 不作为 owner（Layer 0 只定义 kind）
+    component: string           // e.g., "amazon-growth-engine"
+    declaration_path: string    // 指向 owner 的 Component Declaration
+  }
+  trust_boundary: TrustBoundaryDecl     // 见 §4，B4 强制
+  side_effects: SideEffectDecl[]        // 写操作 / 网络 / 文件 / etc
+  observed_by: string[] | null          // 允许 observe 此 capability 的其他 component（最小集合）
+  registered_at: string
+  status: 'pending' | 'active' | 'quarantined' | 'revoked'
+}
+```
+
+**注册边界规则（B2 落地）**：
+
+```typescript
+function register(reg: CapabilityRegistration): RegisterResult {
+  // B1: kind 必须由 Layer 0 已定义
+  if (!capabilityKindRegistry.has(reg.kind)) {
+    return { ok: false, reason: 'unknown_kind', diagnostic: ... }
+  }
+  // B2: 重复注册显式拒绝
+  const existing = registry.findByCapabilityId(reg.capability_id)
+  if (existing && existing.status === 'active') {
+    return { ok: false, reason: 'duplicate_active', diagnostic: ... }
+  }
+  // B4: trust_boundary 缺失 = fail-closed
+  if (!reg.trust_boundary || !reg.trust_boundary.fs_scope) {
+    return { ok: false, reason: 'missing_trust_boundary' }
+  }
+  // 写入注册 + 写入 session event stream（B3 + P1-e）
+  return { ok: true, registration_id: ... }
+}
+```
+
+### §3. Decision Plane Separation（B3 落地）
+
+```typescript
+// 决策类型白名单（初始集合见下方枚举）
+enum DecisionKind {
+  CAPABILITY_ADMISSION   = 'capability.admission',     // Layer 0 only
+  APPROVAL               = 'approval',                  // Loamwise or Layer 0 policy ADR
+  TOOL_SAFETY            = 'tool.safety',               // Layer 0 tool-policy
+  OPERATOR_SCOPE         = 'operator.scope',            // Layer 0 gateway
+  SESSION_WRITE          = 'session.write',             // Layer 0 session contract (P1-e)
+}
+
+interface DecisionAuthority {
+  kind: DecisionKind
+  authoritative_layer: 0 | 1
+  authoritative_path: string    // 指向决策实现 / contract
+  observers_allowed: string[]   // 允许 observe 此决策的 component 集合
+  override_allowed: false       // 永远 false；override 必须走 ADR
+}
+```
+
+**`DecisionKind` 的扩展通道（分层规则，与 P1-Doctrine D5 一致）**：
+
+| 扩展类型 | 修订通道 |
+|---------|---------|
+| 新增一种**具体决策类型**（如新增一种写操作分类、新增一种 quota 决策） | **Layer 0 后续 contract ADR**（不修 Doctrine、不修本 ADR 的 Boundary Rules） |
+| 决策类型涉及**新的 BGHS 元规则 / artifact taxonomy / declaration 字段**（如引入新的 concern、改 declaration 模板） | 修 P1-Doctrine（再 supersede 本 ADR 的相关条款） |
+
+**Plugin / Engine / Hook 不得出现在任何 `DecisionKind` 的 authoritative_path 中**——由 **registration validator 强制**（schema 给出字段约束，validator 在注册时检查；非纯 schema 即可达成）。
+
+### §4. TrustBoundaryDecl（B4 落地）
+
+```typescript
+interface TrustBoundaryDecl {
+  // 文件系统：必须显式声明可访问的根（fail-closed）
+  fs_scope: {
+    read_roots: string[]    // 绝对路径或 "{component_root}/..."
+    write_roots: string[]
+  }
+  // 网络：必须显式声明可访问的 domain / 协议
+  network_scope: {
+    egress_allowlist: string[]   // hostname patterns
+    ingress: 'none' | 'gateway-only'
+  }
+  // 进程：是否允许在 host 进程内运行
+  in_process: boolean            // false = 独立进程 / 容器
+  // 凭据：指向 CredentialBroker seam（P1-f）
+  credential_path: string | null
+}
+```
+
+**默认值**：`fs_scope` 与 `network_scope` 缺省 = 空（什么都不允许）。**没有显式声明 = 没有该能力**。
+
+### §5. Operator Scope（B6 落地，Gateway 暴露层使用）
+
+```typescript
+type OperatorScope = 'operator.admin' | 'operator.write' | 'operator.read'
+
+interface GatewayMethodRegistration {
+  method: string                 // RPC method name
+  scope_required: OperatorScope
+  capability_id: string | null   // 如果方法暴露某 capability，指向其 registration
+  audit_required: boolean        // true = 调用必须写入 session event stream
+}
+```
+
+**保留命名空间**：`config.*` / `exec.approvals.*` / `wizard.*` 等强制 `operator.admin`，由 Layer 0 gateway 拒绝任何 plugin 注册到这些命名空间。
+
+### §6. End-to-End 注册时序
+
+```
+[Layer 1/2/3 component]                  [Layer 0 registry]
+        |                                          |
+        |--- (1) submit CapabilityRegistration --->|
+        |                                          |--- check B1 (kind exists)
+        |                                          |--- check B2 (no duplicate)
+        |                                          |--- check B4 (trust_boundary)
+        |                                          |
+        |<-- (2) RegisterResult{ok:true, id:..} ---|
+        |                                          |--- (3) write session event
+        |                                          |    (P1-e session.write)
+        |                                          |
+        |--- (4) operate via capability ---------->|
+        |                                          |--- (5) DecisionAuthority check
+        |                                          |    (B3, no plugin override)
+        |                                          |
+        |<-- (6) result + receipt ----------------|--- (7) write session-adjacent
+                                                       receipt (P1-e)
+```
+
+---
+
+## Non-goals
+
+- **不实施 §1-§6 的代码**——本 ADR 仅定义 contract 草图与 boundary 规则
+- **不重新定义 BGHS 分类规则**——见 P1-Doctrine §1
+- **不引入 channel / provider 抽象**——这是 OpenClaw 产品形态，不归 Layer 0
+- **不实现 plugin 沙箱机制**——本 ADR 只声明"必须有 trust boundary"，沙箱实现由各 component 自行选择（容器 / VM / WASM / 进程隔离）
+- **不规定 CredentialBroker 的具体实现**——交给 P1-f
+- **不规定 Session event stream 的具体格式**——交给 P1-e
+- **不修改 OpenClaw 上游代码**——上游 fork 仅作只读参考
+
+---
+
+## Adoption Checkpoints
+
+按以下顺序采纳本 ADR 的 Boundary Rules：
+
+| Checkpoint | 触发时机 | 验证项 |
+|-----------|---------|-------|
+| **C1. Doctrine + Boundary 双就位** | 本 ADR 通过后 | P1-Doctrine + 本 ADR 入库；SYSTEMS.md 引用本 ADR 为 Layer 0 能力边界 SSOT |
+| **C2. CapabilityKind registry 落地** | 第一个新 contract ADR（如 P1-e）入库时 | `_meta/contracts/capability/capability-kind.schema.yaml` 建立；Layer 0 强制 schema |
+| **C3. Trust boundary 强制** | 任何新 Engine / Skill 注册到 Layer 0 时 | Component Declaration 必含 `TrustBoundaryDecl`；fail-closed 默认 |
+| **C4. 决策面分离审计** | 每季度一次 | 扫描 `Layer 1/2/3` 代码，确认无 plugin / hook 出现在 `DecisionAuthority.authoritative_path` 中 |
+| **C5. Gateway scope 三级生效** | 现有 `src/gateway/openclaw/` 改造时 | `OperatorScope` 三级落到 HMAC 验证后；保留命名空间由 gateway 注册 validator 强制（plugin 不得注册到 `config.*` / `exec.approvals.*` / `wizard.*` 等命名空间） |
+| **C6. 现有 ADR-004 supersede** | 本 ADR 通过后立即 | `ADR-004-OpenClaw-Capability-Boundary.md` 标注 `Superseded by: ADR-OpenClaw-Capability-Boundary.md`。**这是主题级 supersede（同一主题以新版为准），不要求物理删除旧文件**——旧 ADR 作为历史记录保留 |
+
+**本 ADR 不实施任何代码**。Adoption checkpoints 是后续阶段的入库门，不在本轮执行。
+
+---
+
+## Appendix A: 与 ADR-004（旧版）的关系
+
+旧 `ADR-004-OpenClaw-Capability-Boundary.md` 写于 2026-04-14，基于 `openclaw-skillgate` 仓（Layer 0 扩展插件，非 OpenClaw 本体）。
+
+**本 ADR supersede ADR-004 的关键差异**：
+
+1. 直接基于 OpenClaw 上游本体（`/Users/liye/github/openclaw/`）萃取，源材料更准确
+2. 引入 P1-Doctrine 的 BGHS 分类，旧 ADR 写作时尚无此 doctrine
+3. 添加 Meta Declaration 头部
+4. 把"Registration Scan Gate"等 skillgate 特有的扫描细节剥离——那些应在 P3（Skill candidate quarantine）中讨论
+5. 把"决策面分离"做成显式 schema（B3 + DecisionAuthority），而非旧版的散文描述
+
+**ADR-004 处置**：保留为历史记录，状态改为 `Superseded by: ADR-OpenClaw-Capability-Boundary.md`（实际改字段动作不在本 ADR 范围，留待入库流程执行）。
+
+---
+
+**Version**: 1.0.0
+**Last Updated**: 2026-04-16

--- a/_meta/adr/ADR-Session-and-Session-Adjacent-Taxonomy-Federated-Query.md
+++ b/_meta/adr/ADR-Session-and-Session-Adjacent-Taxonomy-Federated-Query.md
@@ -1,0 +1,644 @@
+---
+artifact_scope: meta
+artifact_name: Session-and-Session-Adjacent-Taxonomy-Federated-Query
+artifact_role: contract
+target_layer: cross
+is_bghs_doctrine: no
+---
+
+# ADR — Session / Session-Adjacent Taxonomy + Federated Query（P1-e）
+
+**Status**: Accepted
+**Date**: 2026-04-16
+**Accepted-Date**: 2026-04-17
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-Session-and-Session-Adjacent-Taxonomy-Federated-Query.md`
+**References**:
+- `_meta/adr/ADR-Architecture-Doctrine-BGHS-Separation.md`（必读前置；§5.5 Session 多源 + receipts session-adjacent）
+- `_meta/adr/ADR-OpenClaw-Capability-Boundary.md`（DecisionAuthority + session.write 决策）
+- `_meta/adr/ADR-Hermes-Skill-Lifecycle.md`（LifecycleTransition 是 session-adjacent）
+- `_meta/adr/ADR-Hermes-Memory-Orchestration.md`（MemoryTier 消费侧约束 + query_mode 命名）
+- `_meta/adr/ADR-Loamwise-Guard-Content-Security.md`（GuardEvidence 是 session-adjacent）
+
+---
+
+## Context
+
+P1-Doctrine §5.5 已硬性区分了两个概念：
+- **authoritative session event streams** 可多源
+- **receipts 是 session-adjacent**，不是 session 本体
+
+P1-c 把这条边界进一步落到了 MemoryTier 的消费侧，并在多处 forward ref 本 ADR。
+
+但目前 LiYe 生态内"什么是 session、什么不是"还没有显式 taxonomy。实际现状：
+
+| 路径 | 形态 | 当前归属 |
+|------|------|---------|
+| `liye_os/data/traces/orchestrator/*.json` | per-event JSON 文件 | 未分类 |
+| `liye_os/state/traces/trace-<uuid>/` | per-trace 目录 | 未分类 |
+| `liye_os/verdicts/` | 决策的人类可读解释 | 未分类 |
+| `liye_os/evidence/` | 证据 bundle | 未分类 |
+| `amazon-growth-engine/artifacts/onboarding/STR-*/state_transitions.jsonl` | append-only ndjson | 未分类 |
+
+如果不立即给出 taxonomy + 联合检索接口：
+1. 各 component 会自行造词，命名漂移
+2. P1-c memory orchestration 没有可消费的 session 概念
+3. P1-d guard evidence 不知道写到哪里
+4. P1-b lifecycle transition 同样没有归属
+5. 跨多源的检索（P1-c 的 federated query）只能各自实现
+
+本 ADR 是 **contract 类**（artifact_role: contract），不是从单一上游萃取——它综合 P1-Doctrine 的边界 + LiYe / AGE 现有实现 + Hermes session_search 启发，输出 LiYe Systems 的 session taxonomy 与 federated query 接口。
+
+---
+
+## 现状盘点（LiYe / AGE 现有 + 上游启发）
+
+### S1. LiYe 现有 session-like 数据
+
+- `liye_os/data/traces/orchestrator/*.json` — per-event 单文件，时间戳排序，事实上是 append-only 但格式为 per-event JSON
+- `liye_os/state/traces/trace-<uuid>/` — per-trace 目录，内部含 `events.ndjson` 等
+- `liye_os/data/traces/{a3,d7,a3-batch1,...}/*.json` — 分批试验产生的 per-event 记录
+- `liye_os/data/traces/revalidation/*.json` — 验证回放记录
+
+### S2. AGE 现有 authoritative session pattern
+
+- `amazon-growth-engine/artifacts/onboarding/STR-<id>/state_transitions.jsonl` — append-only ndjson
+- 单 stream 描述一次 onboarding 流程的完整状态变迁
+
+### S3. LiYe 现有 session-adjacent 数据
+
+- `liye_os/verdicts/` — 决策结果的人类可读解释（geo, schema, README）
+- `liye_os/evidence/` — 各类 evidence bundle（canary, e2e, contracts freeze 等）
+- 未来：LifecycleTransition log（P1-b）、GuardEvidence（P1-d）、receipts、approval log
+
+### S4. Hermes session_search_tool 启发
+
+`/Users/liye/github/hermes-agent/tools/session_search_tool.py`：
+- FTS5 全文索引跨 session 搜索
+- LLM summarization 后输出
+- 感知 delegation chain
+
+**吸收**：跨多源联合检索的接口形态；
+**不吸收**：LLM summarization 作为权威输出（与 P1-c R3 一致）；不吸收"chat-history-first"。
+
+### S5. 当前问题
+
+- 没有统一的 stream 注册机制 → 哪些 stream 存在、谁是 owner、retention 如何，都没有 SSOT
+- 没有联合检索接口 → 每个 caller 自己实现（必然漂移）
+- 没有"什么算 session、什么算 session-adjacent"的 taxonomy → P1-Doctrine §5.5 的区分悬空
+
+---
+
+## 吸收 / 不吸收
+
+| 编号 | 吸收 | 理由 |
+|------|------|------|
+| **A1** | **append-only + hash-chain** 作为 authoritative session 的硬属性 | 决策可 replay 的前提；与 P1-Doctrine §5.5 一致 |
+| **A2** | **Federated query 接口**（不强求统一存储） | Hermes session_search 的接口形态；契合"不引入统一 session 存储"硬约束 |
+| **A3** | **多种 stream format 共存**（jsonl / per-event JSON / 其他） | LiYe + AGE 现状要求；不强迫迁移现有数据 |
+| **A4** | **Stream-level descriptor**（owner / retention / format / hash chain） | 联合检索的最小元数据 |
+| **A5** | **delegation chain awareness**（Hermes 启发）—— 跨 stream 的因果关系可见 | 调用 chain 信息对 replay / 审计关键 |
+
+| 编号 | 不吸收 | 理由 |
+|------|--------|------|
+| **R1** | **统一 session 存储**（中心 session store） | 违反 SYSTEMS.md "明确不做"清单；多源是有意设计 |
+| **R2** | **LLM summarization 作为 federated query 的权威输出** | 摘要 = decision-support 上限（与 P1-c §1 一致） |
+| **R3** | **chat-history-first 检索默认** | strict_truth 为默认（与 P1-c O2 一致） |
+| **R4** | **任意 in-place rewrite** | session / session-adjacent 都 append-only；需修订必须新 record + 引用旧 record |
+| **R5** | **把 receipts / verdicts / evidence 当 session 本体** | 与 P1-Doctrine §5.5 硬底线一致：它们都是 session-adjacent |
+| **R6** | **让 LLM 自行决定 query_mode** | query_mode 由 orchestration 层（MemoryAssemblyPlan / FederatedQueryRequest）显式声明 |
+| **R7** | **balanced_recency 作为日常默认** | balanced_recency 仅诊断 / 排查场景，必须显式授权 |
+| **R8** | **session-adjacent 提升为 session** | 派生不可改 tier（与 P1-c O3 一致）：lifecycle log / guard evidence / receipts 不能升格为 authoritative session |
+
+---
+
+## 与 LiYe Systems 分层与 BGHS 的映射
+
+> 不再定义 BGHS 规则——见 P1-Doctrine §1。
+
+| 概念 | LiYe 视角 primary concern | 在 LiYe Systems 的对应位置 |
+|------|--------------------------|--------------------------|
+| Session taxonomy（什么是 session 本体） | **Governance** | Layer 0 — 本 ADR §Contract Sketch §1 |
+| SessionEventStream schema | **Governance** (contract) + **Session** (实例) | Layer 0 contract；实例是各 component 写的事件流 |
+| SessionAdjacentArtifact schema | **Governance** (contract) + **Session** (实例，session-adjacent 子类) | 同上 |
+| StreamRegistry | **Governance** | Layer 0 — 本 ADR §Contract Sketch §3 |
+| StreamAdapter（如何读各种 stream） | **Hands** | Layer 1 — Loamwise `align/streams/` |
+| FederatedQueryRequest schema | **Governance** | Layer 0 — 本 ADR §Contract Sketch §4 |
+| Federated query runtime（fan-out / 聚合） | **Brain** (调度策略) + **Hands** (执行) | Layer 1 — Loamwise `align/federated/` |
+| query_mode 选择 | **Governance** | 本 ADR §F4 强制 |
+| FederatedQueryResult ranking | **Brain** | Loamwise harness（受 priority order 约束） |
+
+**Layer 归属**：
+- **Layer 0（liye_os）**：定义 taxonomy（什么算 session vs adjacent）、SessionEventStream / SessionAdjacentArtifact schema、StreamRegistry contract、FederatedQueryRequest 接口、query_mode 枚举
+- **Layer 1（loamwise）**：实施 StreamRegistry runtime、StreamAdapter、FederatedQuery 执行器、ranking
+- **Layer 2（engines）**：作为 stream owner（写自己的 session event streams + adjacent artifacts），通过 StreamRegistry 注册
+
+**容易错判**：
+
+| 容易错判 | 正确判法 |
+|---------|---------|
+| 把 receipts 判为 session（"它从 session 来") | 派生 / 衍生 → session-adjacent；**只有"事件本身"才是 session** |
+| 把 verdicts 判为 authoritative truth（"决策结果是真理"） | verdict 是对决策的人类解释（Brain 输出） → session-adjacent；authoritative truth 在原始事件流 + contract |
+| 把 federated query runtime 判为 Governance（"它管检索") | 调度策略与执行 → Brain + Hands；"必须有 federated 接口"这条规则 → Governance |
+| 把 LifecycleTransition log 判为 session（"它就是状态变迁事件") | 它是 lifecycle 的 derived audit；属 session-adjacent |
+
+---
+
+## Federation Rules（裁判手册）
+
+### F1. Session 本体的硬属性（authoritative session event stream）
+
+一份数据要被认定为 **session 本体**，必须同时满足：
+
+1. **Append-only**：写入后不可改写（任何修订 = 追加新事件 + 引用旧事件）
+2. **Time-ordered**：事件按时间戳单调排序
+3. **Hash-chained**：每个事件包含 `prev_event_hash`，可被 replay 重新校验
+4. **Owner-declared**：在 StreamRegistry 中有显式 owner / retention / format
+5. **Authoritative for some scope**：声明的 scope 内，本 stream 是 truth-of-record
+
+不满足全部 5 条 = **不是** session 本体。
+
+### F2. Session-adjacent 的定义（派生但非 session）
+
+任何下列特征之一即归为 **session-adjacent**：
+
+- 派生自一个或多个 SessionEventStream（含 derived_from refs）
+- 是对 session 事件的人类可读解释 / 摘要 / 索引
+- 是 lifecycle / approval / guard 等独立工件的 audit log（自身 append-only，但服务于 session 之外的治理流程）
+- 是 receipts / evidence / verdicts
+
+session-adjacent 也必须 **append-only**，但**不要求 hash chain 与 session 等强**——可以只 hash 自身。
+
+### F3. 既非 session 也非 session-adjacent
+
+- 静态 contracts（`_meta/contracts/`）
+- ADRs 本身
+- code / config / skills body / agent definitions
+
+它们若驱动决策，归 P1-c MemoryTier.AUTHORITATIVE，但**不进入 session taxonomy**。
+
+### F4. Query mode 默认 strict_truth；balanced_recency 受限
+
+```
+默认：query_mode = 'strict_truth'
+  ranking 分层（authoritative bucket 优先，内部并列）：
+
+    Bucket 1（authoritative，并列）：
+      - session-event（authoritative session event streams）
+      - static-truth  （F3 的 contracts / ADRs / authoritative compiled records；
+                       仅当 include_static_truth = true 时进入结果集）
+
+    Bucket 2：
+      - session-adjacent（receipts / verdicts / lifecycle log / guard evidence / etc.）
+
+    Bucket 3：
+      - others（如可选的 decision-support 摘要）
+
+  ranking 规则：
+    Bucket 1 内部 = 并列（session-event 与 static-truth 同等优先；
+                          内部按 scope 匹配度 + recency 排序）
+    Bucket 1 整体 严格优先于 Bucket 2
+    Bucket 2 严格优先于 Bucket 3
+    任何情况下：static-truth 不得排在 session-adjacent 之后
+
+  注：static-truth 不进入 session taxonomy（F3），但参与 strict_truth ranking
+      作为 authoritative bucket 的并列成员；这与 P1-c §1 的"派生不得提升 tier"不冲突
+      ——它仍是 P1-c MemoryTier.AUTHORITATIVE，只是在 federated query 结果集中
+      与 session-event 并列展示。
+
+唯一例外：query_mode = 'balanced_recency'
+  仅允许场景：
+    - 诊断 / 排查（debugging / forensics）
+    - 紧急回放分析（incident replay analysis）
+  必须显式：
+    - FederatedQueryRequest.diagnostic_authorization 字段非空
+    - 引用一份 policy ADR / 应急流程 ADR
+    - 写入 audit trail（自身的访问 = session-adjacent 事件，子类 query-audit）
+  禁用场景：
+    - 任何决策路径
+    - 任何 frozen snapshot 装配
+    - 任何 authoritative tier 写入前的检索
+```
+
+LLM **不可自行选择** query_mode（R6）；query_mode 由 MemoryAssemblyPlan / FederatedQueryRequest 在编排层显式设置。
+
+### F5. Federated query 不强求统一存储
+
+- StreamRegistry 是**索引 + 元数据**（哪些 stream 存在、住在哪），不是 stream 本身
+- StreamAdapter 负责"如何读取某种 format 的 stream"（jsonl / per-event JSON / 其他）
+- 联合检索 = StreamRegistry 找 stream → StreamAdapter 各自读取 → 结果按 query_mode 聚合排序
+
+### F6. Stream owner 唯一，registration validator 强制
+
+- 每个 stream 必须有**唯一 owner**（component_id）
+- owner 是该 stream 的 truth-of-record 责任方
+- 同一 stream 不允许多 owner（避免"谁的 truth 是 truth"歧义）
+- registration 时 validator 检查 owner 唯一性
+
+### F7. Append-only + revision-as-append 强制
+
+- 任何 session / session-adjacent 数据修订 = **追加新 record + 引用旧 record**（`supersedes_event_id` 字段）
+- 旧 record **不删除、不改写**——保留可读
+- 联合查询时，按 `supersedes_event_id` 链推断"当前状态"，但所有事件都返回（caller 决定如何使用）
+
+### F8. Federated query 必须可 replay
+
+- 同一 FederatedQueryRequest 在同一时间点（含 stream 状态快照）必须返回相同结果
+- ranking / 摘要 / 折叠 等不确定性步骤必须用 deterministic algorithm 或带 random seed 记录
+- 这是"决策可 replay"的前提
+
+---
+
+## Contract Sketch
+
+### §1. SessionTaxonomy（核心枚举）
+
+```typescript
+enum ArtifactClass {
+  SESSION_EVENT_STREAM       = 'session.event-stream',         // F1 全部 5 条满足
+  SESSION_ADJACENT           = 'session.adjacent',              // F2 至少一条满足
+  NEITHER                    = 'neither',                       // F3
+}
+
+// SessionAdjacent 子分类（非穷举；新增需后续 contract ADR）
+enum SessionAdjacentKind {
+  RECEIPT                    = 'receipt',                       // 决策回执 / 输出快照
+  VERDICT                    = 'verdict',                       // 人类可读决策解释（liye_os/verdicts/）
+  EVIDENCE_BUNDLE            = 'evidence-bundle',               // P1-d GuardEvidence + 现有 evidence/
+  LIFECYCLE_TRANSITION_LOG   = 'lifecycle-transition-log',     // P1-b LifecycleTransition
+  APPROVAL_LOG               = 'approval-log',                  // approval state machine 的 audit log
+  GUARD_EVIDENCE             = 'guard-evidence',                // P1-d GuardEvidence（通常打包进 evidence-bundle，单独子类供细粒度引用）
+  DERIVED_INDEX              = 'derived-index',                 // 全文索引 / 摘要索引等
+  QUERY_AUDIT                = 'query-audit',                   // FederatedQuery 自身访问行为的审计事件（特别是 balanced_recency）
+                                                                // provenance 规则与其他 adjacent 不同：可允许 derived_from = []
+                                                                // （元事件，不派生于具体 stream/artifact），
+                                                                // 由 §3 SessionAdjacentArtifact 的"QUERY_AUDIT 例外条款"规定
+  CREDENTIAL_AUDIT           = 'credential-audit',              // 由 P1-f ADR-Credential-Mediation 驱动的 companion 扩展
+                                                                // broker.resolve() 成功/失败写一条；
+                                                                // derived_from 必须非空（引用触发本次访问的 session event）；
+                                                                // audit_subject 必为 null（audit_subject 是 QUERY_AUDIT 专用）；
+                                                                // payload 详见 P1-f §4 CredentialAuditRecord
+}
+```
+
+### §2. SessionEventStream（authoritative session 的 stream descriptor）
+
+```typescript
+interface SessionEventStream {
+  stream_id: string                             // 形如 "engine.amazon-growth.onboarding.STR-E438213024"
+  owner: {
+    component_id: string                        // F6 唯一 owner
+    layer: 1 | 2                                // Layer 0 / 3 不写 session（参 P1-c source.layer 矩阵）
+  }
+  scope: StreamScope                            // 此 stream 在哪个 scope 内是 authoritative
+
+  // Stream 物理性
+  format: StreamFormat
+  storage_location: string                      // 绝对路径或 URI（多源允许）
+  retention: RetentionPolicy
+
+  // F1 硬属性自证
+  is_append_only: true                          // 必须 true（F1.1）
+  is_hash_chained: true                         // 必须 true（F1.3）
+  hash_alg: 'sha256' | 'blake3'
+
+  // 注册元数据
+  registered_at: string
+  registered_by_adr: string                     // 必须引用一份 ADR（contract / harvest / decision）
+}
+
+interface StreamScope {
+  scope_kind: 'engine-execution' | 'orchestrator-trace' | 'guard-runtime' | string
+  scope_keys: Record<string, string>            // 如 { tenant_id, marketplace, trace_id }
+}
+
+enum StreamFormat {
+  NDJSON_APPEND        = 'ndjson.append',       // AGE state_transitions.jsonl 模式
+  PER_EVENT_JSON_DIR   = 'per-event-json-dir',  // LiYe data/traces/orchestrator/*.json 模式
+  PER_TRACE_DIR        = 'per-trace-dir',       // LiYe state/traces/trace-<uuid>/ 模式
+}
+
+interface RetentionPolicy {
+  min_retention_days: number
+  immutable_after_days: number | null           // 一段时间后转入 cold storage（仍可读，但不可追加）
+  delete_after_days: number | null              // null = 永久保留
+}
+
+interface SessionEvent {
+  event_id: string                              // UUIDv7
+  stream_id: string
+  seq: number                                   // 单调递增
+  timestamp: string                             // ISO 8601
+  prev_event_hash: string | null                // F1.3 hash chain；首事件为 null
+  payload: unknown                              // 由 stream owner 定义（不在本 ADR 写死）
+  payload_hash: string                          // sha256(payload)
+
+  // F7 revision-as-append
+  supersedes_event_id: string | null            // 若此事件修订旧事件
+}
+```
+
+### §3. SessionAdjacentArtifact（派生工件 descriptor）
+
+```typescript
+interface SessionAdjacentArtifact {
+  artifact_id: string
+  adjacent_kind: SessionAdjacentKind            // §1
+  owner: {
+    component_id: string
+    layer: 0 | 1 | 2                            // Layer 0 也可写 adjacent（如 contract-derived verdicts）
+  }
+
+  // 来源（默认硬约束：必须引用一个或多个 SessionEvent / 上游 adjacent）
+  // QUERY_AUDIT 例外条款（见下）：允许 derived_from = []，但必须填 audit_subject
+  derived_from: ArtifactRef[]                   // 默认至少一条；QUERY_AUDIT 可为空
+
+  // QUERY_AUDIT 专用字段（其他 kind 必为 null）
+  // 当 adjacent_kind = QUERY_AUDIT 时：
+  //   - derived_from 可为 []
+  //   - audit_subject 必填，描述本次查询审计的元数据（请求 id / mode / 授权 / 命中 fragment refs）
+  // 当 adjacent_kind ≠ QUERY_AUDIT 时：
+  //   - derived_from 必须非空
+  //   - audit_subject 必须为 null
+  audit_subject: QueryAuditSubject | null
+
+  // 物理性
+  storage_location: string
+  format_kind: 'json' | 'ndjson' | 'markdown' | 'binary' | 'directory'
+  is_append_only: true                          // F2 强制
+  hash_self: string                             // 可不 chain，但自身必须 hash
+
+  created_at: string
+  registered_by_adr: string | null              // adjacent 不强制 ADR 引用，但建议
+}
+
+interface QueryAuditSubject {
+  request_id: string
+  query_mode: 'strict_truth' | 'balanced_recency'
+  diagnostic_authorization: DiagnosticAuth | null   // balanced_recency 必填
+  hit_fragment_refs: ArtifactRef[]              // 此次命中的 fragment（可为空，但字段必须存在）
+}
+
+interface ArtifactRef {
+  ref_kind: 'session-event' | 'session-adjacent'
+  stream_id?: string                            // ref_kind = session-event 时必填
+  event_id?: string
+  artifact_id?: string                          // ref_kind = session-adjacent 时必填
+  relationship: 'derived-from' | 'summarizes' | 'indexes' | 'verdicts-on' | 'evidences'
+}
+```
+
+### §4. StreamRegistry（统一索引）
+
+```typescript
+interface StreamRegistry {
+  // F5: Registry 是元数据层；不存储 stream 本身
+
+  registerStream(s: SessionEventStream): RegisterResult
+  registerAdjacent(a: SessionAdjacentArtifact): RegisterResult
+
+  lookupStream(stream_id: string): SessionEventStream | null
+  lookupAdjacent(artifact_id: string): SessionAdjacentArtifact | null
+
+  listStreams(filter: StreamFilter): SessionEventStream[]
+  listAdjacent(filter: AdjacentFilter): SessionAdjacentArtifact[]
+}
+
+interface StreamFilter {
+  owner_component_id?: string
+  scope_kind?: string
+  scope_keys?: Record<string, string>
+  format?: StreamFormat
+  active_at?: string                            // 时间窗口（按 retention 计算）
+}
+
+interface AdjacentFilter {
+  adjacent_kind?: SessionAdjacentKind
+  owner_component_id?: string
+  derived_from_event_id?: string                // 反查派生关系
+}
+```
+
+### §5. FederatedQueryRequest / Result
+
+```typescript
+enum QueryMode {
+  STRICT_TRUTH       = 'strict_truth',          // 默认（F4）
+  BALANCED_RECENCY   = 'balanced_recency',      // 仅诊断 / 排查（F4 受限）
+}
+
+interface FederatedQueryRequest {
+  request_id: string
+
+  // 检索目标（Federated 范围）
+  target_classes: ArtifactClass[]               // 至少包含 SESSION_EVENT_STREAM 之一
+  stream_filter: StreamFilter | null
+  adjacent_filter: AdjacentFilter | null
+
+  // 查询条件
+  query: string | StructuredQuery
+  time_range: { from: string; to: string } | null
+  scope_keys: Record<string, string> | null     // 限定 scope（如 trace_id / tenant_id）
+
+  // Mode
+  query_mode: QueryMode
+  diagnostic_authorization: DiagnosticAuth | null   // BALANCED_RECENCY 必填（F4）
+
+  // 结果约束
+  max_events_per_stream: number
+  max_adjacent: number
+  include_static_truth: boolean                 // 是否一并返回 F3 静态 authoritative truth（默认 false）
+
+  // 触发上下文
+  triggered_by: {
+    component: string
+    purpose: 'decision' | 'context' | 'audit' | 'diagnostic'
+    plan_id: string | null                      // P1-c MemoryAssemblyPlan id（若来自 memory orchestration）
+  }
+}
+
+interface DiagnosticAuth {
+  authorization_adr: string                     // 引用授权此 diagnostic 访问的 ADR
+  approver_id: string
+  expires_at: string                            // 授权有效期（短期）
+  reason: string                                // 必须可读
+}
+
+interface FederatedQueryResult {
+  request_id: string
+  fragments: FederatedFragment[]                // 按 priority + scope + recency 排序（依 query_mode）
+  truncated_streams: string[]                   // 哪些 stream 因 max_events 截断
+  retrieved_at: string
+  query_replay_seed: string                     // F8 replay 所需的 deterministic seed
+}
+
+interface FederatedFragment {
+  fragment_kind: 'session-event' | 'session-adjacent' | 'static-truth'
+  source_stream_id: string | null               // session-event 必填
+  source_artifact_id: string | null             // session-adjacent 必填
+  source_static_ref: string | null              // static-truth 必填（如 contract path）
+  payload: unknown
+  match_evidence: string                        // 可解释的命中理由
+  rank: number                                  // 全局 rank（已按 query_mode 排序）
+}
+```
+
+### §6. StreamAdapter（Layer 1 / Loamwise 实现）
+
+```typescript
+// StreamAdapter 是 Hands：每种 StreamFormat 一个实现
+interface StreamAdapter {
+  format: StreamFormat
+  canRead(s: SessionEventStream): boolean
+  iterate(s: SessionEventStream, range: TimeRange | null): AsyncIterable<SessionEvent>
+  countEvents(s: SessionEventStream, range: TimeRange | null): Promise<number>
+  verifyHashChain(s: SessionEventStream): Promise<HashChainResult>   // F1.3 验证
+}
+
+interface HashChainResult {
+  ok: boolean
+  broken_at_event_id: string | null
+  expected_prev_hash: string | null
+  actual_prev_hash: string | null
+}
+```
+
+### §7. Validator（注册时强制）
+
+```typescript
+function registerStream(s: SessionEventStream): RegisterResult {
+  // F1.1 + F1.3 强制
+  if (!s.is_append_only || !s.is_hash_chained) {
+    return fail('not_append_only_or_not_hash_chained')
+  }
+  // F6 唯一 owner（registry 已存在 stream_id 即拒绝）
+  if (registry.has(s.stream_id)) return fail('duplicate_stream_id')
+  // owner.layer 限制
+  if (![1, 2].includes(s.owner.layer)) return fail('owner_layer_must_be_1_or_2')
+  // ADR reference 强制
+  if (!s.registered_by_adr) return fail('missing_registered_by_adr')
+  return ok({ stream_id: s.stream_id })
+}
+
+function executeFederatedQuery(req: FederatedQueryRequest): QueryResult {
+  // F4: BALANCED_RECENCY 必须有 diagnostic_authorization
+  if (req.query_mode === QueryMode.BALANCED_RECENCY) {
+    if (!req.diagnostic_authorization) return fail('balanced_recency_requires_diagnostic_auth')
+    if (req.triggered_by.purpose !== 'diagnostic') return fail('balanced_recency_only_for_diagnostic')
+    if (!req.diagnostic_authorization.authorization_adr) return fail('missing_authorization_adr')
+    // 执行查询并收集 hit_fragment_refs（先查后审计，便于把命中 refs 写入 audit）
+    const result = executeQueryFanOut(req)
+    // 自我审计：访问行为写 SessionAdjacentArtifact，子类 = QUERY_AUDIT
+    // QUERY_AUDIT 例外条款（§3）：derived_from 可为 []，但 audit_subject 必填
+    appendAdjacent({
+      adjacent_kind: SessionAdjacentKind.QUERY_AUDIT,
+      owner: { component_id: 'loamwise:federated-query', layer: 1 },
+      derived_from: [],                      // 元事件，例外允许
+      audit_subject: {
+        request_id: req.request_id,
+        query_mode: 'balanced_recency',
+        diagnostic_authorization: req.diagnostic_authorization,
+        hit_fragment_refs: result.fragments.map(toArtifactRef),
+      },
+      // 其他必填字段（storage / hash_self / created_at / ...）省略
+    })
+    return ok(result)
+  }
+  // STRICT_TRUTH 默认 ranking（F4 修订版）：
+  //   Bucket 1 (并列)：session-event ∥ static-truth (仅当 include_static_truth=true)
+  //   Bucket 2       ：session-adjacent
+  //   Bucket 3       ：others
+  //   Bucket 1 整体严格优先于 Bucket 2；static-truth 不得排在 session-adjacent 之后
+  // ...
+  return ok({ ... })
+}
+
+// SessionAdjacentArtifact validator（与 §3 例外条款配合）
+function validateAdjacent(a: SessionAdjacentArtifact): ValidationResult {
+  if (a.adjacent_kind === SessionAdjacentKind.QUERY_AUDIT) {
+    if (a.audit_subject === null) {
+      return fail('query_audit_must_have_audit_subject')
+    }
+    // QUERY_AUDIT 允许 derived_from = []
+  } else {
+    if (a.derived_from.length === 0) {
+      return fail('non_query_audit_must_have_at_least_one_derived_from')
+    }
+    if (a.audit_subject !== null) {
+      return fail('non_query_audit_must_have_null_audit_subject')
+    }
+  }
+  return ok()
+}
+```
+
+---
+
+## Non-goals
+
+- **不实施 §1-§7 的代码**——本 ADR 仅定义 contract 与 Federation Rules
+- **不重新定义 BGHS 分类规则**——见 P1-Doctrine
+- **不强迫现有 stream 迁移格式**（A3）——LiYe 现有 per-event JSON / per-trace dir / AGE jsonl 都通过 StreamFormat 适配
+- **不规定具体存储后端**——本地文件系统 / 对象存储 / DB 都可作为 storage_location，由 StreamAdapter 处理
+- **不引入统一 session 存储**（R1 + SYSTEMS.md 明确不做）
+- **不引入 LLM-driven 检索路由**（R6）
+- **不定义 StreamFormat 的具体编码规范**（如 ndjson 的具体字段顺序）——由后续 contract ADR / 各 stream owner 自行规定
+- **不处理 cross-tenant / 多 user 的 session 隔离**——这是后续 capability ADR 的范围
+- **不修改任何上游 fork 代码**
+
+---
+
+## Adoption Checkpoints
+
+| Checkpoint | 触发时机 | 验证项 |
+|-----------|---------|-------|
+| **C1. P1-Doctrine + P1-a/b/c/d + 本 ADR 五件就位** | 本 ADR 通过后 | 五份 ADR 互引一致；SYSTEMS.md 引用本 ADR 为 session/adjacent + federated query SSOT |
+| **C2. SessionTaxonomy 三分落入 contract schema** | StreamRegistry 实施前 | `_meta/contracts/session/taxonomy.schema.yaml` 建立；ArtifactClass / SessionAdjacentKind 枚举强制 |
+| **C3. 现有 traces / verdicts / evidence 治理与分类** | StreamRegistry 上线前 | **先补齐 F1 缺失项再注册**：（1）`liye_os/data/traces/*` 与 `state/traces/*` 现无 hash chain → 必须先在每条 stream 引入 `prev_event_hash` 字段或等价 chain 后，才能注册为 SESSION_EVENT_STREAM；未补齐前在 registry 中标 `provisional` 状态；（2）`liye_os/verdicts/` → SESSION_ADJACENT.verdict（adjacent 不强制 chain，可直接注册）；（3）`liye_os/evidence/` → SESSION_ADJACENT.evidence-bundle（同上） |
+| **C4. AGE state_transitions.jsonl 注册** | **AGE 补齐 F1 hash chain 后** + AGE D0→D1 时 | AGE 当前 `persistence.py` 写入的事件行只含 `event_id / store_id / at / by / scope / from_state / to_state ...`，**无 `prev_event_hash`**，**当前不满足 F1**；必须先补齐 hash chain（或等价机制）再注册为 SessionEventStream（format = NDJSON_APPEND, owner = AGE）；补齐前可记为 **provisional authoritative candidate**，但不计入 strict_truth bucket 1 |
+| **C5. F4 query_mode 默认 strict_truth 强制** | 第一个 FederatedQuery 请求时 | runtime 拒绝 query_mode 缺失；balanced_recency 必带 diagnostic_authorization |
+| **C6. F1 hash chain 验证可用** | **C3/C4 之前必须先就绪** | 每个 StreamAdapter 实现 verifyHashChain；replay 用此验证；**hash chain 验证工具就绪是 C3/C4 注册的前置条件，不是后置** |
+| **C7. 自我审计**（balanced_recency 访问写 session-adjacent） | 第一次 balanced_recency 请求 | 写入 SESSION_ADJACENT.query-audit 事件，含授权 ADR ref + audit_subject 必填 |
+
+**本 ADR 不实施任何代码**。
+
+---
+
+## Appendix A: 与 P1-c 命名 / 字段对齐（明示）
+
+P1-c 多次 forward ref 本 ADR。对齐声明：
+
+| P1-c 提及 | 本 ADR 对应 |
+|----------|------------|
+| "session 本体 / authoritative session events" | §1 ArtifactClass.SESSION_EVENT_STREAM + §2 SessionEventStream |
+| "session-adjacent" | §1 ArtifactClass.SESSION_ADJACENT + §3 SessionAdjacentArtifact |
+| "receipts" | §1 SessionAdjacentKind.RECEIPT |
+| "GuardEvidence 写 session-adjacent" | §1 SessionAdjacentKind.GUARD_EVIDENCE / EVIDENCE_BUNDLE |
+| "LifecycleTransition log 属 session-adjacent" | §1 SessionAdjacentKind.LIFECYCLE_TRANSITION_LOG |
+| "query_mode = 'strict_truth' / 'balanced_recency'" | §5 QueryMode 完全一致 |
+| "MemoryAssemblyPlan.plan_id" | §5 FederatedQueryRequest.triggered_by.plan_id |
+| "MemoryTier.AUTHORITATIVE 静态真相" | §5 include_static_truth flag（§F3 解释静态真相不进 session taxonomy） |
+
+**冲突时**（与 P1-c §Appendix A "不得双重定义"约束一致）：
+- session / session-adjacent 分类语义以 **本 ADR 为准**
+- MemoryTier 决策权语义以 **P1-c 为准**
+
+---
+
+## Appendix B: 现有 LiYe / AGE 资产入 taxonomy 的初始映射（NON-NORMATIVE）
+
+| 路径 | 目标分类 | F1 现状 | 备注 |
+|------|---------|---------|------|
+| `liye_os/data/traces/orchestrator/*.json` | SESSION_EVENT_STREAM, format = PER_EVENT_JSON_DIR | **不满足 F1**（无 hash chain）| **provisional authoritative candidate, not yet F1-compliant**；必须先补 hash chain（或等价 chain 机制）才能注册为 SESSION_EVENT_STREAM；治理前不计入 strict_truth bucket 1 |
+| `liye_os/state/traces/trace-<uuid>/` | SESSION_EVENT_STREAM, format = PER_TRACE_DIR | **不满足 F1**（无 hash chain）| 同上 |
+| `liye_os/data/traces/{a3,d7,a3-batch1,...}/` | SESSION_EVENT_STREAM | **不满足 F1**（无 hash chain）| 同上；试验产生，retention 可短 |
+| `liye_os/verdicts/` | SESSION_ADJACENT, kind = VERDICT | adjacent 不需 chain | derived_from 字段需回填指向决策事件；可直接注册 |
+| `liye_os/evidence/` | SESSION_ADJACENT, kind = EVIDENCE_BUNDLE | adjacent 不需 chain | 同上 |
+| `amazon-growth-engine/artifacts/onboarding/STR-*/state_transitions.jsonl` | SESSION_EVENT_STREAM, format = NDJSON_APPEND | **不满足 F1**（AGE `persistence.py` 当前事件行无 `prev_event_hash` 字段）| **provisional authoritative candidate, not yet F1-compliant**；必须先在 AGE 侧补 hash chain（或等价 chain）才能注册；补齐前不计入 strict_truth bucket 1 |
+
+**这是入库参考，不是冻结映射**。具体注册由 C3-C4 落地。**所有标"不满足 F1"的 stream 必须先完成治理才能注册为 SESSION_EVENT_STREAM**——这是 F1 5 条同时满足的硬约束的直接推论。
+
+---
+
+**Version**: 1.0.0
+**Last Updated**: 2026-04-16

--- a/_meta/portfolio/SYSTEMS.md
+++ b/_meta/portfolio/SYSTEMS.md
@@ -168,7 +168,7 @@ explicit_non_goals, future_split_direction
 **Meta Declaration** — 用于 Doctrine / Contract ADR / Harvest ADR / Decision ADR
 ```
 artifact_scope: meta
-artifact_name, artifact_role (doctrine|contract|harvest|decision)
+artifact_name, artifact_role (doctrine|contract|harvest)
 target_layer (0|1|2|3|cross|none)
 bghs_constrains (yes|no)  # 仅 doctrine = yes
 ```


### PR DESCRIPTION
## Summary
- 2nd PR of 8-PR governance batch push (after #127)
- Seals the P1 ADR batch (8 new ADRs covering BGHS doctrine + 7 surfaces) and marks 4 legacy P1 drafts as superseded
- Lands BGHS ADR validator script + CI gate, plus Sprint 0 triage / EVOLUTION_ROADMAP_2025 update

## Commits (chronological)
- `9126ab8` docs(adr): seal P1 batch — BGHS doctrine + 7 contracts/harvests
- `dfdad45` docs(adr): mark legacy P1 drafts as superseded by accepted ADRs
- `4f3b57d` docs(roadmap): add BGHS track, ADR validator, and Sprint 0 triage

## What lands

**8 sealed ADRs (`_meta/adr/`):**
- `ADR-Architecture-Doctrine-BGHS-Separation.md` — overarching doctrine
- `ADR-AGE-Wake-Resume.md`
- `ADR-Credential-Mediation.md`
- `ADR-Hermes-Memory-Orchestration.md`
- `ADR-Hermes-Skill-Lifecycle.md`
- `ADR-Loamwise-Guard-Content-Security.md`
- `ADR-OpenClaw-Capability-Boundary.md`
- `ADR-Session-and-Session-Adjacent-Taxonomy-Federated-Query.md`

**4 legacy P1 drafts marked superseded:**
- `ADR-004-OpenClaw-Capability-Boundary.md`
- `ADR-005-Hermes-Skill-Lifecycle.md`
- `ADR-006-Hermes-Memory-Orchestration.md`
- `ADR-007-Loamwise-Guard-Content-Security.md`

**Validator + CI:**
- `.claude/scripts/validate_adr_bghs.mjs` — BGHS classification validator
- `.github/workflows/adr-bghs-gate.yml` — required gate

**Roadmap:**
- `_meta/EVOLUTION_ROADMAP_2025.md` updated with BGHS track + Sprint 0 triage

## Stats
18 files changed, +6220 / -1

## Dependency
- Builds on #127 (`_meta/portfolio/SYSTEMS.md` BGHS doctrine SSOT)
- Provides ADR substrate for PR-6 (sprint-7 readout + ADR-P3 classification)

## Test plan
- [ ] CI gates pass (incl. new `adr-bghs-gate.yml` self-check)
- [ ] BGHS validator runs locally without errors
- [ ] No source code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)