### PR TITLE
security: credential broker seam + env hygiene gate (PR 5/8)

### DIFF
--- a/.claude/.githooks/pre-commit
+++ b/.claude/.githooks/pre-commit
@@ -104,6 +104,18 @@ fi
 
 echo "✅ Staged file gate passed"
 
+# ===== Env hygiene gate (Sprint 2 Wave 2.2) =====
+# Blocks NEW process.env.* / os.getenv(...) etc. in gated scope
+# (src/**, builders/**, systems/**). Exempt: .claude/scripts/**,
+# scripts/**, examples/**, tools/notion-sync/**. Whitelisted:
+# src/runtime/credential/**. See .claude/scripts/env_hygiene_gate.mjs
+# and .security/env-audit.md for the baseline.
+echo "🔐 Env hygiene gate (new env reads in gated scope)..."
+if ! node .claude/scripts/env_hygiene_gate.mjs; then
+  exit 1
+fi
+echo "✅ Env hygiene gate passed"
+
 # ===== Blocklist scan (customer IDs / real ASINs / key prefixes) =====
 echo "🛡️ Scanning staged files for blocklisted patterns..."
 

--- a/.claude/scripts/env_hygiene_gate.mjs
+++ b/.claude/scripts/env_hygiene_gate.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * Env Hygiene Gate — Sprint 2 Wave 2.2.
+ *
+ * Blocks NEW additions of direct environment variable reads inside the
+ * gated scope (src/, builders/, systems/). Existing reads are reported
+ * by .security/env-audit.md but not blocked here.
+ *
+ * Scope rules (frozen by Sprint 2):
+ *   GATED      src/** , builders/** , systems/**
+ *     → new process.env.X / process.env[...] / os.getenv(...) /
+ *       os.environ[...] / os.environ.get(...) additions = BLOCK
+ *   WHITELIST  src/runtime/credential/**
+ *     → allowed (broker bootstrap; ADR-Credential-Mediation M7)
+ *   EXEMPT     .claude/scripts/** , scripts/** , examples/** ,
+ *              tools/notion-sync/**
+ *     → no enforcement (local tooling / one-shot scripts)
+ *   OTHER      everything else
+ *     → no enforcement (not a migration target)
+ *
+ * Invocation:
+ *   node .claude/scripts/env_hygiene_gate.mjs            # staged-diff mode (pre-commit)
+ *   node .claude/scripts/env_hygiene_gate.mjs --all      # full-repo audit
+ *   node .claude/scripts/env_hygiene_gate.mjs --report   # machine output (JSON)
+ *
+ * Exit codes:
+ *   0 — pass (no new additions found)
+ *   1 — blocked (new additions in gated scope)
+ *   2 — usage error
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ENV_PATTERNS = [
+  /\bprocess\.env\.[A-Z_][A-Z0-9_]*/,            // process.env.FOO
+  /\bprocess\.env\[/,                              // process.env[...]
+  /\bos\.getenv\(/,                                // Python os.getenv(
+  /\bos\.environ\[/,                               // Python os.environ[...]
+  /\bos\.environ\.get\(/,                          // Python os.environ.get(
+];
+
+function isEnvLine(line) {
+  return ENV_PATTERNS.some((re) => re.test(line));
+}
+
+/** Strip the `+` prefix plus the optional hunk-context space. */
+function stripAddMarker(line) {
+  return line.startsWith('+') ? line.slice(1) : line;
+}
+
+/** Classify a file path against the scope rules. */
+function classify(p) {
+  // normalize: no leading slash, posix separators
+  const norm = p.replace(/\\/g, '/');
+  if (/^(node_modules|vendor)\//.test(norm) || /\/(node_modules|vendor)\//.test(norm)) return 'exempt-deps';
+  if (norm.startsWith('src/runtime/credential/')) return 'whitelist';
+  if (
+    norm.startsWith('.claude/scripts/')
+    || norm.startsWith('scripts/')
+    || norm.startsWith('examples/')
+    || norm.startsWith('tools/notion-sync/')
+  ) return 'exempt';
+  if (
+    norm.startsWith('src/')
+    || norm.startsWith('builders/')
+    || norm.startsWith('systems/')
+  ) return 'gated';
+  return 'other';
+}
+
+/** Parse unified diff output into per-file added lines with their line numbers. */
+function parseDiff(diffText) {
+  const files = [];
+  let current = null;
+  let newLineNo = 0;
+
+  for (const raw of diffText.split('\n')) {
+    if (raw.startsWith('diff --git ')) {
+      if (current) files.push(current);
+      current = { path: null, hunks: [] };
+      continue;
+    }
+    if (raw.startsWith('+++ ')) {
+      const m = raw.match(/^\+\+\+ b\/(.+)$/);
+      if (m && current) current.path = m[1];
+      continue;
+    }
+    if (raw.startsWith('@@')) {
+      const m = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (m) newLineNo = parseInt(m[1], 10);
+      continue;
+    }
+    if (!current || !current.path) continue;
+
+    if (raw.startsWith('+') && !raw.startsWith('+++')) {
+      const content = stripAddMarker(raw);
+      current.hunks.push({ line_no: newLineNo, content });
+      newLineNo += 1;
+    } else if (raw.startsWith('-') && !raw.startsWith('---')) {
+      // removal — new-line counter does not advance
+    } else if (raw.startsWith(' ')) {
+      // context
+      newLineNo += 1;
+    } else {
+      // meta line; ignore
+    }
+  }
+  if (current) files.push(current);
+  return files.filter((f) => f.path);
+}
+
+/** --all mode: walk the gated trees and report every env-read line. */
+function scanFull() {
+  const roots = ['src', 'builders', 'systems', '.claude/scripts', 'scripts', 'examples', 'tools'];
+  const hits = [];
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue;
+    walk(root, (filepath) => {
+      const cls = classify(filepath);
+      if (cls === 'exempt-deps') return;
+      const content = fs.readFileSync(filepath, 'utf8');
+      const lines = content.split('\n');
+      lines.forEach((line, idx) => {
+        if (isEnvLine(line)) {
+          hits.push({ path: filepath, line_no: idx + 1, content: line.trim(), classification: cls });
+        }
+      });
+    });
+  }
+  return hits;
+}
+
+function walk(dir, visit) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'vendor') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, visit);
+    } else if (/\.(ts|js|mjs|cjs|tsx|jsx|py)$/.test(entry.name)) {
+      visit(full);
+    }
+  }
+}
+
+function mainStaged() {
+  let diff;
+  try {
+    diff = execSync('git diff --cached --unified=0 --diff-filter=AM', { encoding: 'utf8' });
+  } catch (err) {
+    console.error('env_hygiene_gate: git diff failed:', err.message);
+    process.exit(2);
+  }
+
+  const files = parseDiff(diff);
+  const violations = [];
+
+  for (const f of files) {
+    const cls = classify(f.path);
+    if (cls !== 'gated') continue;
+    for (const h of f.hunks) {
+      if (isEnvLine(h.content)) {
+        violations.push({ path: f.path, line_no: h.line_no, content: h.content.trim() });
+      }
+    }
+  }
+
+  if (violations.length === 0) {
+    return 0;
+  }
+
+  console.error('');
+  console.error('❌ Env hygiene gate blocked the commit.');
+  console.error('');
+  console.error('New direct environment reads detected in gated scope');
+  console.error('(src/**, builders/**, systems/**). These must go through');
+  console.error('CredentialBroker (src/runtime/credential/) per ADR-Credential-');
+  console.error('Mediation; env reads only survive on the whitelist');
+  console.error('(src/runtime/credential/**) or on exempt tooling paths');
+  console.error('(.claude/scripts/**, scripts/**, examples/**, tools/notion-sync/**).');
+  console.error('');
+  for (const v of violations) {
+    console.error(`  ${v.path}:${v.line_no}  ${v.content}`);
+  }
+  console.error('');
+  console.error('To fix: construct a CredentialBroker and replace the env read');
+  console.error('with broker.resolve(cred://<owner>/<name>, ctx). See the');
+  console.error('EnvCredentialBroker reference impl for the minimum plumbing.');
+  console.error('');
+  return 1;
+}
+
+function mainReport() {
+  const hits = scanFull();
+  const grouped = { gated: [], whitelist: [], exempt: [], other: [] };
+  for (const h of hits) grouped[h.classification]?.push(h);
+  process.stdout.write(JSON.stringify(
+    {
+      total_hits: hits.length,
+      counts: {
+        gated: grouped.gated.length,
+        whitelist: grouped.whitelist.length,
+        exempt: grouped.exempt.length,
+        other: grouped.other.length,
+      },
+      hits: grouped,
+    },
+    null,
+    2,
+  ) + '\n');
+  return 0;
+}
+
+function mainAllText() {
+  const hits = scanFull();
+  const grouped = { gated: [], whitelist: [], exempt: [], other: [] };
+  for (const h of hits) grouped[h.classification]?.push(h);
+  console.log(`Env reads across scanned trees: ${hits.length}`);
+  console.log(`  gated (migration target): ${grouped.gated.length}`);
+  console.log(`  whitelist (broker bootstrap): ${grouped.whitelist.length}`);
+  console.log(`  exempt (tooling): ${grouped.exempt.length}`);
+  console.log(`  other: ${grouped.other.length}`);
+  return 0;
+}
+
+const args = process.argv.slice(2);
+if (args.includes('--report')) process.exit(mainReport());
+if (args.includes('--all')) process.exit(mainAllText());
+process.exit(mainStaged());

