### PR TITLE
ci(memory-gate): drop unconditional apt-get for ripgrep

### DIFF
--- a/.github/workflows/memory-gate.yml
+++ b/.github/workflows/memory-gate.yml
@@ -21,8 +21,34 @@ jobs:
       - name: Install dependencies
         run: npm install yaml fast-glob
 
-      - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - name: Ensure ripgrep is available
+        # ubuntu-latest runner images ship with ripgrep pre-installed; the
+        # previous unconditional `apt-get update && apt-get install -y
+        # ripgrep` step has hung GitHub Actions runners 12+ min on apt
+        # mirror flakes, blocking required gate. Strategy:
+        #   1. Fast path: if rg is on PATH, skip apt entirely.
+        #   2. Slow fallback: bounded retry with hard timeout (max 90s
+        #      total) so a wedged apt mirror fails the step quickly
+        #      instead of hanging the whole gate.
+        run: |
+          set -euo pipefail
+          if command -v rg >/dev/null 2>&1; then
+            echo "✅ ripgrep already available: $(rg --version | head -1)"
+            exit 0
+          fi
+          echo "ripgrep not found, attempting apt install with bounded retry"
+          for attempt in 1 2 3; do
+            echo "Attempt $attempt/3"
+            if timeout 30 sudo apt-get update -qq && timeout 30 sudo apt-get install -y --no-install-recommends ripgrep; then
+              echo "✅ ripgrep installed via apt on attempt $attempt"
+              rg --version | head -1
+              exit 0
+            fi
+            echo "apt attempt $attempt failed or timed out, retrying"
+            sleep 5
+          done
+          echo "❌ Could not install ripgrep after 3 timed attempts (apt mirror likely unreachable)"
+          exit 1
 
       - name: Bootstrap memory (smoke test)
         run: node .claude/scripts/memory_bootstrap.mjs "memory gate smoke test"


### PR DESCRIPTION
## Summary

Tiny CI hardening PR. Removes the unconditional `sudo apt-get update && sudo apt-get install -y ripgrep` step in `.github/workflows/memory-gate.yml` that has empirically hung GitHub Actions runners and blocked PR-3 (#129) land for 21+ min across two attempts.

## Root cause

`memory-gate.yml:24-25` did:
```yaml
- name: Install ripgrep
  run: sudo apt-get update && sudo apt-get install -y ripgrep
```

During #129 land:
- Attempt 1: stuck on this step for **12+ min**, cancelled
- Attempt 2: stuck on the same step for **9+ min**, cancelled  
- Attempt 3: passed in 39s (mirror happened to be healthy)

Apt mirror flakes wedged a **required** gate that has nothing to do with the PR's code path.

## Fix

1. **Fast path** — `ubuntu-latest` runner images ship with ripgrep pre-installed (per [`actions/runner-images`](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md)). Detect with `command -v rg`; skip apt entirely when present. Common case finishes in <1s with no network.
2. **Bounded fallback** — If rg is somehow absent, retry apt up to 3× with 30s per-call timeout, ~90s total cap. A wedged mirror fails fast instead of hanging the gate.

The actual consumer (`.claude/scripts/memory_bootstrap.mjs:202` runs `rg -n ...`) is unchanged; only the install path is hardened.

## Why this matters now

PR-4 through PR-8 of the 8-PR governance batch will all hit this same gate. Without this fix every land risks another 12-min apt-mirror dance. This PR is purely infra hardening — no governance / runtime / domain changes.

## Test plan

- [ ] CI passes (memory gate self-checks under new install logic)
- [ ] In runner logs, "Ensure ripgrep is available" step prints "ripgrep already available" (fast path) — confirms ubuntu-latest still ships rg
- [ ] If a future runner image drops rg, the fallback retry would kick in and either install (≤90s) or fail-fast — no more 12-min hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)