--- a/.github/workflows/env-hygiene-gate.yml
+++ b/.github/workflows/env-hygiene-gate.yml
@@ -1,0 +1,58 @@
+name: Env Hygiene Gate
+
+# Blocks NEW direct environment variable reads (process.env.X,
+# os.getenv(), os.environ[…], etc.) inside the gated scope
+# (src/**, builders/**, systems/**). Existing reads are recorded in
+# .security/env-audit.md but not enforced here.
+#
+# Mirrors the pre-commit Check 7 so CI refuses the same PRs that a
+# local commit would refuse.
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'builders/**'
+      - 'systems/**'
+      - '.claude/scripts/env_hygiene_gate.mjs'
+      - '.github/workflows/env-hygiene-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'builders/**'
+      - 'systems/**'
+      - '.claude/scripts/env_hygiene_gate.mjs'
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run env hygiene gate over PR diff
+        run: |
+          # Turn the PR diff (PR HEAD against the base) into the staged
+          # state, so the gate can use its normal `git diff --cached`
+          # path without needing an extra flag. `reset --soft` moves HEAD
+          # back to base while keeping every PR change staged.
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$BASE_SHA" ]; then
+            BASE_SHA="$(git rev-parse HEAD~1)"
+          fi
+          # Need local refs; set identity for reset path.
+          git config user.email ci@liye.os
+          git config user.name "CI"
+          git reset --soft "$BASE_SHA"
+          node .claude/scripts/env_hygiene_gate.mjs
+
+      - name: Summary of env hygiene baseline (informational)
+        if: always()
+        run: node .claude/scripts/env_hygiene_gate.mjs --all || true

--- a/.security/env-audit.md
+++ b/.security/env-audit.md
@@ -1,0 +1,120 @@
+# Env Hygiene Audit — Baseline
+
+**Sprint**: 2 (CredentialBroker seam + env hygiene gate)
+**Wave**: 2.2 (gate installation)
+**Date**: 2026-04-17
+**ADR**: `_meta/adr/ADR-Credential-Mediation.md` (P1-f)
+
+This file records the existing direct environment-variable reads in the
+repository at the moment the env hygiene gate is installed. The gate
+itself only blocks NEW additions in the gated scope; existing readers
+stay until they are migrated component-by-component to the
+`CredentialBroker` seam (`src/runtime/credential/`).
+
+---
+
+## Scope rules (frozen at Sprint 2 seal)
+
+| Bucket | Paths | Enforcement |
+|---|---|---|
+| **Gated** | `src/**`, `builders/**`, `systems/**` | New additions → **BLOCK** (pre-commit Check 7 + CI) |
+| **Whitelist** | `src/runtime/credential/**` | Broker bootstrap — `process.env.*` allowed (ADR-Credential-Mediation M7) |
+| **Exempt** | `.claude/scripts/**`, `scripts/**`, `examples/**`, `tools/notion-sync/**` | No enforcement (local tooling / one-shot) |
+| **Other** | anything else (e.g. `tools/<other>/`) | No enforcement currently; revisit when migrating those trees |
+
+Scanners intentionally skip `node_modules/` and `vendor/` (third-party code).
+
+---
+
+## Baseline counts (2026-04-17)
+
+Run via `node .claude/scripts/env_hygiene_gate.mjs --all`:
+
+| Bucket | Lines found |
+|---|---|
+| Gated (migration target) | **45** |
+| Whitelist | 0 |
+| Exempt | 101 |
+| Other | 112 |
+| **Total scanned** | 258 |
+
+---
+
+## Gated baseline — files to migrate
+
+The 45 gated-scope env reads live across these files. Each one is a
+candidate for broker migration (replace `process.env.X` with
+`broker.resolve('cred://<owner>/<name>', ctx)`). **No deadline** is
+imposed here; migration happens when the owning component otherwise
+touches the file.
+
+| File | Notes |
+|---|---|
+| `src/config/load.js` | Config loader — touches many env vars at startup |
+| `src/gateway/openclaw/server.ts` | Gateway init (5 reads) |
+| `src/gateway/openclaw/age_job_client.ts` | AGE job client (4 reads) |
+| `src/runtime/evidence/evidence_writer.mjs` | Evidence writer |
+| `src/runtime/evidence/action_plan_writer.mjs` | Same family |
+| `src/runtime/evidence/approval_writer.mjs` | Same family |
+| `src/runtime/evidence/execution_result_writer.mjs` | Same family |
+| `src/runtime/evidence/live_run_report_writer.mjs` | Same family |
+| `src/runtime/evidence/live_run_spec_writer.mjs` | Same family |
+| `src/runtime/execution/real_executor.mjs` | Real-run executor |
+| `src/runtime/execution/dry_run_executor.mjs` | Dry-run executor |
+| `src/runtime/execution/write_gate.mjs` | Write gate |
+| `src/runtime/execution/four_key_gate.mjs` | Four-key gate |
+| `src/runtime/execution/kill_switch.mjs` | Kill switch |
+| `src/runtime/mcp/security/vault.py` | Vault glue |
+| `src/runtime/mcp/registry.py` | MCP registry |
+| `src/runtime/mcp/adapters/governed_tool_provider.py` | Governed tool provider |
+| `src/runtime/mcp/servers/knowledge/qdrant_server.py` | Qdrant server |
+| `src/reasoning/execution/build_action_proposal.mjs` | Action proposal builder |
+| `src/reasoning/execution/execute_action.mjs` | Action executor |
+| `src/reasoning/replay/run_readonly_pilot.mjs` | Readonly pilot runner |
+| `src/mission/utils.js` | Mission utils |
+| `src/governance/learning/kill_switch.mjs` | Governance kill switch |
+| `builders/theme-factory/builder.ts` | Theme factory builder |
+| `systems/site-deployer/deployers/vercel.py` | Vercel deployer |
+| `systems/site-deployer/integrations/umami.py` | Umami integration |
+
+(Re-run `node .claude/scripts/env_hygiene_gate.mjs --report` for full
+line-level listings when migrating a particular file.)
+
+---
+
+## Non-goals of this audit
+
+- **No deadline on migration.** Sprint 2 blocks new additions only.
+- **No automatic rewriting.** Each migration needs a broker setup
+  decision (which broker instance, which env_map entry, what
+  CredentialReference string).
+- **No effect on already-committed code.** Files in the table above
+  can be edited without a broker as long as the edit does not add
+  another env read.
+
+---
+
+## How the gate decides
+
+- Pre-commit (`.claude/.githooks/pre-commit` Check 7) and CI
+  (`.github/workflows/env-hygiene-gate.yml`) both call
+  `.claude/scripts/env_hygiene_gate.mjs`.
+- The gate reads `git diff --cached --unified=0 --diff-filter=AM`
+  (or the PR diff in CI), looks at lines prefixed with `+`, matches
+  env-read patterns, classifies each file by the scope rules above,
+  and blocks if any match falls in the Gated bucket.
+- False positives (e.g. a comment that mentions `process.env.FOO`
+  verbatim) should be rare but can be suppressed by rewording the
+  comment. The gate does not parse an AST.
+
+---
+
+## Future tightening (not in Sprint 2)
+
+- Promote `tools/**` (minus the notion-sync exemption) into the Gated
+  bucket once those tools acquire a broker owner.
+- Add SecretValue-roundtrip check: PR diff that introduces a broker
+  resolve call should also assert that the result is consumed through
+  `.reveal()` and not JSON-serialized whole.
+- Auto-generate `env-audit.md` from the gate's `--report` JSON so it
+  never drifts from reality.

--- a/src/runtime/credential/audit.ts
+++ b/src/runtime/credential/audit.ts
@@ -1,0 +1,48 @@
+/**
+ * BGHS Credential Mediation — in-memory audit sink
+ * Location: src/runtime/credential/audit.ts
+ *
+ * Sprint 2 Wave 2.1 ships an in-memory CredentialAuditSink so broker
+ * unit tests and local development have a full end-to-end path. Later
+ * sprints add a SessionAdjacentArtifact sink that registers each
+ * record as a CREDENTIAL_AUDIT entry in the Layer 0 StreamRegistry
+ * (ADR-Credential-Mediation §4 + P1-e §3 QUERY_AUDIT sibling rules).
+ */
+
+import { randomUUID } from 'node:crypto';
+import type {
+  CredentialAuditAppendInput,
+  CredentialAuditRecord,
+  CredentialAuditSink,
+} from './types';
+
+interface InMemoryAuditOptions {
+  /** The component_id / layer writing the audit entries. */
+  owner: { component_id: string; layer: 0 | 1 | 2 };
+}
+
+export class InMemoryCredentialAuditSink implements CredentialAuditSink {
+  private records: CredentialAuditRecord[] = [];
+
+  constructor(private readonly opts: InMemoryAuditOptions) {}
+
+  async append(input: CredentialAuditAppendInput): Promise<string> {
+    const audit_id = randomUUID();
+    const rec: CredentialAuditRecord = {
+      ...input,
+      artifact_id: audit_id,
+      adjacent_kind: 'credential-audit',
+      owner: this.opts.owner,
+    };
+    this.records.push(rec);
+    return audit_id;
+  }
+
+  list(): readonly CredentialAuditRecord[] {
+    return this.records;
+  }
+
+  _clearForTests(): void {
+    this.records = [];
+  }
+}

--- a/src/runtime/credential/broker.ts
+++ b/src/runtime/credential/broker.ts
@@ -1,0 +1,152 @@
+/**
+ * BGHS Credential Mediation — EnvCredentialBroker
+ * Location: src/runtime/credential/broker.ts
+ *
+ * ADR-Credential-Mediation §3. This is the sanctioned bridge between
+ * legacy `process.env.*` reads and the P1-f seam. Consumers get
+ * CredentialReferences; the broker keeps the env-variable mapping in
+ * its own private table (never leaked to callers or logs).
+ *
+ * The env gate (Sprint 2 Wave 2.2) whitelists `src/runtime/credential/**`
+ * so this file is allowed to read process.env directly — it is the
+ * bootstrap seam (ADR M7).
+ */
+
+import { createHash } from 'node:crypto';
+import { parseCredentialRef } from './reference';
+import { wrapSecret } from './secret_value';
+import type {
+  BrokerScope,
+  CredentialAuditSink,
+  CredentialBroker,
+  CredentialReference,
+  ResolutionContext,
+  ResolutionResult,
+} from './types';
+
+export interface EnvBrokerConfig {
+  broker_id: string;
+  declared_scope: BrokerScope;
+  audit_sink: CredentialAuditSink;
+  /**
+   * Mapping from CredentialReference string to the env variable name
+   * that holds the raw secret. Never exposed to consumers.
+   */
+  env_map: Readonly<Record<CredentialReference, string>>;
+  /**
+   * Optional env accessor (defaults to process.env). Injection point
+   * for tests — production always uses the real process.env.
+   */
+  env?: NodeJS.ProcessEnv;
+}
+
+function hint(raw: string): string {
+  const sha = createHash('sha256').update(raw).digest('hex');
+  return `sha256:${sha.slice(0, 12)}...`;
+}
+
+function nowUtc(): string {
+  return new Date().toISOString();
+}
+
+export class EnvCredentialBroker implements CredentialBroker {
+  readonly broker_id: string;
+  readonly declared_scope: BrokerScope;
+  readonly audit_sink: CredentialAuditSink;
+
+  private readonly env_map: Readonly<Record<string, string>>;
+  private readonly env: NodeJS.ProcessEnv;
+
+  constructor(config: EnvBrokerConfig) {
+    this.broker_id = config.broker_id;
+    this.declared_scope = config.declared_scope;
+    this.audit_sink = config.audit_sink;
+    this.env_map = config.env_map;
+    this.env = config.env ?? process.env;
+  }
+
+  async resolve(
+    ref: CredentialReference,
+    ctx: ResolutionContext,
+  ): Promise<ResolutionResult> {
+    const parsed = parseCredentialRef(ref);   // throws InvalidCredentialReferenceError on bad input
+
+    // Scope check — broker must be declared to serve this owner.
+    if (!this.declared_scope.owners_served.includes(parsed.owner)) {
+      const audit_id = await this.audit_sink.append({
+        credential_path: ref,
+        requester_component_id: ctx.requester_component_id,
+        requester_layer: ctx.requester_layer,
+        purpose: ctx.purpose,
+        outcome: 'denied',
+        chain_step: 0,
+        chain_result: 'out-of-scope',
+        redacted_value_hint: null,
+        authorization_ref: ctx.authorization_ref,
+        broker_id: this.broker_id,
+        resolved_at: nowUtc(),
+      });
+      return {
+        outcome: 'denied',
+        denial_reason: `broker ${this.broker_id} does not serve owner "${parsed.owner}"`,
+        audit_id,
+      };
+    }
+
+    const envKey = this.env_map[ref];
+    if (!envKey) {
+      const audit_id = await this.audit_sink.append({
+        credential_path: ref,
+        requester_component_id: ctx.requester_component_id,
+        requester_layer: ctx.requester_layer,
+        purpose: ctx.purpose,
+        outcome: 'not-found',
+        chain_step: 0,
+        chain_result: 'no-mapping',
+        redacted_value_hint: null,
+        authorization_ref: ctx.authorization_ref,
+        broker_id: this.broker_id,
+        resolved_at: nowUtc(),
+      });
+      return { outcome: 'not-found', audit_id };
+    }
+
+    const raw = this.env[envKey];
+    if (!raw) {
+      const audit_id = await this.audit_sink.append({
+        credential_path: ref,
+        requester_component_id: ctx.requester_component_id,
+        requester_layer: ctx.requester_layer,
+        purpose: ctx.purpose,
+        outcome: 'not-found',
+        chain_step: 0,
+        chain_result: 'env-unset',
+        redacted_value_hint: null,
+        authorization_ref: ctx.authorization_ref,
+        broker_id: this.broker_id,
+        resolved_at: nowUtc(),
+      });
+      return { outcome: 'not-found', audit_id };
+    }
+
+    const audit_id = await this.audit_sink.append({
+      credential_path: ref,
+      requester_component_id: ctx.requester_component_id,
+      requester_layer: ctx.requester_layer,
+      purpose: ctx.purpose,
+      outcome: 'resolved',
+      chain_step: 0,
+      chain_result: 'env-hit',
+      redacted_value_hint: hint(raw),
+      authorization_ref: ctx.authorization_ref,
+      broker_id: this.broker_id,
+      resolved_at: nowUtc(),
+    });
+
+    return {
+      outcome: 'resolved',
+      value: wrapSecret(raw),
+      audit_id,
+    };
+  }
+}

--- a/src/runtime/credential/index.ts
+++ b/src/runtime/credential/index.ts
@@ -1,0 +1,38 @@
+/**
+ * BGHS Credential Mediation — barrel
+ * Location: src/runtime/credential/index.ts
+ */
+
+export type {
+  CredentialReference,
+  ParsedCredentialRef,
+  BrokerScope,
+  ResolutionContext,
+  ResolutionResult,
+  ResolutionOutcome,
+  SecretValue,
+  CredentialAuditRecord,
+  CredentialAuditAppendInput,
+  CredentialAuditSink,
+  CredentialBroker,
+  CredentialBinding,
+} from './types';
+
+export { InvalidCredentialReferenceError } from './types';
+
+export {
+  parseCredentialRef,
+  isValidCredentialRef,
+} from './reference';
+
+export {
+  wrapSecret,
+  SECRET_MASK,
+} from './secret_value';
+
+export { InMemoryCredentialAuditSink } from './audit';
+
+export {
+  EnvCredentialBroker,
+  type EnvBrokerConfig,
+} from './broker';

--- a/src/runtime/credential/reference.ts
+++ b/src/runtime/credential/reference.ts
@@ -1,0 +1,62 @@
+/**
+ * BGHS Credential Mediation — CredentialReference parser
+ * Location: src/runtime/credential/reference.ts
+ *
+ * ADR-Credential-Mediation §1 / §7 — URI validation.
+ */
+
+import {
+  InvalidCredentialReferenceError,
+  type CredentialReference,
+  type ParsedCredentialRef,
+} from './types';
+
+const REF_RE = /^cred:\/\/([a-z0-9-]+)\/([a-z0-9-]{3,64})(\?.*)?$/;
+
+function parseQualifiers(query: string | undefined): Record<string, string> {
+  if (!query) return {};
+  const s = query.startsWith('?') ? query.slice(1) : query;
+  if (!s) return {};
+  const out: Record<string, string> = {};
+  for (const part of s.split('&')) {
+    if (!part) continue;
+    const eq = part.indexOf('=');
+    if (eq <= 0) {
+      throw new InvalidCredentialReferenceError(query, `malformed qualifier "${part}"`);
+    }
+    const key = part.slice(0, eq);
+    const value = part.slice(eq + 1);
+    if (!/^[a-z0-9_-]+$/.test(key)) {
+      throw new InvalidCredentialReferenceError(query, `qualifier key "${key}" invalid`);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/** Parse `cred://owner/name[?k=v&...]` into its structural fields. Throws on invalid input. */
+export function parseCredentialRef(ref: CredentialReference): ParsedCredentialRef {
+  const m = ref.match(REF_RE);
+  if (!m) {
+    throw new InvalidCredentialReferenceError(
+      ref,
+      'expected format "cred://<owner>/<name>[?q=v]" with owner [a-z0-9-]+ and name [a-z0-9-]{3,64}',
+    );
+  }
+  return {
+    scheme: 'cred',
+    owner: m[1],
+    name: m[2],
+    qualifiers: parseQualifiers(m[3]),
+  };
+}
+
+/** True iff `ref` is a syntactically valid CredentialReference. */
+export function isValidCredentialRef(ref: string): boolean {
+  try {
+    parseCredentialRef(ref);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/runtime/credential/secret_value.ts
+++ b/src/runtime/credential/secret_value.ts
@@ -1,0 +1,32 @@
+/**
+ * BGHS Credential Mediation — SecretValue wrapper
+ * Location: src/runtime/credential/secret_value.ts
+ *
+ * ADR-Credential-Mediation §6. Node.js implementation of the
+ * contract-level SecretValue requirements:
+ *   - default JSON / string / util.inspect output is masked
+ *   - reveal() is the only sanctioned path to the raw string
+ */
+
+import type { SecretValue } from './types';
+
+const MASK = '***REDACTED***' as const;
+
+/**
+ * Wrap a raw secret in a SecretValue. The returned object hides the raw
+ * value from every default serialization path; callers must explicitly
+ * call `reveal()` to get the string, and are responsible for dropping
+ * the reference quickly (ADR M9).
+ */
+export function wrapSecret(raw: string): SecretValue {
+  return {
+    reveal: () => raw,
+    toJSON: () => MASK,
+    toString: () => MASK,
+    // Node.js-specific: util.inspect custom hook so that console.log and
+    // debug-print paths also emit the mask.
+    [Symbol.for('nodejs.util.inspect.custom')]: () => MASK,
+  } as SecretValue & { [key: symbol]: () => string };
+}
+
+export const SECRET_MASK = MASK;

--- a/src/runtime/credential/types.ts
+++ b/src/runtime/credential/types.ts
@@ -1,0 +1,124 @@
+/**
+ * BGHS Credential Mediation — Types
+ * Location: src/runtime/credential/types.ts
+ *
+ * Mirrors ADR-Credential-Mediation §1–§6. Sprint 2 Wave 2.1 lands the
+ * seam: types, reference parser, SecretValue wrapper, and
+ * EnvCredentialBroker reference implementation. Component Declaration
+ * integration (§5/§7) and full SessionAdjacentRegistry wiring land in
+ * later sprints.
+ */
+
+// === §1 CredentialReference ===
+
+export type CredentialReference = string;  // "cred://<owner>/<name>[?<qualifier>=<value>&...]"
+
+export interface ParsedCredentialRef {
+  scheme: 'cred';
+  owner: string;
+  name: string;
+  qualifiers: Record<string, string>;
+}
+
+export class InvalidCredentialReferenceError extends Error {
+  constructor(readonly input: string, readonly reason: string) {
+    super(`invalid credential reference "${input}": ${reason}`);
+    this.name = 'InvalidCredentialReferenceError';
+  }
+}
+
+// === §6 SecretValue ===
+
+/**
+ * Opaque wrapper around a raw credential string.
+ *
+ * Contract (ADR §6):
+ *   - JSON.stringify / String() / debug-print MUST produce a masked
+ *     placeholder; never the raw value.
+ *   - reveal() is the single sanctioned path to the raw string; callers
+ *     must drop the reference as soon as it's been used.
+ */
+export interface SecretValue {
+  reveal(): string;
+  toJSON(): '***REDACTED***';
+  toString(): '***REDACTED***';
+}
+
+// === §2 BrokerScope / ResolutionContext / ResolutionResult ===
+
+export interface BrokerScope {
+  owners_served: string[];
+  layer: 0 | 1 | 2;
+}
+
+export interface ResolutionContext {
+  requester_component_id: string;
+  requester_layer: 0 | 1 | 2 | 3;
+  purpose: string;
+  /**
+   * Points at the policy / approval record that authorized this access.
+   * v1 permits null (Sprint 2 bootstrap) — policy ADRs tighten this
+   * later by making it required for DecisionKind.CREDENTIAL_ACCESS.
+   */
+  authorization_ref: string | null;
+}
+
+export type ResolutionOutcome = 'resolved' | 'denied' | 'not-found' | 'broker-error';
+
+export type ResolutionResult =
+  | { outcome: 'resolved'; value: SecretValue; audit_id: string }
+  | { outcome: 'denied'; denial_reason: string; audit_id: string }
+  | { outcome: 'not-found'; audit_id: string }
+  | { outcome: 'broker-error'; error: string; audit_id: string };
+
+// === §4 CredentialAuditRecord ===
+
+export interface CredentialAuditAppendInput {
+  credential_path: CredentialReference;
+  requester_component_id: string;
+  requester_layer: 0 | 1 | 2 | 3;
+  purpose: string;
+  outcome: ResolutionOutcome;
+  chain_step: number;
+  chain_result: string;
+  redacted_value_hint: string | null;
+  authorization_ref: string | null;
+  broker_id: string;
+  resolved_at: string;
+}
+
+export interface CredentialAuditRecord extends CredentialAuditAppendInput {
+  artifact_id: string;
+  adjacent_kind: 'credential-audit';
+  owner: { component_id: string; layer: 0 | 1 | 2 };
+  // NOTE: derived_from / hash_self / storage_location / format_kind /
+  // is_append_only / audit_subject / registered_by_adr / created_at are
+  // set by the session-adjacent registration step (later sprint). This
+  // Sprint-2 shape is the seam-level payload.
+}
+
+export interface CredentialAuditSink {
+  append(input: CredentialAuditAppendInput): Promise<string>;   // returns audit_id
+  list(): readonly CredentialAuditRecord[];
+}
+
+// === §2 CredentialBroker ===
+
+export interface CredentialBroker {
+  readonly broker_id: string;
+  readonly declared_scope: BrokerScope;
+  readonly audit_sink: CredentialAuditSink;
+
+  resolve(ref: CredentialReference, ctx: ResolutionContext): Promise<ResolutionResult>;
+
+  invalidate?(ref: CredentialReference): Promise<void>;
+  refresh?(ref: CredentialReference): Promise<void>;
+}
+
+// === §5 CredentialBinding (for Component Declaration integration) ===
+
+export interface CredentialBinding {
+  ref: CredentialReference;
+  purpose: string;
+  broker_required: 'any' | string;
+}

--- a/tests/runtime/credential/credential.test.ts
+++ b/tests/runtime/credential/credential.test.ts
@@ -1,0 +1,214 @@
+/**
+ * CredentialBroker + reference + SecretValue tests — Sprint 2 Wave 2.1.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  EnvCredentialBroker,
+  InMemoryCredentialAuditSink,
+  InvalidCredentialReferenceError,
+  SECRET_MASK,
+  isValidCredentialRef,
+  parseCredentialRef,
+  wrapSecret,
+  type ResolutionContext,
+} from '../../../src/runtime/credential';
+
+// -------------------- CredentialReference --------------------
+
+describe('parseCredentialRef', () => {
+  it('accepts a minimal valid reference', () => {
+    const r = parseCredentialRef('cred://liye-os/notion-api-key');
+    expect(r.scheme).toBe('cred');
+    expect(r.owner).toBe('liye-os');
+    expect(r.name).toBe('notion-api-key');
+    expect(r.qualifiers).toEqual({});
+  });
+
+  it('parses qualifiers', () => {
+    const r = parseCredentialRef(
+      'cred://amazon-growth-engine/ads-api-refresh-token?marketplace=US',
+    );
+    expect(r.owner).toBe('amazon-growth-engine');
+    expect(r.name).toBe('ads-api-refresh-token');
+    expect(r.qualifiers).toEqual({ marketplace: 'US' });
+  });
+
+  it('parses multiple qualifiers', () => {
+    const r = parseCredentialRef(
+      'cred://amazon-growth-engine/ads-api-token?marketplace=US&profile=default',
+    );
+    expect(r.qualifiers).toEqual({ marketplace: 'US', profile: 'default' });
+  });
+
+  it('rejects wrong scheme', () => {
+    expect(() => parseCredentialRef('http://liye-os/x')).toThrow(InvalidCredentialReferenceError);
+  });
+
+  it('rejects uppercase owner', () => {
+    expect(() => parseCredentialRef('cred://LiYe/notion')).toThrow(InvalidCredentialReferenceError);
+  });
+
+  it('rejects too-short name (<3 chars)', () => {
+    expect(() => parseCredentialRef('cred://liye-os/x')).toThrow(InvalidCredentialReferenceError);
+  });
+
+  it('rejects too-long name (>64 chars)', () => {
+    const big = 'a'.repeat(65);
+    expect(() => parseCredentialRef(`cred://liye-os/${big}`)).toThrow(InvalidCredentialReferenceError);
+  });
+
+  it('rejects underscore in name', () => {
+    expect(() => parseCredentialRef('cred://liye-os/notion_key')).toThrow(InvalidCredentialReferenceError);
+  });
+
+  it('rejects malformed qualifier', () => {
+    expect(() => parseCredentialRef('cred://liye-os/notion-key?no-equals')).toThrow(
+      InvalidCredentialReferenceError,
+    );
+  });
+});
+
+describe('isValidCredentialRef', () => {
+  it('returns true for valid refs, false otherwise', () => {
+    expect(isValidCredentialRef('cred://liye-os/notion-key')).toBe(true);
+    expect(isValidCredentialRef('not-a-ref')).toBe(false);
+  });
+});
+
+// -------------------- SecretValue --------------------
+
+describe('wrapSecret / SecretValue', () => {
+  it('reveal() returns the raw string', () => {
+    const s = wrapSecret('my-real-token-1234');
+    expect(s.reveal()).toBe('my-real-token-1234');
+  });
+
+  it('JSON.stringify produces the masked placeholder', () => {
+    const s = wrapSecret('my-real-token-1234');
+    expect(JSON.stringify(s)).toBe(`"${SECRET_MASK}"`);
+  });
+
+  it('String(s) and s.toString() produce the masked placeholder', () => {
+    const s = wrapSecret('my-real-token-1234');
+    expect(String(s)).toBe(SECRET_MASK);
+    expect(s.toString()).toBe(SECRET_MASK);
+  });
+
+  it('util.inspect custom hook produces the masked placeholder', () => {
+    const s = wrapSecret('my-real-token-1234') as Record<symbol, () => string>;
+    const hook = s[Symbol.for('nodejs.util.inspect.custom')];
+    expect(typeof hook).toBe('function');
+    expect(hook()).toBe(SECRET_MASK);
+  });
+
+  it('template-literal interpolation produces the masked placeholder', () => {
+    const s = wrapSecret('my-real-token-1234');
+    expect(`${s}`).toBe(SECRET_MASK);
+  });
+});
+
+// -------------------- EnvCredentialBroker --------------------
+
+function makeBroker(env: Record<string, string | undefined>, owner_served: string = 'liye-os') {
+  const sink = new InMemoryCredentialAuditSink({
+    owner: { component_id: 'liye-os.test', layer: 1 },
+  });
+  const broker = new EnvCredentialBroker({
+    broker_id: 'test-broker',
+    declared_scope: { owners_served: [owner_served], layer: 1 },
+    audit_sink: sink,
+    env_map: {
+      'cred://liye-os/notion-api-key': 'NOTION_API_KEY',
+      'cred://liye-os/hmac-secret': 'HMAC_SECRET',
+    },
+    env,
+  });
+  return { broker, sink };
+}
+
+const CTX: ResolutionContext = {
+  requester_component_id: 'tester',
+  requester_layer: 1,
+  purpose: 'unit-test',
+  authorization_ref: null,
+};
+
+describe('EnvCredentialBroker.resolve', () => {
+  it('returns resolved + redacted hint for a present env var', async () => {
+    const { broker, sink } = makeBroker({ NOTION_API_KEY: 'secret-abc' });
+    const r = await broker.resolve('cred://liye-os/notion-api-key', CTX);
+    expect(r.outcome).toBe('resolved');
+    if (r.outcome === 'resolved') {
+      expect(r.value.reveal()).toBe('secret-abc');
+      expect(r.audit_id).toBeTruthy();
+    }
+    const audit = sink.list();
+    expect(audit).toHaveLength(1);
+    expect(audit[0].outcome).toBe('resolved');
+    expect(audit[0].chain_result).toBe('env-hit');
+    expect(audit[0].redacted_value_hint).toMatch(/^sha256:[a-f0-9]{12}\.\.\.$/);
+  });
+
+  it('returns not-found when env var is unset', async () => {
+    const { broker, sink } = makeBroker({});
+    const r = await broker.resolve('cred://liye-os/notion-api-key', CTX);
+    expect(r.outcome).toBe('not-found');
+    expect(sink.list()[0].chain_result).toBe('env-unset');
+  });
+
+  it('returns not-found when ref has no mapping', async () => {
+    const { broker, sink } = makeBroker({ SOMETHING: 'x' });
+    const r = await broker.resolve('cred://liye-os/unmapped-key', CTX);
+    expect(r.outcome).toBe('not-found');
+    expect(sink.list()[0].chain_result).toBe('no-mapping');
+  });
+
+  it('returns denied when owner is out of declared_scope', async () => {
+    const { broker, sink } = makeBroker({ NOTION_API_KEY: 'secret-abc' }, 'some-other-owner');
+    const r = await broker.resolve('cred://liye-os/notion-api-key', CTX);
+    expect(r.outcome).toBe('denied');
+    expect(sink.list()[0].chain_result).toBe('out-of-scope');
+    expect(sink.list()[0].outcome).toBe('denied');
+  });
+
+  it('rejects invalid credential reference before any audit write', async () => {
+    const { broker, sink } = makeBroker({});
+    await expect(
+      broker.resolve('http://bad/thing' as unknown as `cred://${string}/${string}`, CTX),
+    ).rejects.toThrow(InvalidCredentialReferenceError);
+    expect(sink.list()).toHaveLength(0);
+  });
+});
+
+describe('EnvCredentialBroker — audit fields', () => {
+  it('preserves requester_component_id / purpose / authorization_ref on every outcome', async () => {
+    const { broker, sink } = makeBroker({ NOTION_API_KEY: 'k' });
+    const ctx: ResolutionContext = {
+      requester_component_id: 'component-x',
+      requester_layer: 2,
+      purpose: 'nightly-sync',
+      authorization_ref: 'ADR-Credential-Mediation#M7',
+    };
+    await broker.resolve('cred://liye-os/notion-api-key', ctx);
+    await broker.resolve('cred://liye-os/unmapped', ctx);
+
+    const [a, b] = sink.list();
+    for (const rec of [a, b]) {
+      expect(rec.requester_component_id).toBe('component-x');
+      expect(rec.requester_layer).toBe(2);
+      expect(rec.purpose).toBe('nightly-sync');
+      expect(rec.authorization_ref).toBe('ADR-Credential-Mediation#M7');
+      expect(rec.broker_id).toBe('test-broker');
+      expect(rec.adjacent_kind).toBe('credential-audit');
+    }
+  });
+
+  it('does NOT include the raw secret anywhere in the audit record', async () => {
+    const { broker, sink } = makeBroker({ NOTION_API_KEY: 'super-secret-xyz' });
+    await broker.resolve('cred://liye-os/notion-api-key', CTX);
+    const serialized = JSON.stringify(sink.list());
+    expect(serialized).not.toContain('super-secret-xyz');
+    expect(serialized).toContain(SECRET_MASK === '***REDACTED***' ? 'sha256:' : '');  // hint prefix
+  });
+});


### PR DESCRIPTION
## Summary
Sprint 2 Wave 2.1–2.2 — install the Layer 0 credential mediation seam and the staged-env-hygiene gate. Two independent commits, both new modules / new files, no existing-code overlap.

## Commits

**1. `feat(credential)`** — CredentialBroker seam (P1-f reference impl)
- New module: `src/runtime/credential/` (types / reference parser / SecretValue redact / audit sink / EnvCredentialBroker)
- 22 vitest cases pinning ref-parser rules, SecretValue redact across JSON / toString / util.inspect / template literal, broker resolve / not-found / denied / invalid-ref, and an audit-redaction assertion (raw secret never appears in serialized audit)
- Out of scope (later sprints): Component Declaration validator, chained fallback brokers, `DecisionKind.CREDENTIAL_ACCESS` authorization, SessionAdjacentRegistry integration

**2. `feat(security)`** — env hygiene gate (Sprint 2 Wave 2.2)
- `.claude/scripts/env_hygiene_gate.mjs` — staged-mode pre-commit script + `--all` baseline
- `.claude/.githooks/pre-commit` — wires it into the existing hook
- `.github/workflows/env-hygiene-gate.yml` — CI mirror, uses `git reset --soft` to stage the PR diff so the same logic applies
- `.security/env-audit.md` — frozen baseline 2026-04-17:
  - Gated = `src/** + builders/** + systems/**`
  - Whitelist = `src/runtime/credential/**` (broker bootstrap, M7)
  - Exempt = `.claude/scripts/**`, `scripts/**`, `examples/**`, `tools/notion-sync/**`
  - 45 existing gated hits across 26 files, enumerated; no migration deadline

## Verification
- Local: `tests/runtime/credential` 22/22 pass
- `env_hygiene_gate.mjs --all` reports gated=45, whitelist=0 — matches the `.security/env-audit.md` baseline exactly

## Test plan
- [ ] `Test (18/20/22)` green
- [ ] `env-hygiene-gate` workflow green (new gate)
- [ ] `Lint` / `Architecture Check` / `Layer Dependency Check` / `Block Amazon Asset Leakage` / `gitleaks scan` / `blocklist scan` green
- [ ] `Memory Governance Gate (SSOT)` / `memory` green

5/8 in the topic-decomposition sequence (#127 → #128 → #129 → #130 follow-up → #131 → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)