### PR TITLE
feat(governance): Guard + Capability + SkillLifecycle + Memory runtime (PR 6/8)

### DIFF
--- a/src/runtime/governance/capability/README.md
+++ b/src/runtime/governance/capability/README.md
@@ -1,0 +1,63 @@
+# BGHS Capability Registry — Boundary Notes
+
+**Location**: `src/runtime/governance/capability/`
+**ADR**: `_meta/adr/ADR-OpenClaw-Capability-Boundary.md` (P1-a)
+**Sprint**: 4
+
+## One-line boundary
+
+> `src/control/registry.ts` = **AI-agent capability registry**
+> `src/runtime/governance/capability/` = **BGHS capability registry**
+> The two are **not** interchangeable and **must not** cross-import.
+
+## Why the split exists
+
+LiYe OS has two registries that happen to share the word "capability".
+They describe different things at different layers:
+
+| Aspect | `src/control/` | `src/runtime/governance/capability/` |
+|---|---|---|
+| What "capability" means | An AI agent's skill/tool binding; a 7-field `CapabilityContract` (id, kind, name, domain, tags, side_effect, source_path) used by the orchestrator to pick which agent to call | A BGHS-layer action an engine/skill/guard offers, identified by a `CapabilityKind` like `engine.write.amazon-ads-bid`; governs admission, trust boundary, decision authority |
+| Primary interface | `CapabilityRegistry` in `src/control/registry.ts` (`scanAgents`, `findByCapability`, trust scoring) | `CapabilityKindRegistry` + `CapabilityRegistry` + `DecisionAuthorityRegistry` in this directory |
+| Who owns the identifier | The agent implementer (skill author picks the tag vocabulary) | Layer 0 (the ADR author) — kinds are admitted only via contract ADR + schema |
+| Data model | `AgentCard` / `CapabilityContract` / `AgentCapabilityCandidate` / `TrustProfile` | `CapabilityKindRegistration` / `CapabilityRegistration` / `TrustBoundaryDecl` / `DecisionAuthority` |
+| Ranking / matching | Jaccard tag similarity | None — registration is binary (accept/reject) |
+| Failure mode | Ranking lands a weaker match | Registration is rejected (`UNKNOWN_KIND`, `DUPLICATE_ACTIVE`, `MISSING_TRUST_BOUNDARY`, …) |
+| Consumed by | Orchestrator, task decomposer, router | Future decision plane, gateway method registration, guard chains, session-event ownership checks |
+
+## Hard rule — no cross-import
+
+- BGHS capability code **MUST NOT** import from `src/control/`.
+- AI-agent registry code **MUST NOT** import from
+  `src/runtime/governance/capability/`.
+
+The two packages may both be referenced from higher-level code, but
+they never reference each other. If future work needs to bridge the
+two, that bridge lives in a **third** module whose purpose is to
+translate between the identifier spaces — not in either registry tree.
+
+CI enforcement for this rule lives in the existing layer-dependency
+gate (`.github/workflows/layer-dependency-gate.yml`); add a rule there
+when violations appear, do not carve exceptions in either tree.
+
+## What this sprint provides
+
+- `CapabilityKindRegistry` — Layer-0-only admission of new kinds;
+  requires a `contract_adr` + `contract_schema` reference.
+- `CapabilityRegistry` — Layer 1/2/3 components submit `CapabilityRegistration`
+  entries; B1/B2/B4 validators enforce kind-exists / no-duplicate-active /
+  trust_boundary-present (+ non-empty `egress_allowlist` when the capability
+  declares network side effects).
+- `DecisionAuthorityRegistry` — a narrow hook for decision-plane
+  admission; `override_allowed` is a schema-locked `false`.
+
+## What this sprint does NOT do
+
+- It does **not** implement the decision plane itself (§3 runtime
+  enforcement) — the registry stores declarations.
+- It does **not** wire gateway method routing (§5 reserved-namespace
+  enforcement lives in the Gateway sprint).
+- It does **not** write registrations into a session event stream;
+  that wiring arrives with the `StreamRegistry` + write-path integration.
+- It does **not** touch `src/control/registry.ts`. If you feel the urge
+  to unify the two, stop and write a proposal in `_meta/adr/` first.

--- a/src/runtime/governance/capability/index.ts
+++ b/src/runtime/governance/capability/index.ts
@@ -1,0 +1,40 @@
+/**
+ * BGHS Capability — barrel
+ * Location: src/runtime/governance/capability/index.ts
+ *
+ * See README.md in this directory for the hard boundary against
+ * src/control/registry.ts (AI-agent capability registry). Cross-
+ * imports between the two trees are forbidden.
+ */
+
+export type {
+  CapabilityKind,
+  CapabilityKindRegistration,
+  KindStatus,
+  OwnerLayer,
+  CapabilityOwner,
+  SideEffectDecl,
+  TrustBoundaryFsScope,
+  TrustBoundaryNetworkScope,
+  TrustBoundaryDecl,
+  CapabilityStatus,
+  CapabilityRegistration,
+  DecisionAuthority,
+  OperatorScope,
+  GatewayMethodRegistration,
+  KindRegisterResult,
+  CapabilityRegisterResult,
+  DecisionAuthorityRegisterResult,
+  CapabilityKindFailureCode,
+  CapabilityRegisterFailureCode,
+  DecisionAuthorityFailureCode,
+} from './types';
+
+export {
+  DecisionKind,
+  CAPABILITY_KIND_RE,
+  RESERVED_OPERATOR_ADMIN_NAMESPACES,
+} from './types';
+
+export { CapabilityKindRegistry } from './kind_registry';
+export { CapabilityRegistry, DecisionAuthorityRegistry } from './registry';

--- a/src/runtime/governance/capability/kind_registry.ts
+++ b/src/runtime/governance/capability/kind_registry.ts
@@ -1,0 +1,63 @@
+/**
+ * BGHS Capability — CapabilityKindRegistry
+ * Location: src/runtime/governance/capability/kind_registry.ts
+ *
+ * ADR-OpenClaw-Capability-Boundary §1 + B1. Layer 0 is the ONLY place
+ * that may introduce new CapabilityKinds. Every registration must be
+ * backed by a contract ADR and a schema file.
+ */
+
+import {
+  CAPABILITY_KIND_RE,
+  type CapabilityKind,
+  type CapabilityKindRegistration,
+  type KindRegisterResult,
+  type KindStatus,
+} from './types';
+
+const VALID_STATUS: ReadonlySet<KindStatus> = new Set<KindStatus>([
+  'proposed', 'active', 'frozen', 'superseded',
+]);
+
+export class CapabilityKindRegistry {
+  private kinds: Map<CapabilityKind, CapabilityKindRegistration> = new Map();
+
+  register(r: CapabilityKindRegistration): KindRegisterResult {
+    if (!CAPABILITY_KIND_RE.test(r.kind)) {
+      return { ok: false, code: 'INVALID_KIND_NAME', detail: r.kind };
+    }
+    if (this.kinds.has(r.kind)) {
+      return { ok: false, code: 'DUPLICATE_KIND', detail: r.kind };
+    }
+    if (r.layer_introduced !== 0) {
+      return { ok: false, code: 'LAYER_INTRODUCED_MUST_BE_ZERO' };
+    }
+    if (!r.contract_adr) {
+      return { ok: false, code: 'MISSING_CONTRACT_ADR' };
+    }
+    if (!r.contract_schema) {
+      return { ok: false, code: 'MISSING_CONTRACT_SCHEMA' };
+    }
+    if (!VALID_STATUS.has(r.status)) {
+      return { ok: false, code: 'INVALID_STATUS', detail: r.status };
+    }
+    this.kinds.set(r.kind, r);
+    return { ok: true, kind: r.kind };
+  }
+
+  has(kind: CapabilityKind): boolean {
+    return this.kinds.has(kind);
+  }
+
+  lookup(kind: CapabilityKind): CapabilityKindRegistration | null {
+    return this.kinds.get(kind) ?? null;
+  }
+
+  size(): number {
+    return this.kinds.size;
+  }
+
+  _clearForTests(): void {
+    this.kinds.clear();
+  }
+}

--- a/src/runtime/governance/capability/registry.ts
+++ b/src/runtime/governance/capability/registry.ts
@@ -1,0 +1,120 @@
+/**
+ * BGHS Capability — CapabilityRegistry (Layer 1/2/3 submissions)
+ * Location: src/runtime/governance/capability/registry.ts
+ *
+ * ADR-OpenClaw-Capability-Boundary §2 + B2/B4. Enforces:
+ *   - B1  kind must be registered in CapabilityKindRegistry.
+ *   - B2  duplicate active capability_id → reject; supersede requires
+ *         the previous entry to move to a non-active status first.
+ *   - B4  TrustBoundaryDecl must be present; fs_scope/network_scope
+ *         objects are required (empty arrays allowed = fail-closed).
+ *         Any side_effect of kind 'network-egress' must have a
+ *         non-empty network_scope.egress_allowlist.
+ *   - Owner layer ∈ {1, 2, 3}; Layer 0 is not a capability owner.
+ *
+ * Also hosts the minimum DecisionAuthority registry with
+ * override_allowed=false enforcement.
+ */
+
+import type { CapabilityKindRegistry } from './kind_registry';
+import {
+  type CapabilityRegisterResult,
+  type CapabilityRegistration,
+  type DecisionAuthority,
+  type DecisionAuthorityRegisterResult,
+  type DecisionKind,
+} from './types';
+
+const CAP_ID_RE = /^[a-z][a-z0-9-]*(?::[a-z][a-z0-9_-]*)+$/;
+
+export class CapabilityRegistry {
+  private entries: Map<string, CapabilityRegistration> = new Map();
+
+  constructor(private readonly kinds: CapabilityKindRegistry) {}
+
+  register(reg: CapabilityRegistration): CapabilityRegisterResult {
+    // capability_id format
+    if (!CAP_ID_RE.test(reg.capability_id)) {
+      return { ok: false, code: 'INVALID_CAPABILITY_ID_FORMAT', detail: reg.capability_id };
+    }
+
+    // B1
+    if (!this.kinds.has(reg.kind)) {
+      return { ok: false, code: 'UNKNOWN_KIND', detail: reg.kind };
+    }
+
+    // B2 — duplicate active
+    const prior = this.entries.get(reg.capability_id);
+    if (prior && prior.status === 'active') {
+      return { ok: false, code: 'DUPLICATE_ACTIVE', detail: reg.capability_id };
+    }
+
+    // Owner layer
+    if (![1, 2, 3].includes(reg.owner.layer)) {
+      return { ok: false, code: 'INVALID_OWNER_LAYER' };
+    }
+    if (!reg.owner.declaration_path) {
+      return { ok: false, code: 'MISSING_DECLARATION_PATH' };
+    }
+
+    // B4 — trust boundary required (objects present; arrays may be empty)
+    const tb = reg.trust_boundary;
+    if (!tb || !tb.fs_scope || !tb.network_scope
+      || !Array.isArray(tb.fs_scope.read_roots)
+      || !Array.isArray(tb.fs_scope.write_roots)
+      || !Array.isArray(tb.network_scope.egress_allowlist)) {
+      return { ok: false, code: 'MISSING_TRUST_BOUNDARY' };
+    }
+
+    // B4 follow-through: if the capability declares network-egress, egress_allowlist must be non-empty
+    const needsNet = reg.side_effects.some((s) => s.kind === 'network-egress');
+    if (needsNet && tb.network_scope.egress_allowlist.length === 0) {
+      return { ok: false, code: 'EMPTY_NETWORK_SCOPE_ON_NETWORK_SIDE_EFFECT' };
+    }
+
+    this.entries.set(reg.capability_id, reg);
+    return { ok: true, capability_id: reg.capability_id };
+  }
+
+  lookup(capability_id: string): CapabilityRegistration | null {
+    return this.entries.get(capability_id) ?? null;
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+
+  _clearForTests(): void {
+    this.entries.clear();
+  }
+}
+
+export class DecisionAuthorityRegistry {
+  private authorities: Map<DecisionKind, DecisionAuthority> = new Map();
+
+  register(a: DecisionAuthority): DecisionAuthorityRegisterResult {
+    if (a.override_allowed !== false) {
+      return { ok: false, code: 'OVERRIDE_ALLOWED_MUST_BE_FALSE' };
+    }
+    if (![0, 1].includes(a.authoritative_layer)) {
+      return { ok: false, code: 'INVALID_AUTHORITATIVE_LAYER' };
+    }
+    if (!a.authoritative_path) {
+      return { ok: false, code: 'MISSING_AUTHORITATIVE_PATH' };
+    }
+    this.authorities.set(a.kind, a);
+    return { ok: true, kind: a.kind };
+  }
+
+  lookup(kind: DecisionKind): DecisionAuthority | null {
+    return this.authorities.get(kind) ?? null;
+  }
+
+  size(): number {
+    return this.authorities.size;
+  }
+
+  _clearForTests(): void {
+    this.authorities.clear();
+  }
+}

--- a/src/runtime/governance/capability/types.ts
+++ b/src/runtime/governance/capability/types.ts
@@ -1,0 +1,167 @@
+/**
+ * BGHS Capability — Types
+ * Location: src/runtime/governance/capability/types.ts
+ *
+ * Mirrors ADR-OpenClaw-Capability-Boundary §1–§5. This tree is the
+ * **BGHS** capability registry — distinct from src/control/registry.ts
+ * (the AI-agent CapabilityRegistry). See README.md in this directory
+ * for the no-cross-import rule.
+ *
+ * Sprint 4 scope:
+ *   - CapabilityKindRegistry (Layer 0 exclusive definitions)
+ *   - CapabilityRegistry (Layer 1/2/3 submissions)
+ *   - Runtime validators for B1/B2/B4, DecisionAuthority.override_allowed=false,
+ *     operator_scope reserved namespaces.
+ * Out of scope: DecisionAuthority runtime enforcement, GatewayMethodRegistration
+ * routing, SessionEventStream writeback on registration (comes after
+ * SessionRegistry integration in a later sprint).
+ */
+
+// === §1 CapabilityKind ===
+
+/**
+ * Globally unique capability kind, defined exclusively by Layer 0.
+ * Minimum naming pattern (Sprint 4): dotted segments, each segment
+ * `[a-z][a-z0-9-]*`, at least 2 segments, no trailing dot. Version
+ * suffixes and deeper grammars are up to later contract schemas.
+ */
+export type CapabilityKind = string;
+
+export const CAPABILITY_KIND_RE = /^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$/;
+
+export type KindStatus = 'proposed' | 'active' | 'frozen' | 'superseded';
+
+export interface CapabilityKindRegistration {
+  kind: CapabilityKind;
+  layer_introduced: 0;            // schema-forced (B1)
+  contract_adr: string;           // required
+  contract_schema: string;        // required; points at the JSON/YAML schema file
+  introduced_at: string;          // ISO 8601
+  superseded_by: string | null;
+  status: KindStatus;
+}
+
+// === §2 CapabilityRegistration ===
+
+export type OwnerLayer = 1 | 2 | 3;
+
+export interface CapabilityOwner {
+  layer: OwnerLayer;
+  component: string;
+  declaration_path: string;
+}
+
+export interface SideEffectDecl {
+  kind: 'fs-write' | 'network-egress' | 'external-api' | 'process-spawn' | 'db-write';
+  target: string;                 // path / hostname / endpoint — already scoped by trust_boundary
+  notes?: string;
+}
+
+// === §4 TrustBoundaryDecl ===
+
+export interface TrustBoundaryFsScope {
+  read_roots: string[];
+  write_roots: string[];
+}
+
+export interface TrustBoundaryNetworkScope {
+  egress_allowlist: string[];
+  ingress: 'none' | 'gateway-only';
+}
+
+export interface TrustBoundaryDecl {
+  fs_scope: TrustBoundaryFsScope;
+  network_scope: TrustBoundaryNetworkScope;
+  in_process: boolean;
+  credential_path: string | null;      // points at CredentialBroker seam (P1-f)
+}
+
+export type CapabilityStatus = 'pending' | 'active' | 'quarantined' | 'revoked';
+
+export interface CapabilityRegistration {
+  capability_id: string;          // e.g. "amazon-growth-engine:bid_write"
+  kind: CapabilityKind;
+  owner: CapabilityOwner;
+  trust_boundary: TrustBoundaryDecl;
+  side_effects: SideEffectDecl[];
+  observed_by: string[] | null;
+  registered_at: string;
+  status: CapabilityStatus;
+}
+
+// === §3 Decision plane ===
+
+export enum DecisionKind {
+  CAPABILITY_ADMISSION = 'capability.admission',
+  APPROVAL = 'approval',
+  TOOL_SAFETY = 'tool.safety',
+  OPERATOR_SCOPE = 'operator.scope',
+  SESSION_WRITE = 'session.write',
+}
+
+export interface DecisionAuthority {
+  kind: DecisionKind;
+  authoritative_layer: 0 | 1;
+  authoritative_path: string;
+  observers_allowed: string[];
+  override_allowed: false;        // schema-forced (B3)
+}
+
+// === §5 Operator scope ===
+
+export type OperatorScope = 'operator.admin' | 'operator.write' | 'operator.read';
+
+export interface GatewayMethodRegistration {
+  method: string;
+  scope_required: OperatorScope;
+  capability_id: string | null;
+  audit_required: boolean;
+}
+
+/**
+ * Reserved gateway namespaces — Layer 0 rejects any plugin that tries
+ * to register a capability binding to a method in these namespaces.
+ * Sprint 4 captures the ADR's §5 reserved set; Gateway enforcement
+ * lands with the gateway wiring sprint.
+ */
+export const RESERVED_OPERATOR_ADMIN_NAMESPACES: readonly string[] = [
+  'config.',
+  'exec.approvals.',
+  'wizard.',
+];
+
+// === Register result ===
+
+export type CapabilityKindFailureCode =
+  | 'INVALID_KIND_NAME'
+  | 'DUPLICATE_KIND'
+  | 'LAYER_INTRODUCED_MUST_BE_ZERO'
+  | 'MISSING_CONTRACT_ADR'
+  | 'MISSING_CONTRACT_SCHEMA'
+  | 'INVALID_STATUS';
+
+export type CapabilityRegisterFailureCode =
+  | 'UNKNOWN_KIND'
+  | 'DUPLICATE_ACTIVE'
+  | 'INVALID_OWNER_LAYER'
+  | 'MISSING_DECLARATION_PATH'
+  | 'MISSING_TRUST_BOUNDARY'
+  | 'EMPTY_NETWORK_SCOPE_ON_NETWORK_SIDE_EFFECT'
+  | 'INVALID_CAPABILITY_ID_FORMAT';
+
+export type DecisionAuthorityFailureCode =
+  | 'OVERRIDE_ALLOWED_MUST_BE_FALSE'
+  | 'INVALID_AUTHORITATIVE_LAYER'
+  | 'MISSING_AUTHORITATIVE_PATH';
+
+export type KindRegisterResult =
+  | { ok: true; kind: CapabilityKind }
+  | { ok: false; code: CapabilityKindFailureCode; detail?: string };
+
+export type CapabilityRegisterResult =
+  | { ok: true; capability_id: string }
+  | { ok: false; code: CapabilityRegisterFailureCode; detail?: string };
+
+export type DecisionAuthorityRegisterResult =
+  | { ok: true; kind: DecisionKind }
+  | { ok: false; code: DecisionAuthorityFailureCode; detail?: string };

--- a/src/runtime/governance/guard/chain_registry.ts
+++ b/src/runtime/governance/guard/chain_registry.ts
@@ -1,0 +1,106 @@
+/**
+ * BGHS Guard — GuardChain registry + validator
+ * Location: src/runtime/governance/guard/chain_registry.ts
+ *
+ * ADR-Loamwise-Guard-Content-Security §7. Enforces:
+ *   - G2 protected_path.kind must be in the 6-entry whitelist.
+ *   - G2 protected_path.required_guard_kinds must be covered by
+ *     chain.steps.
+ *   - G3 SHADOW step must have non_shadow_allowed_by == null.
+ *   - G3 ADVISORY/ACTIVE step must have non_shadow_allowed_by != null
+ *     (step-level; chain-level declared_by_adr does not satisfy this).
+ *   - G3 global_shadow must be false (schema-forced; caller may not
+ *     override without a double-signed ADR).
+ *   - VerdictRouting must never allow on_dangerous = 'pass'.
+ *   - Chain must carry declared_by_adr.
+ */
+
+import {
+  GuardEnforcementMode,
+  PROTECTED_PATHS_WHITELIST,
+  type GuardChain,
+  type GuardRegisterResult,
+} from './types';
+
+export class GuardChainRegistry {
+  private chains: Map<string, GuardChain> = new Map();
+
+  register(chain: GuardChain): GuardRegisterResult {
+    if (this.chains.has(chain.chain_id)) {
+      return { ok: false, code: 'DUPLICATE_CHAIN_ID', detail: chain.chain_id };
+    }
+
+    if (!chain.declared_by_adr) {
+      return { ok: false, code: 'MISSING_CHAIN_ADR' };
+    }
+
+    if (chain.global_shadow !== false) {
+      return { ok: false, code: 'GLOBAL_SHADOW_DISALLOWED' };
+    }
+
+    if (!PROTECTED_PATHS_WHITELIST.has(chain.protected_path.kind)) {
+      return {
+        ok: false,
+        code: 'PATH_NOT_IN_WHITELIST',
+        detail: chain.protected_path.kind,
+      };
+    }
+
+    const stepKinds = new Set(chain.steps.map((s) => s.guard_kind));
+    for (const required of chain.protected_path.required_guard_kinds) {
+      if (!stepKinds.has(required)) {
+        return {
+          ok: false,
+          code: 'MISSING_REQUIRED_GUARD_KIND',
+          detail: required,
+        };
+      }
+    }
+
+    for (const step of chain.steps) {
+      if (step.mode === GuardEnforcementMode.SHADOW) {
+        if (step.non_shadow_allowed_by !== null) {
+          return {
+            ok: false,
+            code: 'SHADOW_STEP_HAS_NON_SHADOW_REF',
+            detail: step.step_id,
+          };
+        }
+      } else {
+        if (!step.non_shadow_allowed_by) {
+          return {
+            ok: false,
+            code: 'NON_SHADOW_STEP_MISSING_ESCALATION_ADR',
+            detail: step.step_id,
+          };
+        }
+      }
+
+      // VerdictRouting: 'pass' on dangerous is forbidden (TS type already
+      // excludes it, but runtime validator guards against relaxed inputs).
+      const dangerous = step.on_verdict.on_dangerous as string;
+      if (dangerous === 'pass') {
+        return {
+          ok: false,
+          code: 'VERDICT_ROUTING_ALLOWS_DANGEROUS_PASS',
+          detail: step.step_id,
+        };
+      }
+    }
+
+    this.chains.set(chain.chain_id, chain);
+    return { ok: true, chain_id: chain.chain_id };
+  }
+
+  lookup(chain_id: string): GuardChain | null {
+    return this.chains.get(chain_id) ?? null;
+  }
+
+  size(): number {
+    return this.chains.size;
+  }
+
+  _clearForTests(): void {
+    this.chains.clear();
+  }
+}

--- a/src/runtime/governance/guard/evidence.ts
+++ b/src/runtime/governance/guard/evidence.ts
@@ -1,0 +1,86 @@
+/**
+ * BGHS Guard — Evidence redaction helpers + sink
+ * Location: src/runtime/governance/guard/evidence.ts
+ *
+ * ADR-Loamwise-Guard-Content-Security §4 / G7. Evidence is
+ * append-only and every `redacted_snippet` must never carry the raw
+ * matched content. These utilities are the single seam for the
+ * redaction rules; scanner implementations funnel through here.
+ *
+ * Reuses src/audit/evidence/hash.ts:sha256Hex (F4 discipline — one
+ * evidence-infrastructure tree for the whole repo).
+ */
+
+import { randomUUID } from 'node:crypto';
+import { sha256Hex } from '../../../audit/evidence/hash';
+import type { GuardEvidence, GuardEvidenceSink, HitDetail } from './types';
+
+const MAX_SNIPPET = 40;
+
+/**
+ * Produce a safe representation of a matched snippet for storage in
+ * GuardEvidence.hits[].redacted_snippet. Rules:
+ *   - Length <= MAX_SNIPPET → return as-is ONLY if it passes the
+ *     sensitive-pattern heuristic; otherwise hash.
+ *   - Longer → sha256 prefix + length hint.
+ *   - Empty/undefined → '[empty]'.
+ */
+export function redactSnippet(raw: string | null | undefined): string {
+  if (!raw) return '[empty]';
+  if (looksSensitive(raw)) {
+    const sha = sha256Hex(raw).slice(0, 12);
+    return `sha256:${sha}...`;
+  }
+  if (raw.length <= MAX_SNIPPET) return raw;
+  const sha = sha256Hex(raw).slice(0, 12);
+  return `sha256:${sha}... [len=${raw.length}]`;
+}
+
+/** Heuristic — token-ish / high-entropy / credential-shaped strings. */
+export function looksSensitive(s: string): boolean {
+  // OAuth / Amazon / Google / JWT-like prefixes and common token shapes
+  return (
+    /^ya29\./.test(s) ||
+    /^Atza\|/.test(s) ||
+    /\bBearer\s+/.test(s) ||
+    /\b[A-Za-z0-9+/]{32,}={0,2}\b/.test(s) ||        // base64-ish long run
+    /\b[a-f0-9]{32,}\b/i.test(s)                      // hex token
+  );
+}
+
+/** Build a GuardEvidence record with normalized defaults. */
+export function makeEvidence(input: Omit<GuardEvidence, 'evidence_id' | 'scanned_at'>): GuardEvidence {
+  return {
+    evidence_id: randomUUID(),
+    scanned_at: new Date().toISOString(),
+    ...input,
+  };
+}
+
+/** Normalize a hit, applying redaction to the snippet. */
+export function normalizeHit(hit: Omit<HitDetail, 'redacted_snippet'> & { raw_snippet: string | null }): HitDetail {
+  const { raw_snippet, ...rest } = hit;
+  return {
+    ...rest,
+    redacted_snippet: redactSnippet(raw_snippet),
+  };
+}
+
+/** In-memory evidence sink — the default sink for Sprint 3 tests and
+ *  local dev. SessionAdjacentArtifact-backed sink (P1-e CREDENTIAL_AUDIT
+ *  sibling) lands in a later sprint. */
+export class InMemoryGuardEvidenceSink implements GuardEvidenceSink {
+  private records: GuardEvidence[] = [];
+
+  async append(ev: GuardEvidence): Promise<void> {
+    this.records.push(ev);
+  }
+
+  list(): readonly GuardEvidence[] {
+    return this.records;
+  }
+
+  _clearForTests(): void {
+    this.records = [];
+  }
+}

--- a/src/runtime/governance/guard/index.ts
+++ b/src/runtime/governance/guard/index.ts
@@ -1,0 +1,47 @@
+/**
+ * BGHS Guard — barrel
+ * Location: src/runtime/governance/guard/index.ts
+ */
+
+export {
+  GuardKind,
+  GuardVerdict,
+  GuardEnforcementMode,
+  ProtectedPathKind,
+  PROTECTED_PATHS_WHITELIST,
+} from './types';
+
+export type {
+  GuardEvidence,
+  GuardEvidenceSink,
+  GuardChain,
+  GuardChainStep,
+  GuardRegisterResult,
+  GuardRegisterFailureCode,
+  GuardRunInput,
+  HitDetail,
+  ScannedPath,
+  ProtectedScannedPathKind,
+  ProtectedPath,
+  VerdictRouting,
+} from './types';
+
+export {
+  redactSnippet,
+  looksSensitive,
+  makeEvidence,
+  normalizeHit,
+  InMemoryGuardEvidenceSink,
+} from './evidence';
+
+export {
+  ShadowRunner,
+  NoopScanner,
+  AlwaysDangerousScanner,
+  type Scanner,
+  type ScannerResult,
+  type ShadowRunnerOptions,
+  type ShadowRunOutput,
+} from './shadow_runner';
+
+export { GuardChainRegistry } from './chain_registry';

--- a/src/runtime/governance/guard/shadow_runner.ts
+++ b/src/runtime/governance/guard/shadow_runner.ts
@@ -1,0 +1,143 @@
+/**
+ * BGHS Guard — ShadowRunner
+ * Location: src/runtime/governance/guard/shadow_runner.ts
+ *
+ * ADR-Loamwise-Guard-Content-Security G3 / G5. Runs a pluggable
+ * Scanner in SHADOW mode: observes, writes GuardEvidence, and NEVER
+ * blocks. SHADOW is the only mode supported by Sprint 3 Wave 3.1;
+ * ADVISORY and ACTIVE land after SHADOW evidence justifies escalation
+ * (Sprint 7).
+ *
+ * Scanner implementations plug in via the Scanner interface. Sprint 3
+ * ships a NoopScanner that returns SAFE + [] — enough to exercise the
+ * full plumbing (scan → evidence → sink) without any real content
+ * matching. Business-path wiring to skill candidate submit / memory
+ * write / assembly ingest happens in Sprint 5.2 and Sprint 6.2.
+ */
+
+import { makeEvidence } from './evidence';
+import type {
+  GuardEvidence,
+  GuardEvidenceSink,
+  GuardKind,
+  GuardRunInput,
+  GuardVerdict,
+  HitDetail,
+} from './types';
+import { GuardEnforcementMode, GuardVerdict as Verdict } from './types';
+
+export interface ScannerResult {
+  verdict: GuardVerdict;
+  hits: HitDetail[];
+}
+
+export interface Scanner {
+  scanner_id: string;
+  scanner_version: string;
+  pattern_catalog_version: string;
+  supports_kind: GuardKind;
+  scan(input: GuardRunInput): Promise<ScannerResult>;
+}
+
+/** A scanner that always reports SAFE with zero hits. Use as the
+ *  default for skeleton wiring and as a fixture in unit tests. */
+export class NoopScanner implements Scanner {
+  readonly scanner_id: string;
+  readonly scanner_version = '0.0.0-noop';
+  readonly pattern_catalog_version = '0.0.0-noop';
+
+  constructor(readonly supports_kind: GuardKind, id: string = 'noop-scanner') {
+    this.scanner_id = id;
+  }
+
+  async scan(_input: GuardRunInput): Promise<ScannerResult> {
+    return { verdict: Verdict.SAFE, hits: [] };
+  }
+}
+
+/** Always reports DANGEROUS. Useful for unit tests that need to assert
+ *  shadow-mode non-blocking behavior. */
+export class AlwaysDangerousScanner implements Scanner {
+  readonly scanner_id: string;
+  readonly scanner_version = '0.0.0-always-dangerous';
+  readonly pattern_catalog_version = '0.0.0-always-dangerous';
+
+  constructor(readonly supports_kind: GuardKind, id: string = 'always-dangerous') {
+    this.scanner_id = id;
+  }
+
+  async scan(_input: GuardRunInput): Promise<ScannerResult> {
+    return {
+      verdict: Verdict.DANGEROUS,
+      hits: [
+        {
+          pattern_id: 'test.always-dangerous',
+          category: 'test',
+          redacted_snippet: '[test-fixture]',
+          position_hint: null,
+          severity_score: 1,
+        },
+      ],
+    };
+  }
+}
+
+export interface ShadowRunnerOptions {
+  sink: GuardEvidenceSink;
+  /**
+   * Whether fail-open is permitted on scanner failure. SHADOW is the
+   * only mode that accepts `true`; ADVISORY/ACTIVE runners (not in
+   * Sprint 3) must set false.
+   */
+  fail_open: true;
+}
+
+export interface ShadowRunOutput {
+  verdict: GuardVerdict;        // the scanner's verdict, recorded for observability
+  evidence_id: string;
+  blocked: false;               // SHADOW never blocks
+}
+
+export class ShadowRunner {
+  readonly mode = GuardEnforcementMode.SHADOW;
+
+  constructor(
+    private readonly scanner: Scanner,
+    private readonly opts: ShadowRunnerOptions,
+  ) {}
+
+  async run(input: GuardRunInput): Promise<ShadowRunOutput> {
+    let result: ScannerResult;
+    let scannerFailed = false;
+    let failureReason: string | null = null;
+
+    try {
+      result = await this.scanner.scan(input);
+    } catch (err) {
+      if (!this.opts.fail_open) {
+        throw err;    // Cannot happen in Sprint 3 — fail_open is forced true.
+      }
+      scannerFailed = true;
+      failureReason = err instanceof Error ? err.message : String(err);
+      result = { verdict: Verdict.SAFE, hits: [] };
+    }
+
+    const evidence: GuardEvidence = makeEvidence({
+      guard_id: input.guard_id,
+      guard_kind: input.guard_kind,
+      mode: this.mode,
+      verdict: result.verdict,
+      trace_id: input.trace_id,
+      scanned_path: input.scanned_path,
+      hits: result.hits,
+      scanner_version: this.scanner.scanner_version,
+      pattern_catalog_version: this.scanner.pattern_catalog_version,
+      scanner_failed: scannerFailed,
+      failure_reason: failureReason,
+    });
+
+    await this.opts.sink.append(evidence);
+
+    return { verdict: result.verdict, evidence_id: evidence.evidence_id, blocked: false };
+  }
+}

--- a/src/runtime/governance/guard/types.ts
+++ b/src/runtime/governance/guard/types.ts
@@ -1,0 +1,166 @@
+/**
+ * BGHS Guard — Types
+ * Location: src/runtime/governance/guard/types.ts
+ *
+ * Mirrors ADR-Loamwise-Guard-Content-Security §1–§5. Sprint 3 Wave 3.1
+ * lands the declarative surface and a SHADOW-only runner. ADVISORY and
+ * ACTIVE modes, real scanner implementations, and business-path wiring
+ * (skill candidate submit, memory write, assembly ingest) land in later
+ * sprints per the sprint 3 discipline.
+ */
+
+// === §1 GuardKind (固定三种) ===
+
+export enum GuardKind {
+  CONTENT_SCAN = 'content-scan',
+  TRUTH_WRITE = 'truth-write',
+  CONTEXT_INJECT = 'context-inject',
+}
+
+// === §2 GuardVerdict (固定三级) ===
+
+export enum GuardVerdict {
+  SAFE = 'safe',
+  CAUTION = 'caution',
+  DANGEROUS = 'dangerous',
+}
+
+// === §3 GuardEnforcementMode (SHADOW → ADVISORY → ACTIVE) ===
+
+export enum GuardEnforcementMode {
+  SHADOW = 'shadow',
+  ADVISORY = 'advisory',
+  ACTIVE = 'active',
+}
+
+// === §4 GuardEvidence ===
+
+export type ProtectedScannedPathKind =
+  | 'skill-candidate'
+  | 'memory-write'
+  | 'frozen-snapshot-fragment'
+  | 'capability-registration';
+
+export interface ScannedPath {
+  path_kind: ProtectedScannedPathKind;
+  target_ref: string;
+}
+
+export interface HitDetail {
+  pattern_id: string;
+  category: string;
+  redacted_snippet: string;   // ADR §7 G7 — never raw
+  position_hint: string | null;
+  severity_score: number;     // 0..1
+}
+
+export interface GuardEvidence {
+  evidence_id: string;
+  guard_id: string;
+  guard_kind: GuardKind;
+  mode: GuardEnforcementMode;
+  verdict: GuardVerdict;
+  scanned_at: string;
+  trace_id: string;
+  scanned_path: ScannedPath;
+  hits: HitDetail[];
+  scanner_version: string;
+  pattern_catalog_version: string;
+  scanner_failed: boolean;       // SHADOW only; ADVISORY/ACTIVE must be false
+  failure_reason: string | null;
+}
+
+// === §5 GuardChain ===
+
+export enum ProtectedPathKind {
+  SKILL_CANDIDATE_SUBMIT = 'skill.candidate-submit',
+  SKILL_PROMOTION = 'skill.promotion',
+  MEMORY_WRITE_NON_AUTH = 'memory.write.non-authoritative',
+  MEMORY_WRITE_AUTH = 'memory.write.authoritative',
+  ASSEMBLY_FRAGMENT_INGEST = 'assembly.fragment-ingest',
+  CAPABILITY_REGISTRATION = 'capability.registration',
+}
+
+export const PROTECTED_PATHS_WHITELIST: ReadonlySet<ProtectedPathKind> = new Set<ProtectedPathKind>([
+  ProtectedPathKind.SKILL_CANDIDATE_SUBMIT,
+  ProtectedPathKind.SKILL_PROMOTION,
+  ProtectedPathKind.MEMORY_WRITE_NON_AUTH,
+  ProtectedPathKind.MEMORY_WRITE_AUTH,
+  ProtectedPathKind.ASSEMBLY_FRAGMENT_INGEST,
+  ProtectedPathKind.CAPABILITY_REGISTRATION,
+]);
+
+export interface ProtectedPath {
+  kind: ProtectedPathKind;
+  required_guard_kinds: GuardKind[];
+}
+
+export interface VerdictRouting {
+  on_safe: 'pass';
+  on_caution: 'pass-with-warning' | 'escalate-approval' | 'block';
+  on_dangerous: 'block' | 'escalate-approval';   // 'pass' never allowed
+}
+
+export interface GuardChainStep {
+  step_id: string;
+  guard_kind: GuardKind;
+  mode: GuardEnforcementMode;
+  parallel_with: string[] | null;
+  on_verdict: VerdictRouting;
+  /**
+   * Step-level escalation reference. SHADOW steps MUST be null; any
+   * ADVISORY/ACTIVE step MUST be non-null (chain-level ADR is not
+   * enough — ADR §7 G3).
+   */
+  non_shadow_allowed_by: string | null;
+}
+
+export interface GuardChain {
+  chain_id: string;
+  protected_path: ProtectedPath;
+  steps: GuardChainStep[];
+  global_shadow: false;          // always false unless a double-signed ADR says otherwise
+  declared_at: string;
+  declared_by_adr: string;
+}
+
+// === Registration result ===
+
+export type GuardRegisterFailureCode =
+  | 'DUPLICATE_CHAIN_ID'
+  | 'PATH_NOT_IN_WHITELIST'
+  | 'MISSING_REQUIRED_GUARD_KIND'
+  | 'SHADOW_STEP_HAS_NON_SHADOW_REF'
+  | 'NON_SHADOW_STEP_MISSING_ESCALATION_ADR'
+  | 'VERDICT_ROUTING_ALLOWS_DANGEROUS_PASS'
+  | 'GLOBAL_SHADOW_DISALLOWED'
+  | 'MISSING_CHAIN_ADR';
+
+export type GuardRegisterResult =
+  | { ok: true; chain_id: string }
+  | { ok: false; code: GuardRegisterFailureCode; detail?: string };
+
+// === Runner interfaces ===
+
+export interface GuardEvidenceSink {
+  append(ev: GuardEvidence): Promise<void>;
+  list(): readonly GuardEvidence[];
+}
+
+export interface GuardRunInput {
+  guard_id: string;
+  guard_kind: GuardKind;
+  scanner_version: string;
+  pattern_catalog_version: string;
+
+  trace_id: string;
+  scanned_path: ScannedPath;
+
+  /**
+   * Opaque payload to scan. The shadow runner does NOT inspect this —
+   * real scanners plug in later via a Scanner interface (later sprint).
+   * Sprint 3 ships a stub scanner that always returns SAFE with zero
+   * hits so the full pipe is exercisable without real content.
+   */
+  payload: unknown;
+}

--- a/src/runtime/governance/memory/README.md
+++ b/src/runtime/governance/memory/README.md
@@ -1,0 +1,97 @@
+# BGHS Memory — Boundary Notes
+
+**Location**: `src/runtime/governance/memory/`
+**ADR**: `_meta/adr/ADR-Hermes-Memory-Orchestration.md` (P1-c)
+**Sprint**: 6
+
+## One-line boundary
+
+> `src/runtime/memory/`                     = **memory execution-face** (context, observation gateway)
+> `src/runtime/governance/memory/`          = **BGHS memory governance surface**
+> Loamwise `align/` (separate repo)         = **retrieval engine / orchestrator**
+> The three are **not** interchangeable and the first two **must not** cross-import.
+
+## Why the split exists
+
+ADR-Hermes-Memory-Orchestration §O8 is explicit: Layer 0 defines the
+contracts (tiers, records, plans, use policies, snapshot shape); Layer 1
+(Loamwise) implements the manager, the retrieval router, the prefetch
+orchestration, and the summarization pipeline. If governance types and
+execution behaviors share a file, "strict_truth" becomes a knob the
+retrieval engine can quietly flip — exactly the slip the ADR forbids.
+
+| Aspect | `src/runtime/memory/` | `src/runtime/governance/memory/` |
+|---|---|---|
+| What "memory" means | Runtime context plumbing and observation ingress | Structural contracts: tiers, records, plans, use policies, frozen snapshots |
+| Primary interface | `context.ts`, `observation-gateway.ts` | `MemoryUsePolicyRegistry` + `MemoryRecordRegistry` + `MemoryPlanRegistry` + `buildFrozenSnapshot` + `validateRetrievalRequest` + guard-wired write / ingest seams |
+| Who touches state | Runtime context pipeline (Layer 1 execution) | Registry registrations (accept/reject), plan freeze, snapshot builder |
+| Data model | Execution context objects | `MemoryRecord`, `MemoryAssemblyPlan`, `MemoryUsePolicy`, `FrozenSnapshot` |
+| Failure mode | Runtime plumbing error | Registration rejected (`DERIVATION_ELEVATES_TIER`, `AUTHORITATIVE_MUST_DECLARE_DECISION_CONSUMERS`, `PLAN_FROZEN_IS_IMMUTABLE`, …) |
+| Consumed by | Loamwise `align/` execution, AGE runtime | Loamwise planner (plan register + freeze), Guard wiring (observation), audit / replay |
+
+## Hard rule — no cross-import
+
+- `src/runtime/governance/memory/` **MUST NOT** import from `src/runtime/memory/`.
+- `src/runtime/memory/` **MUST NOT** import from `src/runtime/governance/memory/`.
+
+If a future caller needs both faces (e.g., "the observation gateway
+should write records that the governance registry accepts"), that
+adapter is a **third** module. Neither tree should be aware of the
+other's internals.
+
+CI layer-dependency enforcement tracks this alongside the Sprint-4
+capability boundary and Sprint-5 skill-lifecycle boundary; add an entry
+to `.github/workflows/layer-dependency-gate.yml` if violations appear
+rather than carving exceptions.
+
+## Sprint 6 scope
+
+### Wave 6.1 — Memory frozen + strict_truth default
+
+- `MemoryTier` enum (AUTHORITATIVE / DECISION_SUPPORT / CONTEXT_ONLY)
+  with `tierRank()` and `canDeriveTo()` helpers.
+- `MemoryRecord` schema with source/layer/trace/guard-evidence rules.
+- `MemoryRecordRegistry` enforcing O3 derivation rule (no tier
+  elevation), mandatory guard evidence, Layer-3 write rejection.
+- `MemoryUsePolicyRegistry` enforcing §5 twin invariants:
+  AUTHORITATIVE ⇒ decision_consumers non-empty; non-AUTH ⇒ empty;
+  derivation_rule may not elevate tier.
+- `MemoryAssemblyPlan` + `MemoryPlanRegistry` with explicit freeze()
+  step. Once frozen, the plan object is deep-`Object.freeze`d — any
+  later `register()` / `freeze()` call on the same id is rejected.
+- `buildFrozenSnapshot()` produces a strict-truth-sorted immutable
+  snapshot from assembled fragments.
+- `validateRetrievalRequest()` rejects empty `tiers_allowed`,
+  `providers_allowed`; rejects `balanced_recency` unless
+  `purpose === 'audit'` (structural gate — full whitelist deferred to
+  P1-e).
+- `DEFAULT_QUERY_MODE = 'strict_truth'`.
+
+### Wave 6.2 — Guard wired to memory write + assembly fragment ingest
+
+- `guardedMemoryWrite()` runs the ShadowRunner (TRUTH_WRITE guard for
+  AUTHORITATIVE records, CONTENT_SCAN otherwise), writes GuardEvidence,
+  attaches the evidence ref to the record, and submits to
+  MemoryRecordRegistry.
+- `guardedAssemblyFragmentIngest()` runs the ShadowRunner
+  (CONTEXT_INJECT guard), writes evidence, and only admits the
+  fragment when the referenced plan is frozen + unexpired and the
+  record ref is known.
+- SHADOW mode only — the runner records but never blocks. Registry /
+  plan admission is authoritative.
+
+## What this sprint does NOT do
+
+- It does **not** implement retrieval execution, provider registration,
+  LLM summarization, federated query routing, smart routing, or any
+  auto-merge / auto-rewrite. All execution lives in Layer 1.
+- It does **not** persist records, plans, policies, or snapshots —
+  in-memory registries are the Sprint-6 storage, and the persistent
+  backing lands with the P1-e Session-adjacent integration.
+- It does **not** wire Guard onto retrieval, query orchestration,
+  provider `sync_turn`, or any path beyond the two listed above.
+- It does **not** define the `balanced_recency` whitelist / trigger
+  values — those are deferred to P1-e (only the structural gate lives
+  here).
+- It does **not** touch `src/runtime/memory/`. If bridging is ever
+  required, write a new adapter module and a proposal ADR first.

--- a/src/runtime/governance/memory/guard_wire.ts
+++ b/src/runtime/governance/memory/guard_wire.ts
@@ -1,0 +1,185 @@
+/**
+ * BGHS Memory — Guard wiring (Sprint 6 Wave 6.2)
+ * Location: src/runtime/governance/memory/guard_wire.ts
+ *
+ * Connects the Sprint-3 Guard ShadowRunner to exactly two real
+ * protected paths:
+ *
+ *   - MEMORY_WRITE_{NON_AUTH, AUTH}  → guardedMemoryWrite()
+ *   - ASSEMBLY_FRAGMENT_INGEST       → guardedAssemblyFragmentIngest()
+ *
+ * Scope discipline (Sprint 6 exit gates):
+ *   - SHADOW ONLY. The runner writes evidence and never blocks.
+ *   - Registry / plan rules remain authoritative for admission.
+ *   - GuardKind is chosen by the target: AUTHORITATIVE writes take
+ *     the TRUTH_WRITE guard; other tiers take CONTENT_SCAN. Fragment
+ *     ingest takes CONTEXT_INJECT.
+ *   - Does NOT wire retrieval, query orchestration, provider registration,
+ *     summarization, or any other memory path. Those remain SHADOW-less.
+ */
+
+import {
+  GuardKind,
+  GuardVerdict,
+  type GuardEvidenceSink,
+  type ScannedPath,
+} from '../guard';
+import type { ShadowRunner } from '../guard/shadow_runner';
+import type { MemoryPlanRegistry } from './plan_registry';
+import type { MemoryRecordRegistry } from './record_registry';
+import type { MemoryUsePolicyRegistry } from './use_policy_registry';
+import {
+  MemoryTier,
+  type AssemblyFragmentIngestRequest,
+  type GuardKindId,
+  type GuardedFragmentIngestResult,
+  type GuardedMemoryWriteResult,
+  type MemoryRecord,
+  type MemoryWriteRequest,
+} from './types';
+
+export interface GuardedMemoryWriteOptions {
+  runner: ShadowRunner;
+  sink: GuardEvidenceSink;
+  policies: MemoryUsePolicyRegistry;
+  records: MemoryRecordRegistry;
+  scanner_id: string;
+}
+
+function guardKindForTier(tier: MemoryTier): { gk: GuardKind; label: GuardKindId } {
+  return tier === MemoryTier.AUTHORITATIVE
+    ? { gk: GuardKind.TRUTH_WRITE, label: 'truth-write' }
+    : { gk: GuardKind.CONTENT_SCAN, label: 'content-scan' };
+}
+
+function verdictLiteral(v: GuardVerdict): 'safe' | 'caution' | 'dangerous' {
+  switch (v) {
+    case GuardVerdict.SAFE: return 'safe';
+    case GuardVerdict.CAUTION: return 'caution';
+    case GuardVerdict.DANGEROUS: return 'dangerous';
+  }
+}
+
+/**
+ * Run SHADOW guard → append GuardEvidence → register the MemoryRecord
+ * (with the new guard evidence ref attached). The policy's tier must
+ * match the record's tier (two different tiers pointing at the same
+ * policy id is a registration error, not a runtime guard concern).
+ */
+export async function guardedMemoryWrite(
+  req: MemoryWriteRequest,
+  opts: GuardedMemoryWriteOptions,
+): Promise<GuardedMemoryWriteResult> {
+  const policy = opts.policies.lookup(req.use_policy_id);
+  if (!policy) {
+    return { ok: false, code: 'UNKNOWN_USE_POLICY', detail: req.use_policy_id };
+  }
+  if (policy.tier !== req.record.tier) {
+    return {
+      ok: false,
+      code: 'POLICY_TIER_MISMATCH',
+      detail: `${req.record.tier} vs policy ${policy.tier}`,
+    };
+  }
+
+  const { gk, label } = guardKindForTier(req.record.tier);
+  const scanned_path: ScannedPath = {
+    path_kind: 'memory-write',
+    target_ref: req.record.record_id,
+  };
+
+  const out = await opts.runner.run({
+    guard_id: `memory-write:${opts.scanner_id}`,
+    guard_kind: gk,
+    scanner_version: '',
+    pattern_catalog_version: '',
+    trace_id: req.trace_id,
+    scanned_path,
+    payload: req.scan_payload,
+  });
+
+  const vl = verdictLiteral(out.verdict);
+
+  const finalRecord: MemoryRecord = {
+    ...req.record,
+    guard_evidence: [
+      { evidence_id: out.evidence_id, guard_kind: label, verdict: vl },
+    ],
+  };
+
+  const reg = opts.records.register(finalRecord);
+  if (!reg.ok) {
+    return {
+      ok: false,
+      code: reg.code,
+      detail: reg.detail,
+      guard_evidence_id: out.evidence_id,
+      guard_verdict: vl,
+    };
+  }
+  return {
+    ok: true,
+    record_id: reg.record_id,
+    guard_evidence_id: out.evidence_id,
+    guard_kind: label,
+    guard_verdict: vl,
+    guard_mode: 'shadow',
+  };
+}
+
+export interface GuardedFragmentIngestOptions {
+  runner: ShadowRunner;
+  sink: GuardEvidenceSink;
+  plans: MemoryPlanRegistry;
+  records: MemoryRecordRegistry;
+  scanner_id: string;
+}
+
+/**
+ * Run SHADOW CONTEXT_INJECT guard for a fragment on its way into a
+ * frozen plan's assembly stream. Rejects if plan is not frozen, is
+ * expired, or the referenced record is unknown — those are the
+ * structural preconditions Layer 0 owns. Evidence is still written
+ * when the ingest is rejected, so audits can observe attempts.
+ */
+export async function guardedAssemblyFragmentIngest(
+  req: AssemblyFragmentIngestRequest,
+  opts: GuardedFragmentIngestOptions,
+): Promise<GuardedFragmentIngestResult> {
+  const scanned_path: ScannedPath = {
+    path_kind: 'frozen-snapshot-fragment',
+    target_ref: req.fragment_id,
+  };
+  const out = await opts.runner.run({
+    guard_id: `assembly-fragment-ingest:${opts.scanner_id}`,
+    guard_kind: GuardKind.CONTEXT_INJECT,
+    scanner_version: '',
+    pattern_catalog_version: '',
+    trace_id: req.trace_id,
+    scanned_path,
+    payload: req.scan_payload,
+  });
+  const vl = verdictLiteral(out.verdict);
+
+  const plan = opts.plans.lookup(req.plan_id);
+  if (!plan) {
+    return { ok: false, code: 'PLAN_NOT_FOUND', detail: req.plan_id, guard_evidence_id: out.evidence_id, guard_verdict: vl };
+  }
+  if (!plan.frozen) {
+    return { ok: false, code: 'PLAN_NOT_FROZEN', detail: req.plan_id, guard_evidence_id: out.evidence_id, guard_verdict: vl };
+  }
+  if (opts.plans.isExpired(req.plan_id)) {
+    return { ok: false, code: 'PLAN_EXPIRED', detail: plan.expires_at, guard_evidence_id: out.evidence_id, guard_verdict: vl };
+  }
+  if (!opts.records.has(req.record_ref)) {
+    return { ok: false, code: 'UNKNOWN_RECORD_REF', detail: req.record_ref, guard_evidence_id: out.evidence_id, guard_verdict: vl };
+  }
+
+  return {
+    ok: true,
+    fragment_id: req.fragment_id,
+    guard_evidence_id: out.evidence_id,
+    guard_verdict: vl,
+    guard_mode: 'shadow',
+  };
+}

--- a/src/runtime/governance/memory/index.ts
+++ b/src/runtime/governance/memory/index.ts
@@ -1,0 +1,69 @@
+/**
+ * BGHS Memory — barrel
+ * Location: src/runtime/governance/memory/index.ts
+ *
+ * See README.md in this directory for the hard boundary against
+ * `src/runtime/memory/` (the pre-existing execution-face memory
+ * module) and Loamwise `align/` (retrieval engine). Cross-imports
+ * between governance and execution trees are forbidden.
+ */
+
+export {
+  MemoryTier,
+  tierRank,
+  canDeriveTo,
+} from './types';
+
+export type {
+  MemoryRecord,
+  MemoryRecordSource,
+  MemoryRecordSourceLayer,
+  GuardEvidenceRef,
+  MemoryRetrievalRequest,
+  MemoryRetrievalTriggeredBy,
+  RetrievalPurpose,
+  QueryMode,
+  StructuredQuery,
+  RetrievalFragment,
+  RetrievalResult,
+  MemoryAssemblyPlan,
+  RetrievalSpec,
+  AssemblyStep,
+  AssemblyStepKind,
+  MemoryWriteSpec,
+  MemoryUsePolicy,
+  DerivationRule,
+  WriteActorRule,
+  WriteActorKind,
+  GuardKindId,
+  DecisionKindId,
+  FrozenSnapshot,
+  MemoryWriteRequest,
+  AssemblyFragmentIngestRequest,
+  UsePolicyFailureCode,
+  UsePolicyRegisterResult,
+  PlanFailureCode,
+  PlanRegisterResult,
+  PlanFreezeResult,
+  RecordFailureCode,
+  RecordRegisterResult,
+  RetrievalFailureCode,
+  RetrievalValidateResult,
+  GuardedWriteFailureCode,
+  GuardedMemoryWriteResult,
+  FragmentIngestFailureCode,
+  GuardedFragmentIngestResult,
+} from './types';
+
+export { MemoryUsePolicyRegistry } from './use_policy_registry';
+export { MemoryRecordRegistry } from './record_registry';
+export { MemoryPlanRegistry } from './plan_registry';
+export { buildFrozenSnapshot } from './snapshot';
+export { validateRetrievalRequest, DEFAULT_QUERY_MODE } from './retrieval';
+
+export {
+  guardedMemoryWrite,
+  guardedAssemblyFragmentIngest,
+  type GuardedMemoryWriteOptions,
+  type GuardedFragmentIngestOptions,
+} from './guard_wire';

--- a/src/runtime/governance/memory/plan_registry.ts
+++ b/src/runtime/governance/memory/plan_registry.ts
@@ -1,0 +1,112 @@
+/**
+ * BGHS Memory — MemoryAssemblyPlan registry
+ * Location: src/runtime/governance/memory/plan_registry.ts
+ *
+ * ADR-Hermes-Memory-Orchestration §4 + O5 + O7. Enforces:
+ *   - Plans are registered in a non-frozen state, then explicitly frozen.
+ *   - Once frozen, the plan is IMMUTABLE — no further register / freeze
+ *     calls succeed; the underlying object is Object.frozen to guard
+ *     against accidental in-place mutation (O5).
+ *   - write_specs.use_policy_id must reference a registered MemoryUsePolicy.
+ *   - write_specs.target_tier must match the referenced policy's tier.
+ *   - Expired plans cannot be frozen and are not valid as triggered_by
+ *     plan_id for retrieval requests.
+ *
+ * This registry is NOT a planner — it validates and stores plans that
+ * higher layers (Loamwise `align/`) compose. The retrieval engine that
+ * executes plans lives in Layer 1 and is out of scope.
+ */
+
+import type { MemoryUsePolicyRegistry } from './use_policy_registry';
+import {
+  type MemoryAssemblyPlan,
+  type PlanFreezeResult,
+  type PlanRegisterResult,
+} from './types';
+
+export class MemoryPlanRegistry {
+  private plans: Map<string, MemoryAssemblyPlan> = new Map();
+
+  constructor(private readonly policies: MemoryUsePolicyRegistry) {}
+
+  register(plan: MemoryAssemblyPlan): PlanRegisterResult {
+    if (this.plans.has(plan.plan_id)) {
+      return { ok: false, code: 'DUPLICATE_PLAN_ID', detail: plan.plan_id };
+    }
+    if (plan.frozen) {
+      return { ok: false, code: 'PLAN_ALREADY_FROZEN_AT_REGISTER', detail: plan.plan_id };
+    }
+    // write_specs must reference known MemoryUsePolicies; tier must match.
+    for (const ws of plan.write_specs) {
+      const policy = this.policies.lookup(ws.use_policy_id);
+      if (!policy) {
+        return { ok: false, code: 'UNKNOWN_USE_POLICY', detail: ws.use_policy_id };
+      }
+      if (policy.tier !== ws.target_tier) {
+        return {
+          ok: false,
+          code: 'WRITE_SPEC_TIER_MISMATCH',
+          detail: `${ws.target_tier} vs policy ${policy.tier}`,
+        };
+      }
+    }
+    // assembly_order can reference fragments by record_id; we do not yet
+    // have a cross-registry validator against MemoryRecordRegistry
+    // (plans may be registered before records exist — intentional).
+
+    // Shallow copy so registered form cannot be flipped from the outside
+    // before freeze(); fragments inside remain shared by ref (acceptable
+    // — freeze snapshot happens on explicit freeze()).
+    const stored: MemoryAssemblyPlan = { ...plan, frozen: false };
+    this.plans.set(plan.plan_id, stored);
+    return { ok: true, plan_id: plan.plan_id };
+  }
+
+  freeze(plan_id: string): PlanFreezeResult {
+    const plan = this.plans.get(plan_id);
+    if (!plan) return { ok: false, code: 'PLAN_NOT_FOUND', detail: plan_id };
+    if (plan.frozen) return { ok: false, code: 'PLAN_ALREADY_FROZEN', detail: plan_id };
+    if (new Date(plan.expires_at).getTime() < Date.now()) {
+      return { ok: false, code: 'PLAN_EXPIRED', detail: plan.expires_at };
+    }
+    plan.frozen = true;
+    // Object.freeze guards against in-place mutation of the plan object
+    // (O5). Nested arrays / objects are frozen deeply to block item
+    // swapping as well.
+    deepFreeze(plan);
+    return { ok: true, plan_id, frozen_at: new Date().toISOString() };
+  }
+
+  lookup(plan_id: string): MemoryAssemblyPlan | null {
+    return this.plans.get(plan_id) ?? null;
+  }
+
+  isFrozen(plan_id: string): boolean {
+    return this.plans.get(plan_id)?.frozen === true;
+  }
+
+  isExpired(plan_id: string): boolean {
+    const plan = this.plans.get(plan_id);
+    if (!plan) return false;
+    return new Date(plan.expires_at).getTime() < Date.now();
+  }
+
+  size(): number {
+    return this.plans.size;
+  }
+
+  _clearForTests(): void {
+    this.plans.clear();
+  }
+}
+
+function deepFreeze<T>(obj: T): T {
+  if (obj === null || typeof obj !== 'object') return obj;
+  if (Object.isFrozen(obj)) return obj;
+  Object.freeze(obj);
+  for (const key of Object.keys(obj as Record<string, unknown>)) {
+    const v = (obj as Record<string, unknown>)[key];
+    if (v && typeof v === 'object') deepFreeze(v);
+  }
+  return obj;
+}

--- a/src/runtime/governance/memory/record_registry.ts
+++ b/src/runtime/governance/memory/record_registry.ts
@@ -1,0 +1,93 @@
+/**
+ * BGHS Memory — MemoryRecord registry
+ * Location: src/runtime/governance/memory/record_registry.ts
+ *
+ * ADR-Hermes-Memory-Orchestration §2 + O3. Enforces:
+ *   - source.layer ∈ {0, 1, 2}; Layer 3 may NOT write memory records.
+ *   - content_hash is a valid sha256 (with or without "sha256:" prefix).
+ *   - guard_evidence must be non-empty (O4 — all writes are observed).
+ *   - upstream_ref must exist if specified; derived record cannot
+ *     elevate tier (O3): tierRank(derived) >= tierRank(upstream).
+ *   - trace_id mandatory.
+ *
+ * This registry is storage-only. It does not implement retrieval,
+ * routing, summarization, or any provider behavior — those belong to
+ * Loamwise `align/` (Layer 1). The Sprint 6 scope is governance
+ * structure for records, not query execution.
+ */
+
+import {
+  MemoryTier,
+  tierRank,
+  type MemoryRecord,
+  type RecordRegisterResult,
+} from './types';
+
+const CONTENT_HASH_RE = /^sha256:[a-f0-9]{64}$|^[a-f0-9]{64}$/i;
+const VALID_TIERS = new Set<MemoryTier>([
+  MemoryTier.AUTHORITATIVE,
+  MemoryTier.DECISION_SUPPORT,
+  MemoryTier.CONTEXT_ONLY,
+]);
+
+export class MemoryRecordRegistry {
+  private records: Map<string, MemoryRecord> = new Map();
+
+  register(rec: MemoryRecord): RecordRegisterResult {
+    if (!VALID_TIERS.has(rec.tier)) {
+      return { ok: false, code: 'INVALID_TIER', detail: rec.tier };
+    }
+    if (!CONTENT_HASH_RE.test(rec.content_hash)) {
+      return { ok: false, code: 'INVALID_CONTENT_HASH', detail: rec.content_hash };
+    }
+    if (![0, 1, 2].includes(rec.source?.layer)) {
+      // Layer 3 or other: covered by next check but give a specific code when it's 3.
+      if ((rec.source?.layer as number) === 3) {
+        return { ok: false, code: 'LAYER_3_CANNOT_WRITE_MEMORY' };
+      }
+      return { ok: false, code: 'INVALID_SOURCE_LAYER', detail: String(rec.source?.layer) };
+    }
+    if (!rec.source.trace_id) {
+      return { ok: false, code: 'MISSING_TRACE_ID' };
+    }
+    if (!rec.guard_evidence || rec.guard_evidence.length === 0) {
+      return { ok: false, code: 'MISSING_GUARD_EVIDENCE' };
+    }
+    if (this.records.has(rec.record_id)) {
+      return { ok: false, code: 'DUPLICATE_RECORD_ID', detail: rec.record_id };
+    }
+    if (rec.source.upstream_ref !== null) {
+      const parent = this.records.get(rec.source.upstream_ref);
+      if (!parent) {
+        return { ok: false, code: 'UNKNOWN_UPSTREAM_REF', detail: rec.source.upstream_ref };
+      }
+      // O3: derived record may not elevate tier.
+      if (tierRank(rec.tier) < tierRank(parent.tier)) {
+        return {
+          ok: false,
+          code: 'DERIVATION_ELEVATES_TIER',
+          detail: `${parent.tier} → ${rec.tier}`,
+        };
+      }
+    }
+
+    this.records.set(rec.record_id, rec);
+    return { ok: true, record_id: rec.record_id };
+  }
+
+  has(record_id: string): boolean {
+    return this.records.has(record_id);
+  }
+
+  lookup(record_id: string): MemoryRecord | null {
+    return this.records.get(record_id) ?? null;
+  }
+
+  size(): number {
+    return this.records.size;
+  }
+
+  _clearForTests(): void {
+    this.records.clear();
+  }
+}

--- a/src/runtime/governance/memory/retrieval.ts
+++ b/src/runtime/governance/memory/retrieval.ts
@@ -1,0 +1,58 @@
+/**
+ * BGHS Memory — retrieval request validator
+ * Location: src/runtime/governance/memory/retrieval.ts
+ *
+ * ADR-Hermes-Memory-Orchestration §3 + O2. This module does NOT
+ * execute retrieval — it validates that a MemoryRetrievalRequest
+ * satisfies the structural rules Layer 0 owns:
+ *
+ *   - tiers_allowed must be explicit non-empty (no "all tiers" default).
+ *   - providers_allowed must be explicit non-empty (O7 — retrieval
+ *     routing is static).
+ *   - query_mode ∈ {'strict_truth', 'balanced_recency'}; the default
+ *     at caller level is strict_truth.
+ *   - balanced_recency is a diagnostic gate: Sprint 6 allows it only
+ *     when triggered_by.purpose === 'audit'. The full policy matrix
+ *     (conditions / whitelist) is deferred to P1-e.
+ *   - triggered_by.plan_id must reference a frozen, unexpired plan.
+ *
+ * The Loamwise retrieval engine consumes a validated request; a
+ * validator OK means "the shape is admissible" — not "retrieval
+ * succeeded".
+ */
+
+import type { MemoryPlanRegistry } from './plan_registry';
+import {
+  type MemoryRetrievalRequest,
+  type RetrievalValidateResult,
+} from './types';
+
+export function validateRetrievalRequest(
+  req: MemoryRetrievalRequest,
+  plans: MemoryPlanRegistry,
+): RetrievalValidateResult {
+  if (!req.tiers_allowed || req.tiers_allowed.length === 0) {
+    return { ok: false, code: 'TIERS_ALLOWED_EMPTY' };
+  }
+  if (!req.providers_allowed || req.providers_allowed.length === 0) {
+    return { ok: false, code: 'PROVIDERS_ALLOWED_EMPTY' };
+  }
+  if (req.query_mode !== 'strict_truth' && req.query_mode !== 'balanced_recency') {
+    return { ok: false, code: 'INVALID_QUERY_MODE', detail: String(req.query_mode) };
+  }
+  if (req.query_mode === 'balanced_recency' && req.triggered_by.purpose !== 'audit') {
+    return { ok: false, code: 'BALANCED_RECENCY_REQUIRES_AUDIT_PURPOSE' };
+  }
+
+  const plan = plans.lookup(req.triggered_by.plan_id);
+  if (!plan) return { ok: false, code: 'PLAN_NOT_FOUND', detail: req.triggered_by.plan_id };
+  if (!plan.frozen) return { ok: false, code: 'PLAN_NOT_FROZEN', detail: plan.plan_id };
+  if (plans.isExpired(plan.plan_id)) {
+    return { ok: false, code: 'PLAN_EXPIRED', detail: plan.expires_at };
+  }
+
+  return { ok: true };
+}
+
+/** Default for the caller's query_mode field — O2 truth-first. */
+export const DEFAULT_QUERY_MODE: 'strict_truth' = 'strict_truth';

--- a/src/runtime/governance/memory/snapshot.ts
+++ b/src/runtime/governance/memory/snapshot.ts
@@ -1,0 +1,40 @@
+/**
+ * BGHS Memory — FrozenSnapshot builder
+ * Location: src/runtime/governance/memory/snapshot.ts
+ *
+ * ADR-Hermes-Memory-Orchestration §6 + O5. Per-turn prefetch freezes
+ * the assembled fragments into a snapshot. Once built, the snapshot
+ * is IMMUTABLE — the same snapshot must be replayable verbatim later.
+ *
+ * Sprint 6 provides the snapshot shape and the builder; prefix-cache
+ * integration / prefetch orchestration live in Loamwise.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tierRank, type FrozenSnapshot, type RetrievalFragment } from './types';
+
+/**
+ * Build a FrozenSnapshot from assembled fragments. Fragments are sorted
+ * by tierRank asc (strict_truth ordering) then by rank_in_tier asc,
+ * deep-frozen, and returned as a readonly artifact.
+ */
+export function buildFrozenSnapshot(
+  plan_id: string,
+  fragments: readonly RetrievalFragment[],
+): FrozenSnapshot {
+  // Strict-truth ordering: authoritative(0) → decision-support(1) →
+  // context-only(2). Within a tier, preserve caller's rank_in_tier.
+  const sorted = [...fragments].sort((a, b) => {
+    const d = tierRank(a.record.tier) - tierRank(b.record.tier);
+    if (d !== 0) return d;
+    return a.rank_in_tier - b.rank_in_tier;
+  });
+  const snapshot: FrozenSnapshot = {
+    snapshot_id: randomUUID(),
+    plan_id,
+    fragments: Object.freeze(sorted) as ReadonlyArray<RetrievalFragment>,
+    frozen_at: new Date().toISOString(),
+  };
+  // Object.freeze the top-level record so every field is non-writable.
+  return Object.freeze(snapshot);
+}

--- a/src/runtime/governance/memory/types.ts
+++ b/src/runtime/governance/memory/types.ts
@@ -1,0 +1,325 @@
+/**
+ * BGHS Memory Orchestration — Types
+ * Location: src/runtime/governance/memory/types.ts
+ *
+ * Mirrors ADR-Hermes-Memory-Orchestration §1–§6. This tree is the
+ * **governance surface** for memory orchestration — NOT the retrieval
+ * engine, query orchestrator, or provider execution runtime. See
+ * README.md for the hard boundary against `src/runtime/memory/` and
+ * the Loamwise `align/` face.
+ *
+ * Sprint 6 Wave 6.1 lands:
+ *   - MemoryTier enum + rank ordering (O1, O2)
+ *   - MemoryRecord (§2) with derivation-rule enforcement (O3)
+ *   - MemoryAssemblyPlan (§4) with immutability-after-freeze (O5)
+ *   - MemoryRetrievalRequest (§3) — structural validation only
+ *   - MemoryUsePolicy (§5) validator (decision_consumers invariants)
+ *   - FrozenSnapshot (§6) immutable artifact
+ *
+ * Explicitly NOT in scope: retrieval execution, provider registration,
+ * LLM summarization, federated query routing (all deferred to
+ * Loamwise / P1-e). Sprint 6 Wave 6.2 wires Guard onto memory write
+ * and assembly fragment ingest only.
+ */
+
+// === §1 MemoryTier (decision authority) ===
+
+export enum MemoryTier {
+  AUTHORITATIVE = 'authoritative',
+  DECISION_SUPPORT = 'decision-support',
+  CONTEXT_ONLY = 'context-only',
+}
+
+/**
+ * Retrieval priority rank. Lower rank = higher priority (queried /
+ * surfaced first). `strict_truth` default: authoritative(0) →
+ * decision-support(1) → context-only(2).
+ */
+export function tierRank(t: MemoryTier): 0 | 1 | 2 {
+  switch (t) {
+    case MemoryTier.AUTHORITATIVE: return 0;
+    case MemoryTier.DECISION_SUPPORT: return 1;
+    case MemoryTier.CONTEXT_ONLY: return 2;
+  }
+}
+
+/**
+ * Derivation rule — source tier can only derive records at the same or
+ * lower tier (O3). AUTHORITATIVE cannot be created by summarization.
+ */
+export function canDeriveTo(source: MemoryTier, target: MemoryTier): boolean {
+  return tierRank(target) >= tierRank(source);
+}
+
+// === §2 MemoryRecord ===
+
+export type MemoryRecordSourceLayer = 0 | 1 | 2;
+
+export interface GuardEvidenceRef {
+  evidence_id: string;
+  guard_kind: string;                 // 'content-scan' | 'truth-write' | 'context-inject'
+  verdict: 'safe' | 'caution' | 'dangerous';
+}
+
+export interface MemoryRecordSource {
+  provider_id: string;
+  layer: MemoryRecordSourceLayer;     // Layer 3 may NOT write memory records
+  upstream_ref: string | null;        // record_id of parent if derived
+  trace_id: string;                   // session event link
+}
+
+export interface MemoryRecord {
+  record_id: string;
+  tier: MemoryTier;
+  content_kind: string;               // e.g., "contract.adr", "trace.event"
+  content_hash: string;               // sha256 hex (with or without "sha256:" prefix)
+
+  source: MemoryRecordSource;
+  created_at: string;                 // ISO 8601
+
+  guard_evidence: GuardEvidenceRef[]; // non-empty; all writes must have guard evidence
+  redaction_applied: boolean;
+
+  payload: unknown;                   // shape governed by content_kind sub-schema
+}
+
+// === §3 MemoryRetrievalRequest ===
+
+export type RetrievalPurpose = 'decision' | 'context' | 'audit';
+export type QueryMode = 'strict_truth' | 'balanced_recency';
+
+export interface StructuredQuery {
+  filters: Record<string, string | number | boolean>;
+}
+
+export interface MemoryRetrievalTriggeredBy {
+  component: string;
+  purpose: RetrievalPurpose;
+  plan_id: string;                    // must reference a registered plan (O7)
+}
+
+export interface MemoryRetrievalRequest {
+  request_id: string;
+  query: string | StructuredQuery;
+  tiers_allowed: MemoryTier[];        // must be explicit non-empty
+  providers_allowed: string[];        // must be explicit non-empty
+  query_mode: QueryMode;              // default 'strict_truth'; 'balanced_recency' gated
+  max_fragments_per_tier: Partial<Record<MemoryTier, number>>;
+  triggered_by: MemoryRetrievalTriggeredBy;
+}
+
+export interface RetrievalFragment {
+  record: MemoryRecord;
+  rank_in_tier: number;
+  match_evidence: string;
+}
+
+export interface RetrievalResult {
+  request_id: string;
+  fragments: RetrievalFragment[];     // sorted by tierRank asc, then rank_in_tier asc
+  truncated: boolean;
+  retrieved_at: string;
+}
+
+// === §4 MemoryAssemblyPlan ===
+
+export interface RetrievalSpec {
+  provider_id: string;
+  tiers: MemoryTier[];
+  query_template: string;
+  max_results: number;
+}
+
+export type AssemblyStepKind = 'system-prompt' | 'tool-context' | 'memory-fence';
+
+export interface AssemblyStep {
+  step: AssemblyStepKind;
+  fragments: string[];                // record_id refs
+  fence_boundary: string | null;      // O6 fencing
+}
+
+export interface MemoryWriteSpec {
+  target_tier: MemoryTier;
+  content_kind: string;
+  use_policy_id: string;              // must reference a registered MemoryUsePolicy
+}
+
+export interface MemoryAssemblyPlan {
+  plan_id: string;
+  intended_for: RetrievalPurpose;
+  retrieval_specs: RetrievalSpec[];
+  assembly_order: AssemblyStep[];
+  write_specs: MemoryWriteSpec[];
+  created_at: string;
+  expires_at: string;                 // ISO 8601; plan expires — new plan required
+  frozen: boolean;                    // flipped true on freeze; then immutable (O5)
+}
+
+// === §5 MemoryUsePolicy ===
+
+export type DecisionKindId = string;  // loose ref to P1-a DecisionKind (avoid cross-import)
+
+export type WriteActorKind =
+  | 'contract-adr'
+  | 'event-stream'
+  | 'engine-cosign'
+  | 'policy-engine'
+  | 'human-maintainer';
+
+export type GuardKindId = 'content-scan' | 'truth-write' | 'context-inject';
+
+export interface WriteActorRule {
+  actor_kind: WriteActorKind;
+  guard_chain_required: GuardKindId[];
+}
+
+export interface DerivationRule {
+  can_summarize_to: MemoryTier[];     // must satisfy tierRank(target) >= tierRank(self)
+  can_index_into: MemoryTier[];       // same constraint
+}
+
+export interface MemoryUsePolicy {
+  policy_id: string;
+  tier: MemoryTier;
+  read_allowed_for: RetrievalPurpose[];
+  write_allowed_by: WriteActorRule[];
+  /** See §5 validator — see use_policy_registry.ts. */
+  decision_consumers: DecisionKindId[];
+  derivation_rule: DerivationRule;
+  revocation_path: string;
+}
+
+// === §6 FrozenSnapshot ===
+
+export interface FrozenSnapshot {
+  snapshot_id: string;
+  plan_id: string;
+  fragments: ReadonlyArray<RetrievalFragment>;
+  frozen_at: string;
+}
+
+// === Failure codes ===
+
+export type UsePolicyFailureCode =
+  | 'MISSING_POLICY_ID'
+  | 'DUPLICATE_POLICY_ID'
+  | 'INVALID_TIER'
+  | 'AUTHORITATIVE_MUST_DECLARE_DECISION_CONSUMERS'
+  | 'NON_AUTH_MUST_HAVE_EMPTY_DECISION_CONSUMERS'
+  | 'DERIVATION_CANNOT_ELEVATE_TIER'
+  | 'WRITE_ACTOR_RULES_EMPTY';
+
+export type UsePolicyRegisterResult =
+  | { ok: true; policy_id: string }
+  | { ok: false; code: UsePolicyFailureCode; detail?: string };
+
+export type PlanFailureCode =
+  | 'DUPLICATE_PLAN_ID'
+  | 'PLAN_ALREADY_FROZEN_AT_REGISTER'
+  | 'PLAN_NOT_FOUND'
+  | 'PLAN_EXPIRED'
+  | 'PLAN_ALREADY_FROZEN'
+  | 'PLAN_FROZEN_IS_IMMUTABLE'
+  | 'UNKNOWN_USE_POLICY'
+  | 'ASSEMBLY_STEP_REFERENCES_UNKNOWN_FRAGMENT'
+  | 'WRITE_SPEC_TIER_MISMATCH';
+
+export type PlanRegisterResult =
+  | { ok: true; plan_id: string }
+  | { ok: false; code: PlanFailureCode; detail?: string };
+
+export type PlanFreezeResult =
+  | { ok: true; plan_id: string; frozen_at: string }
+  | { ok: false; code: PlanFailureCode; detail?: string };
+
+export type RecordFailureCode =
+  | 'INVALID_CONTENT_HASH'
+  | 'INVALID_SOURCE_LAYER'
+  | 'LAYER_3_CANNOT_WRITE_MEMORY'
+  | 'DUPLICATE_RECORD_ID'
+  | 'UNKNOWN_UPSTREAM_REF'
+  | 'DERIVATION_ELEVATES_TIER'
+  | 'MISSING_GUARD_EVIDENCE'
+  | 'MISSING_TRACE_ID'
+  | 'INVALID_TIER';
+
+export type RecordRegisterResult =
+  | { ok: true; record_id: string }
+  | { ok: false; code: RecordFailureCode; detail?: string };
+
+export type RetrievalFailureCode =
+  | 'TIERS_ALLOWED_EMPTY'
+  | 'PROVIDERS_ALLOWED_EMPTY'
+  | 'INVALID_QUERY_MODE'
+  | 'BALANCED_RECENCY_REQUIRES_AUDIT_PURPOSE'
+  | 'PLAN_NOT_FOUND'
+  | 'PLAN_EXPIRED'
+  | 'PLAN_NOT_FROZEN';
+
+export type RetrievalValidateResult =
+  | { ok: true }
+  | { ok: false; code: RetrievalFailureCode; detail?: string };
+
+// === Guard-wired seams (Wave 6.2) ===
+
+export type GuardedWriteFailureCode =
+  | RecordFailureCode
+  | 'UNKNOWN_USE_POLICY'
+  | 'POLICY_TIER_MISMATCH'
+  | 'DANGEROUS_VERDICT_BLOCKED_BY_POLICY';   // reserved — SHADOW does not block
+
+export interface MemoryWriteRequest {
+  record: Omit<MemoryRecord, 'guard_evidence'>;
+  use_policy_id: string;
+  /** Opaque payload for the guard scanner — e.g., serialized record body. */
+  scan_payload: unknown;
+  trace_id: string;
+}
+
+export type GuardedMemoryWriteResult =
+  | {
+      ok: true;
+      record_id: string;
+      guard_evidence_id: string;
+      guard_kind: GuardKindId;
+      guard_verdict: 'safe' | 'caution' | 'dangerous';
+      guard_mode: 'shadow';
+    }
+  | {
+      ok: false;
+      code: GuardedWriteFailureCode;
+      detail?: string;
+      guard_evidence_id?: string;
+      guard_verdict?: 'safe' | 'caution' | 'dangerous';
+    };
+
+export interface AssemblyFragmentIngestRequest {
+  fragment_id: string;
+  plan_id: string;
+  step: AssemblyStepKind;
+  record_ref: string;                 // the MemoryRecord the fragment is derived from
+  scan_payload: unknown;
+  trace_id: string;
+}
+
+export type FragmentIngestFailureCode =
+  | 'PLAN_NOT_FOUND'
+  | 'PLAN_NOT_FROZEN'
+  | 'PLAN_EXPIRED'
+  | 'UNKNOWN_RECORD_REF';
+
+export type GuardedFragmentIngestResult =
+  | {
+      ok: true;
+      fragment_id: string;
+      guard_evidence_id: string;
+      guard_verdict: 'safe' | 'caution' | 'dangerous';
+      guard_mode: 'shadow';
+    }
+  | {
+      ok: false;
+      code: FragmentIngestFailureCode;
+      detail?: string;
+      guard_evidence_id?: string;
+      guard_verdict?: 'safe' | 'caution' | 'dangerous';
+    };

--- a/src/runtime/governance/memory/use_policy_registry.ts
+++ b/src/runtime/governance/memory/use_policy_registry.ts
@@ -1,0 +1,86 @@
+/**
+ * BGHS Memory — MemoryUsePolicy registry + validator
+ * Location: src/runtime/governance/memory/use_policy_registry.ts
+ *
+ * ADR-Hermes-Memory-Orchestration §5 validator. Enforces the twin
+ * invariants that shape decision authority in the memory tree:
+ *
+ *   - AUTHORITATIVE tier → `decision_consumers` MUST be non-empty
+ *     (authoritative memory exists specifically to drive decisions).
+ *   - Non-AUTHORITATIVE tiers → `decision_consumers` MUST be empty
+ *     (decision-support / context-only may NEVER drive decisions
+ *     directly — they are inputs, not authorities).
+ *
+ * Also enforces O3: derivation rules may not elevate tier —
+ * `can_summarize_to` and `can_index_into` must only contain tiers
+ * with rank ≥ the source tier's rank.
+ */
+
+import {
+  MemoryTier,
+  tierRank,
+  type MemoryUsePolicy,
+  type UsePolicyRegisterResult,
+} from './types';
+
+const VALID_TIERS = new Set<MemoryTier>([
+  MemoryTier.AUTHORITATIVE,
+  MemoryTier.DECISION_SUPPORT,
+  MemoryTier.CONTEXT_ONLY,
+]);
+
+export class MemoryUsePolicyRegistry {
+  private policies: Map<string, MemoryUsePolicy> = new Map();
+
+  register(p: MemoryUsePolicy): UsePolicyRegisterResult {
+    if (!p.policy_id) {
+      return { ok: false, code: 'MISSING_POLICY_ID' };
+    }
+    if (this.policies.has(p.policy_id)) {
+      return { ok: false, code: 'DUPLICATE_POLICY_ID', detail: p.policy_id };
+    }
+    if (!VALID_TIERS.has(p.tier)) {
+      return { ok: false, code: 'INVALID_TIER', detail: p.tier };
+    }
+    // §5 twin invariants
+    if (p.tier === MemoryTier.AUTHORITATIVE) {
+      if (!p.decision_consumers || p.decision_consumers.length === 0) {
+        return { ok: false, code: 'AUTHORITATIVE_MUST_DECLARE_DECISION_CONSUMERS' };
+      }
+    } else {
+      if (p.decision_consumers && p.decision_consumers.length > 0) {
+        return { ok: false, code: 'NON_AUTH_MUST_HAVE_EMPTY_DECISION_CONSUMERS', detail: p.tier };
+      }
+    }
+    // O3: derivation rules cannot elevate tier
+    const elevates = [
+      ...(p.derivation_rule?.can_summarize_to ?? []),
+      ...(p.derivation_rule?.can_index_into ?? []),
+    ].some((t) => tierRank(t) < tierRank(p.tier));
+    if (elevates) {
+      return { ok: false, code: 'DERIVATION_CANNOT_ELEVATE_TIER' };
+    }
+    if (!p.write_allowed_by || p.write_allowed_by.length === 0) {
+      return { ok: false, code: 'WRITE_ACTOR_RULES_EMPTY' };
+    }
+
+    this.policies.set(p.policy_id, p);
+    return { ok: true, policy_id: p.policy_id };
+  }
+
+  has(policy_id: string): boolean {
+    return this.policies.has(policy_id);
+  }
+
+  lookup(policy_id: string): MemoryUsePolicy | null {
+    return this.policies.get(policy_id) ?? null;
+  }
+
+  size(): number {
+    return this.policies.size;
+  }
+
+  _clearForTests(): void {
+    this.policies.clear();
+  }
+}

--- a/src/runtime/governance/skill_lifecycle/README.md
+++ b/src/runtime/governance/skill_lifecycle/README.md
@@ -1,0 +1,90 @@
+# BGHS Skill Lifecycle — Boundary Notes
+
+**Location**: `src/runtime/governance/skill_lifecycle/`
+**ADR**: `_meta/adr/ADR-Hermes-Skill-Lifecycle.md` (P1-b)
+**Sprint**: 5
+
+## One-line boundary
+
+> `src/skill/`                                  = **skill execution face**
+> `src/runtime/governance/skill_lifecycle/`      = **BGHS skill lifecycle state machine**
+> The two are **not** interchangeable and **must not** cross-import.
+
+## Why the split exists
+
+"Skill" in LiYe Systems straddles two very different concerns, and
+conflating them is exactly the Hermes shortcut ADR-Hermes-Skill-Lifecycle
+§R1 rejects ("scan pass ≠ trust").
+
+| Aspect | `src/skill/` | `src/runtime/governance/skill_lifecycle/` |
+|---|---|---|
+| What "skill" means | An executable artifact: loader, atomic / composite unit, registry entry the dispatcher can invoke | A governance record: state machine entry that tracks a candidate's journey through quarantine, promotion decisions, and revocation |
+| Primary interface | loader + atomic/composite runtime (pre-existing) | `SkillLifecycleRegistry` + `TransitionLog` + guard-wired `guardedSubmitCandidate` |
+| Who touches state | Dispatcher, skill runtime | PromotionDecision / QuarantineDecision drivers + lifecycle log writes |
+| Data model | Skill manifest, loader outputs, execution inputs | `SkillCandidateRecord`, `LifecycleTransition`, `PromotionDecision`, `QuarantineDecision` |
+| Failure mode | Runtime error on load / invoke | Admission rejected (`MISSING_PROVENANCE`, `UNKNOWN_CAPABILITY_KIND`, `ILLEGAL_TRANSITION`, `SCAN_EVIDENCE_NOT_SAFE`, …) |
+| Consumed by | Dispatcher / agent runtime | Loamwise `construct/` promotion scheduler, Guard wiring, operator audit UIs |
+
+## Hard rule — no cross-import
+
+- `src/runtime/governance/skill_lifecycle/` **MUST NOT** import from `src/skill/`.
+- `src/skill/` **MUST NOT** import from `src/runtime/governance/skill_lifecycle/`.
+
+The lifecycle registry is the **governance state** for a skill's journey
+— it does not load, validate, or execute skill code. The execution face
+is the **runtime behavior** for an already-promoted skill — it does not
+produce or consume lifecycle state.
+
+If future work needs to bridge the two (e.g., "the dispatcher should
+refuse to load anything not currently in `ACTIVE`"), that bridge lives
+in a **third** module whose purpose is to translate between lifecycle
+state and dispatcher admission — not in either tree.
+
+CI enforcement for this rule lives alongside the Sprint-4 capability
+boundary gate in `.github/workflows/layer-dependency-gate.yml`; extend
+that file when violations appear rather than carving exceptions.
+
+## Sprint 5 scope
+
+### Wave 5.1 — Lifecycle governance surface
+
+- `SkillLifecycleState` enum and `ALLOWED_TRANSITIONS` whitelist.
+- `TransitionLog` with append-only hash chain (per-candidate chain of
+  `entry_hash = sha256(prev_transition_id || canonical(payload))`).
+- `SkillLifecycleRegistry` that enforces L1–L7 structural discipline:
+  L1 controlled transitions + append-only, L2 initial state = CANDIDATE,
+  L3 approver + signature required, L4 scan evidence must contain
+  `'safe'` for promotion-class transitions, L6 provenance fields
+  mandatory, L7 `capability_kind` must be in the BGHS
+  `CapabilityKindRegistry`.
+- `PromotionDecision` / `QuarantineDecision` treated as co-equal
+  drivers (L1) — any `LifecycleTransition` must carry one.
+
+### Wave 5.2 — Guard wired to skill candidate submit
+
+- `guardedSubmitCandidate(record, opts)` runs the Sprint-3
+  `ShadowRunner` against the candidate payload, writes `GuardEvidence`
+  to the sink, appends the resulting reference to `record.scan_results`,
+  and then calls `SkillLifecycleRegistry.submitCandidate`.
+- SHADOW mode only. The runner records but never blocks; registry
+  acceptance is authoritative.
+- Only this single real path is wired: **skill candidate submit**. No
+  hook on skill install / enable / promote / invoke.
+
+## What this sprint does NOT do
+
+- It does **not** enforce policy-specific thresholds (required approver
+  counts per TrustSource, grace-period seconds). §3 of the ADR calls
+  those NON-NORMATIVE; a later policy ADR will put them in schema.
+- It does **not** persist the lifecycle log — the in-memory
+  `TransitionLog` is authoritative for Sprint 5, and the persistent
+  session-adjacent storage lands with Sprint 6 / P1-e integration.
+- It does **not** implement the Loamwise quarantine scheduler, the
+  review UI, or the dispatcher admission check. Those are Layer 1
+  responsibilities.
+- It does **not** wire Guard into memory write, assembly fragment
+  ingest, promotion, or any other protected path beyond
+  `skill.candidate-submit`. Those wirings land in Sprint 6.2 and later.
+- It does **not** touch `src/skill/`. If you find yourself about to
+  add an import across the boundary, stop and write a bridging module
+  proposal in `_meta/adr/` first.

--- a/src/runtime/governance/skill_lifecycle/candidate_submit.ts
+++ b/src/runtime/governance/skill_lifecycle/candidate_submit.ts
@@ -1,0 +1,113 @@
+/**
+ * BGHS Skill Lifecycle — Guard-wired candidate submit (Sprint 5 Wave 5.2)
+ * Location: src/runtime/governance/skill_lifecycle/candidate_submit.ts
+ *
+ * This is the deferred wiring from Sprint 3: the ShadowRunner is
+ * connected to exactly one real governance path — skill candidate
+ * submit (ProtectedPathKind.SKILL_CANDIDATE_SUBMIT).
+ *
+ * Scope discipline (Sprint 5 exit gates):
+ *   - SHADOW ONLY. The runner never blocks; we record evidence and
+ *     forward to SkillLifecycleRegistry.submitCandidate.
+ *   - Does NOT wire skill promotion, install, enable, or invoke.
+ *     Those remain SHADOW-less / unwired until later sprints.
+ *   - Does NOT short-circuit lifecycle admission on scanner failure:
+ *     the lifecycle registry is authoritative; the guard is observer.
+ *   - Produces a ScanResultRef from the evidence so the same record
+ *     persisted in SkillCandidateRecord.scan_results points back at
+ *     the GuardEvidence sink entry.
+ */
+
+import { GuardKind, type GuardEvidenceSink, type ScannedPath } from '../guard';
+import type { ShadowRunner } from '../guard/shadow_runner';
+import type { SkillLifecycleRegistry } from './registry';
+import type {
+  GuardedSubmitResult,
+  ScanResultRef,
+  SkillCandidateRecord,
+  ScanVerdictLiteral,
+} from './types';
+import { GuardVerdict } from '../guard';
+
+export interface GuardedSubmitOptions {
+  runner: ShadowRunner;
+  sink: GuardEvidenceSink;
+  registry: SkillLifecycleRegistry;
+  /** Trace id to tie evidence back to the session event stream. */
+  trace_id: string;
+  /** Opaque payload handed to the scanner (skill body + frontmatter). */
+  payload: unknown;
+  /** Scanner metadata — used to build the ScanResultRef. */
+  scanner_id: string;
+}
+
+function verdictToLiteral(v: GuardVerdict): ScanVerdictLiteral {
+  switch (v) {
+    case GuardVerdict.SAFE: return 'safe';
+    case GuardVerdict.CAUTION: return 'caution';
+    case GuardVerdict.DANGEROUS: return 'dangerous';
+  }
+}
+
+/**
+ * Run SHADOW guard → append evidence → submit candidate.
+ * SHADOW never blocks, so registry rejection is the only terminal
+ * failure path. The returned object always includes the guard evidence
+ * id so the caller can reconcile with the evidence sink.
+ */
+export async function guardedSubmitCandidate(
+  record: SkillCandidateRecord,
+  opts: GuardedSubmitOptions,
+): Promise<GuardedSubmitResult> {
+  const scanned_path: ScannedPath = {
+    path_kind: 'skill-candidate',
+    target_ref: record.candidate_id,
+  };
+
+  const out = await opts.runner.run({
+    guard_id: `skill-candidate-submit:${opts.scanner_id}`,
+    guard_kind: GuardKind.CONTENT_SCAN,
+    scanner_version: '',                   // scanner fills in
+    pattern_catalog_version: '',
+    trace_id: opts.trace_id,
+    scanned_path,
+    payload: opts.payload,
+  });
+
+  const verdictLiteral = verdictToLiteral(out.verdict);
+
+  // Attach the guard evidence as a ScanResultRef — the lifecycle record
+  // may arrive with or without prior scan_results; the Guard seam always
+  // contributes one. SHADOW evidence is non-authoritative for L4; §8
+  // allows subsequent PromotionDecisions to supply 'safe' evidence.
+  const ref: ScanResultRef = {
+    scanner_id: opts.scanner_id,
+    scanned_at: new Date().toISOString(),
+    verdict: verdictLiteral,
+    evidence_path: out.evidence_id,
+  };
+
+  const next: SkillCandidateRecord = {
+    ...record,
+    scan_results: [...record.scan_results, ref],
+  };
+
+  const submit = opts.registry.submitCandidate(next);
+  if (!submit.ok) {
+    return {
+      ok: false,
+      code: submit.code,
+      detail: submit.detail,
+      guard_evidence_id: out.evidence_id,
+      guard_verdict: verdictLiteral,
+    };
+  }
+
+  return {
+    ok: true,
+    candidate_id: submit.candidate_id,
+    guard_evidence_id: out.evidence_id,
+    guard_verdict: verdictLiteral,
+    guard_mode: 'shadow',
+  };
+}

--- a/src/runtime/governance/skill_lifecycle/index.ts
+++ b/src/runtime/governance/skill_lifecycle/index.ts
@@ -1,0 +1,45 @@
+/**
+ * BGHS Skill Lifecycle — barrel
+ * Location: src/runtime/governance/skill_lifecycle/index.ts
+ *
+ * See README.md in this directory for the hard boundary against
+ * `src/skill/` (the skill execution face). Cross-imports between the
+ * two trees are forbidden — this tree is governance state only.
+ */
+
+export {
+  SkillLifecycleState,
+  ALLOWED_TRANSITIONS,
+  TrustSource,
+  QuarantineReason,
+} from './types';
+
+export type {
+  ScanVerdictLiteral,
+  ScanResultRef,
+  GeneratedBy,
+  GeneratedByLayer,
+  SkillCandidateRecord,
+  ApproverKind,
+  ApproverEvidence,
+  PolicyEvalResult,
+  RollbackPolicy,
+  DecidedBy,
+  DecidedByActorKind,
+  PromotionDecision,
+  QuarantineDecision,
+  LifecycleDriver,
+  LifecycleTransition,
+  SubmitFailureCode,
+  TransitionFailureCode,
+  SubmitResult,
+  TransitionResult,
+  GuardedSubmitResult,
+  CandidateSubmitFailureCode,
+} from './types';
+
+export { TransitionLog, canonicalJson, type AppendTransitionInput } from './transition_log';
+
+export { SkillLifecycleRegistry } from './registry';
+
+export { guardedSubmitCandidate, type GuardedSubmitOptions } from './candidate_submit';

--- a/src/runtime/governance/skill_lifecycle/registry.ts
+++ b/src/runtime/governance/skill_lifecycle/registry.ts
@@ -1,0 +1,217 @@
+/**
+ * BGHS Skill Lifecycle — SkillLifecycleRegistry
+ * Location: src/runtime/governance/skill_lifecycle/registry.ts
+ *
+ * ADR-Hermes-Skill-Lifecycle §8. State machine wrapper around
+ * TransitionLog. Enforces L1–L7:
+ *
+ *   L1  Controlled transitions + append-only (no bypass, no in-place
+ *       mutation). Every transition is driven by a PromotionDecision
+ *       or QuarantineDecision — no "update this state field" API.
+ *   L2  Initial state must be CANDIDATE. DRAFT is a pre-registration
+ *       editor state and is never accepted into the lifecycle log.
+ *   L3  approvers ≥ 1 and signature non-empty (scan_pass ≠ trust;
+ *       promotion requires explicit approver evidence).
+ *   L4  scan_evidence must contain at least one 'safe' verdict for
+ *       promotion-class transitions. Any 'dangerous' = reject.
+ *   L6  Provenance fields (source_trace_id / generated_by /
+ *       content_hash) are mandatory at submit.
+ *   L7  generated_by.layer ∈ {1,2}. capability_kind must be registered
+ *       in the BGHS CapabilityKindRegistry.
+ *
+ * Note: policy-specific values (required approver counts, grace-period
+ * seconds per TrustSource) are NOT enforced here. §3 calls those values
+ * illustrative / NON-NORMATIVE and defers them to a later policy ADR.
+ * This registry enforces the structural discipline only.
+ */
+
+import type { CapabilityKindRegistry } from '../capability/kind_registry';
+import { TransitionLog } from './transition_log';
+import {
+  ALLOWED_TRANSITIONS,
+  SkillLifecycleState,
+  type PromotionDecision,
+  type QuarantineDecision,
+  type SkillCandidateRecord,
+  type SubmitResult,
+  type TransitionResult,
+} from './types';
+
+const CANDIDATE_ID_RE = /^[a-z0-9][a-z0-9-]*(?::[a-z0-9][a-z0-9-]*)*$/i;
+const CONTENT_HASH_RE = /^sha256:[a-f0-9]{64}$|^[a-f0-9]{64}$/i;
+
+interface CandidateEntry {
+  record: SkillCandidateRecord;
+  /** Current state — advanced by applyPromotion / applyQuarantine. */
+  current_state: SkillLifecycleState;
+  /**
+   * Earliest moment (ISO 8601) at which a QUARANTINED → CANDIDATE
+   * re-admission may be attempted. Set by QuarantineDecision; null = no
+   * timed block (but still needs a new PromotionDecision to exit).
+   */
+  release_blocked_until: string | null;
+}
+
+export class SkillLifecycleRegistry {
+  private candidates: Map<string, CandidateEntry> = new Map();
+  private readonly log: TransitionLog;
+
+  constructor(
+    private readonly kinds: CapabilityKindRegistry,
+    log?: TransitionLog,
+  ) {
+    this.log = log ?? new TransitionLog();
+  }
+
+  /** Expose the underlying log for auditing; not for mutation. */
+  transitions(): TransitionLog {
+    return this.log;
+  }
+
+  submitCandidate(rec: SkillCandidateRecord): SubmitResult {
+    if (!CANDIDATE_ID_RE.test(rec.candidate_id)) {
+      return { ok: false, code: 'INVALID_CANDIDATE_ID_FORMAT', detail: rec.candidate_id };
+    }
+    if (this.candidates.has(rec.candidate_id)) {
+      return { ok: false, code: 'DUPLICATE_CANDIDATE_ID', detail: rec.candidate_id };
+    }
+    // L2 — initial state is CANDIDATE (DRAFT is not persisted)
+    if (rec.state !== SkillLifecycleState.CANDIDATE) {
+      return { ok: false, code: 'INITIAL_STATE_MUST_BE_CANDIDATE', detail: rec.state };
+    }
+    // L6 — provenance
+    if (!rec.source_trace_id || !rec.generated_by?.component || !rec.content_hash) {
+      return { ok: false, code: 'MISSING_PROVENANCE' };
+    }
+    if (!CONTENT_HASH_RE.test(rec.content_hash)) {
+      return { ok: false, code: 'INVALID_CONTENT_HASH', detail: rec.content_hash };
+    }
+    // L7 — Layer 0 may not produce candidates
+    if ((rec.generated_by.layer as number) === 0) {
+      return { ok: false, code: 'LAYER_0_CANNOT_PRODUCE_CANDIDATE' };
+    }
+    if (![1, 2].includes(rec.generated_by.layer)) {
+      return { ok: false, code: 'LAYER_0_CANNOT_PRODUCE_CANDIDATE', detail: String(rec.generated_by.layer) };
+    }
+    // L7 + P1-a B1 — capability_kind must be known
+    if (!this.kinds.has(rec.capability_kind)) {
+      return { ok: false, code: 'UNKNOWN_CAPABILITY_KIND', detail: rec.capability_kind };
+    }
+
+    this.candidates.set(rec.candidate_id, {
+      record: rec,
+      current_state: SkillLifecycleState.CANDIDATE,
+      release_blocked_until: null,
+    });
+    return { ok: true, candidate_id: rec.candidate_id };
+  }
+
+  applyPromotion(decision: PromotionDecision): TransitionResult {
+    const entry = this.candidates.get(decision.candidate_id);
+    if (!entry) return { ok: false, code: 'CANDIDATE_NOT_FOUND', detail: decision.candidate_id };
+
+    if (entry.current_state !== decision.from_state) {
+      return { ok: false, code: 'FROM_STATE_MISMATCH', detail: `${entry.current_state} vs ${decision.from_state}` };
+    }
+    if (entry.current_state === SkillLifecycleState.REVOKED) {
+      return { ok: false, code: 'REVOKED_IS_TERMINAL' };
+    }
+    // L1 — whitelist check
+    const allowed = ALLOWED_TRANSITIONS[decision.from_state];
+    if (!allowed.includes(decision.to_state)) {
+      return { ok: false, code: 'ILLEGAL_TRANSITION', detail: `${decision.from_state} → ${decision.to_state}` };
+    }
+    // QUARANTINED → CANDIDATE re-admission respects release_blocked_until
+    if (
+      decision.from_state === SkillLifecycleState.QUARANTINED
+      && decision.to_state === SkillLifecycleState.CANDIDATE
+      && entry.release_blocked_until
+      && new Date().toISOString() < entry.release_blocked_until
+    ) {
+      return { ok: false, code: 'QUARANTINE_RELEASE_BLOCKED', detail: entry.release_blocked_until };
+    }
+    // L3 — approvers + signature
+    if (!decision.approvers || decision.approvers.length === 0) {
+      return { ok: false, code: 'MISSING_APPROVERS' };
+    }
+    if (!decision.decided_by?.signature) {
+      return { ok: false, code: 'MISSING_SIGNATURE' };
+    }
+    // L4 — scan evidence must include 'safe' when transitioning to ACTIVE or
+    // re-admitting to CANDIDATE. DEPRECATED / graceful wind-down transitions
+    // are promotion-class too but have their own checkpoint later; Sprint 5
+    // enforces safe-evidence on any promotion path that lands in ACTIVE or
+    // re-admission CANDIDATE.
+    const needsSafeScan =
+      decision.to_state === SkillLifecycleState.ACTIVE
+      || decision.to_state === SkillLifecycleState.CANDIDATE;
+    if (needsSafeScan) {
+      if (!decision.scan_evidence || decision.scan_evidence.length === 0) {
+        return { ok: false, code: 'MISSING_SCAN_EVIDENCE' };
+      }
+      const hasSafe = decision.scan_evidence.some((s) => s.verdict === 'safe');
+      if (!hasSafe) return { ok: false, code: 'SCAN_EVIDENCE_NOT_SAFE' };
+    }
+
+    const t = this.log.append({
+      candidate_id: decision.candidate_id,
+      from_state: decision.from_state,
+      to_state: decision.to_state,
+      driver: { kind: 'promotion', decision },
+    });
+    entry.current_state = decision.to_state;
+    if (decision.to_state === SkillLifecycleState.CANDIDATE) {
+      // Re-admission — clear the block.
+      entry.release_blocked_until = null;
+    }
+    return { ok: true, transition_id: t.transition_id, to_state: decision.to_state };
+  }
+
+  applyQuarantine(decision: QuarantineDecision): TransitionResult {
+    const entry = this.candidates.get(decision.candidate_id);
+    if (!entry) return { ok: false, code: 'CANDIDATE_NOT_FOUND', detail: decision.candidate_id };
+
+    if (entry.current_state !== decision.from_state) {
+      return { ok: false, code: 'FROM_STATE_MISMATCH', detail: `${entry.current_state} vs ${decision.from_state}` };
+    }
+    if (entry.current_state === SkillLifecycleState.REVOKED) {
+      return { ok: false, code: 'REVOKED_IS_TERMINAL' };
+    }
+    const allowed = ALLOWED_TRANSITIONS[decision.from_state];
+    if (!allowed.includes(decision.to_state)) {
+      return { ok: false, code: 'ILLEGAL_TRANSITION', detail: `${decision.from_state} → ${decision.to_state}` };
+    }
+    if (!decision.decided_by?.signature) {
+      return { ok: false, code: 'MISSING_SIGNATURE' };
+    }
+
+    const t = this.log.append({
+      candidate_id: decision.candidate_id,
+      from_state: decision.from_state,
+      to_state: decision.to_state,
+      driver: { kind: 'quarantine', decision },
+    });
+    entry.current_state = decision.to_state;
+    if (decision.to_state === SkillLifecycleState.QUARANTINED) {
+      entry.release_blocked_until = decision.release_blocked_until;
+    }
+    return { ok: true, transition_id: t.transition_id, to_state: decision.to_state };
+  }
+
+  getState(candidate_id: string): SkillLifecycleState | null {
+    return this.candidates.get(candidate_id)?.current_state ?? null;
+  }
+
+  lookup(candidate_id: string): SkillCandidateRecord | null {
+    return this.candidates.get(candidate_id)?.record ?? null;
+  }
+
+  size(): number {
+    return this.candidates.size;
+  }
+
+  _clearForTests(): void {
+    this.candidates.clear();
+    this.log._clearForTests();
+  }
+}

--- a/src/runtime/governance/skill_lifecycle/transition_log.ts
+++ b/src/runtime/governance/skill_lifecycle/transition_log.ts
@@ -1,0 +1,147 @@
+/**
+ * BGHS Skill Lifecycle — append-only TransitionLog with hash chain
+ * Location: src/runtime/governance/skill_lifecycle/transition_log.ts
+ *
+ * ADR-Hermes-Skill-Lifecycle §6 + L1. Every LifecycleTransition carries
+ * entry_hash = sha256(prev_transition_id || canonical_payload). Existing
+ * entries cannot be mutated or removed (L1); the class exposes no such
+ * operation. A `_clearForTests()` escape hatch exists for unit tests
+ * only — production call sites must not touch it.
+ *
+ * Storage location for the persisted form (per-candidate file / per-
+ * session-adjacent shard) is decided by the P1-e Session-adjacent
+ * taxonomy and lands with a later sprint. Sprint 5 ships the in-memory
+ * append-only log with hash chain; the same entry shape will be the
+ * serialized form.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { sha256Hex } from '../../../audit/evidence/hash';
+import type {
+  LifecycleDriver,
+  LifecycleTransition,
+  SkillLifecycleState,
+} from './types';
+
+export interface AppendTransitionInput {
+  candidate_id: string;
+  from_state: SkillLifecycleState;
+  to_state: SkillLifecycleState;
+  driver: LifecycleDriver;
+}
+
+/**
+ * Canonical JSON stringify — sort keys so the hash is stable regardless
+ * of input object key order. Handles nested objects and arrays; Date
+ * objects are expected to be pre-stringified by callers (ISO 8601).
+ */
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(',')}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  const parts = keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(obj[k])}`);
+  return `{${parts.join(',')}}`;
+}
+
+export class TransitionLog {
+  /** Per-candidate chain tip (last transition id). */
+  private tips: Map<string, string> = new Map();
+  /** Per-candidate ordered entries. */
+  private perCandidate: Map<string, LifecycleTransition[]> = new Map();
+  /** Global append order for audit / replay. */
+  private all: LifecycleTransition[] = [];
+
+  append(input: AppendTransitionInput): LifecycleTransition {
+    const prev = this.tips.get(input.candidate_id) ?? null;
+    const transitioned_at = new Date().toISOString();
+    const transition_id = randomUUID();
+
+    const payload = {
+      transition_id,
+      candidate_id: input.candidate_id,
+      from_state: input.from_state,
+      to_state: input.to_state,
+      transitioned_at,
+      driver_kind: input.driver.kind,
+      driver_decision_id: input.driver.decision.decision_id,
+    };
+    const canonical = canonicalJson(payload);
+    const entry_hash = sha256Hex((prev ?? '') + '|' + canonical);
+
+    const entry: LifecycleTransition = {
+      transition_id,
+      candidate_id: input.candidate_id,
+      from_state: input.from_state,
+      to_state: input.to_state,
+      transitioned_at,
+      driver: input.driver,
+      prev_transition_id: prev,
+      entry_hash,
+    };
+
+    let list = this.perCandidate.get(input.candidate_id);
+    if (!list) {
+      list = [];
+      this.perCandidate.set(input.candidate_id, list);
+    }
+    list.push(entry);
+    this.all.push(entry);
+    this.tips.set(input.candidate_id, transition_id);
+
+    return entry;
+  }
+
+  getChain(candidate_id: string): readonly LifecycleTransition[] {
+    return this.perCandidate.get(candidate_id) ?? [];
+  }
+
+  tip(candidate_id: string): string | null {
+    return this.tips.get(candidate_id) ?? null;
+  }
+
+  list(): readonly LifecycleTransition[] {
+    return this.all;
+  }
+
+  /**
+   * Recompute every entry_hash in order and compare against the stored
+   * value. Any mismatch or out-of-order prev_transition_id returns the
+   * offending index. Used by tests and replay audits.
+   */
+  verifyChain(candidate_id: string): { ok: true } | { ok: false; at: number; reason: string } {
+    const chain = this.perCandidate.get(candidate_id) ?? [];
+    let prev: string | null = null;
+    for (let i = 0; i < chain.length; i++) {
+      const e = chain[i];
+      if (e.prev_transition_id !== prev) {
+        return { ok: false, at: i, reason: 'prev_transition_id mismatch' };
+      }
+      const payload = {
+        transition_id: e.transition_id,
+        candidate_id: e.candidate_id,
+        from_state: e.from_state,
+        to_state: e.to_state,
+        transitioned_at: e.transitioned_at,
+        driver_kind: e.driver.kind,
+        driver_decision_id: e.driver.decision.decision_id,
+      };
+      const expected = sha256Hex((prev ?? '') + '|' + canonicalJson(payload));
+      if (expected !== e.entry_hash) {
+        return { ok: false, at: i, reason: 'entry_hash mismatch' };
+      }
+      prev = e.transition_id;
+    }
+    return { ok: true };
+  }
+
+  _clearForTests(): void {
+    this.tips.clear();
+    this.perCandidate.clear();
+    this.all = [];
+  }
+}

--- a/src/runtime/governance/skill_lifecycle/types.ts
+++ b/src/runtime/governance/skill_lifecycle/types.ts
@@ -3,10 +3,10 @@
  * Location: src/runtime/governance/skill_lifecycle/types.ts
  *
  * Mirrors ADR-Hermes-Skill-Lifecycle §1–§8. This tree is the **governance
- * state machine** for skill candidates — it is NOT the skill execution
- * face (`src/skill/`). See README.md in this directory for the hard
- * boundary rule: skill_lifecycle never imports from src/skill/, and
- * src/skill/ never imports from here.
+ * state machine** for skill candidates — it is NOT the execution face.
+ * See README.md in this directory for the hard boundary rule (the two
+ * sibling trees never reach into each other across the layer 0 / layer 2
+ * line).
  *
  * Sprint 5 Wave 5.1 lands the declarative surface, the transition log,
  * and the registry. Actual dispatcher behavior (Loamwise promotion

--- a/src/runtime/governance/skill_lifecycle/types.ts
+++ b/src/runtime/governance/skill_lifecycle/types.ts
@@ -1,0 +1,254 @@
+/**
+ * BGHS Skill Lifecycle — Types
+ * Location: src/runtime/governance/skill_lifecycle/types.ts
+ *
+ * Mirrors ADR-Hermes-Skill-Lifecycle §1–§8. This tree is the **governance
+ * state machine** for skill candidates — it is NOT the skill execution
+ * face (`src/skill/`). See README.md in this directory for the hard
+ * boundary rule: skill_lifecycle never imports from src/skill/, and
+ * src/skill/ never imports from here.
+ *
+ * Sprint 5 Wave 5.1 lands the declarative surface, the transition log,
+ * and the registry. Actual dispatcher behavior (Loamwise promotion
+ * scheduler, quarantine watchers) lives in Layer 1 and is out of scope.
+ */
+
+// === §1 SkillLifecycleState ===
+
+export enum SkillLifecycleState {
+  DRAFT = 'draft',
+  CANDIDATE = 'candidate',
+  QUARANTINED = 'quarantined',
+  ACTIVE = 'active',
+  DEPRECATED = 'deprecated',
+  REVOKED = 'revoked',
+}
+
+/**
+ * Controlled transition whitelist. Any transition not listed here is
+ * rejected at registry level (L1 — no bypass).
+ */
+export const ALLOWED_TRANSITIONS: Readonly<Record<SkillLifecycleState, readonly SkillLifecycleState[]>> = {
+  [SkillLifecycleState.DRAFT]: [SkillLifecycleState.CANDIDATE],
+  [SkillLifecycleState.CANDIDATE]: [
+    SkillLifecycleState.ACTIVE,
+    SkillLifecycleState.QUARANTINED,
+    SkillLifecycleState.REVOKED,
+  ],
+  [SkillLifecycleState.QUARANTINED]: [
+    SkillLifecycleState.CANDIDATE,
+    SkillLifecycleState.REVOKED,
+  ],
+  [SkillLifecycleState.ACTIVE]: [
+    SkillLifecycleState.DEPRECATED,
+    SkillLifecycleState.QUARANTINED,
+  ],
+  [SkillLifecycleState.DEPRECATED]: [SkillLifecycleState.REVOKED],
+  [SkillLifecycleState.REVOKED]: [],
+};
+
+// === §3 TrustSource ===
+
+export enum TrustSource {
+  INTERNAL_VETTED = 'internal-vetted',
+  ENGINE_PUBLISHED = 'engine-published',
+  AGENT_GENERATED = 'agent-generated',
+  EXTERNAL = 'external',
+}
+
+// === Scan reference (points at GuardEvidence) ===
+
+export type ScanVerdictLiteral = 'safe' | 'caution' | 'dangerous';
+
+export interface ScanResultRef {
+  scanner_id: string;
+  scanned_at: string;
+  verdict: ScanVerdictLiteral;
+  evidence_path: string;    // references GuardEvidence.evidence_id or an external ref
+}
+
+// === §2 SkillCandidateRecord ===
+
+export type GeneratedByLayer = 1 | 2;
+
+export interface GeneratedBy {
+  component: string;                // e.g., "loamwise:construct.learning-loop"
+  layer: GeneratedByLayer;          // Layer 0 may NOT produce candidates (L7)
+}
+
+export interface SkillCandidateRecord {
+  candidate_id: string;
+  skill_id: string;                 // e.g., "amazon-growth-engine:bid_recommend"
+  version: string;                  // SemVer
+  content_hash: string;             // sha256 hex of body + frontmatter
+
+  source_trace_id: string;
+  source_kind: TrustSource;
+  generated_by: GeneratedBy;
+  created_at: string;               // ISO 8601
+  expires_at: string | null;        // CANDIDATE grace deadline; null = no expiry policy
+
+  risk_class: 'low' | 'medium' | 'high' | 'unknown';
+  scan_results: ScanResultRef[];
+
+  /** Must be the submission state — CANDIDATE only (L2). */
+  state: SkillLifecycleState;
+  state_changed_at: string;
+
+  /** Must reference a kind registered in the BGHS CapabilityKindRegistry. */
+  capability_kind: string;
+  /** Filled in only after ACTIVE; null at submission. */
+  capability_registration_id: string | null;
+}
+
+// === §4 PromotionDecision + support types ===
+
+export type ApproverKind = 'human-maintainer' | 'engine-cosign' | 'policy-rule';
+
+export interface ApproverEvidence {
+  approver_kind: ApproverKind;
+  approver_id: string;
+  approved_at: string;
+  evidence_ref: string;
+}
+
+export interface PolicyEvalResult {
+  policy_adr: string;
+  evaluated_at: string;
+  passed: boolean;
+  notes?: string;
+}
+
+export interface RollbackPolicy {
+  on_drift_detected: 'auto-quarantine' | 'alert-only';
+  on_kill_switch: 'auto-revoke' | 'auto-quarantine';
+}
+
+export type DecidedByActorKind = 'human' | 'service' | 'policy-engine' | 'kill-switch';
+
+export interface DecidedBy {
+  actor_id: string;
+  actor_kind: DecidedByActorKind;
+  signature: string;                // HMAC or stronger; must be non-empty
+}
+
+export interface PromotionDecision {
+  decision_id: string;
+  candidate_id: string;
+  from_state: SkillLifecycleState;
+  to_state: SkillLifecycleState;    // expected to be ACTIVE or CANDIDATE (re-admission)
+  decided_at: string;
+
+  approvers: ApproverEvidence[];    // ≥ 1 required (L3)
+  scan_evidence: ScanResultRef[];   // ≥ 1 required with verdict='safe' (L4)
+  policy_evaluations: PolicyEvalResult[];
+
+  rollback_policy: RollbackPolicy;
+
+  decided_by: DecidedBy;
+}
+
+// === §5 QuarantineDecision ===
+
+export enum QuarantineReason {
+  SCAN_DANGEROUS = 'scan.dangerous',
+  SCAN_CAUTION = 'scan.caution',
+  PROMOTION_REJECTED = 'promotion.rejected',
+  DRIFT_DETECTED = 'drift.detected',
+  POLICY_VIOLATION = 'policy.violation',
+  KILL_SWITCH = 'kill-switch',
+  EXTERNAL_REPORT = 'external.report',
+  GRACE_PERIOD_EXPIRED = 'grace-period.expired',
+}
+
+export interface QuarantineDecision {
+  decision_id: string;
+  candidate_id: string;
+  from_state: SkillLifecycleState;
+  to_state: SkillLifecycleState;    // usually QUARANTINED or REVOKED
+  reason: QuarantineReason;
+  reason_detail: string;
+  reason_evidence: string[];
+  decided_at: string;
+  /** Null = blocked until a new decision explicitly releases. */
+  release_blocked_until: string | null;
+
+  decided_by: DecidedBy;
+}
+
+// === §6 LifecycleTransition (append-only log entry) ===
+
+export type LifecycleDriver =
+  | { kind: 'promotion'; decision: PromotionDecision }
+  | { kind: 'quarantine'; decision: QuarantineDecision };
+
+export interface LifecycleTransition {
+  transition_id: string;
+  candidate_id: string;
+  from_state: SkillLifecycleState;
+  to_state: SkillLifecycleState;
+  transitioned_at: string;
+  driver: LifecycleDriver;
+  /** sha256(prev_transition_id || canonical(payload)) — see transition_log.ts */
+  prev_transition_id: string | null;
+  entry_hash: string;
+}
+
+// === Registry failure codes ===
+
+export type SubmitFailureCode =
+  | 'INITIAL_STATE_MUST_BE_CANDIDATE'
+  | 'MISSING_PROVENANCE'
+  | 'LAYER_0_CANNOT_PRODUCE_CANDIDATE'
+  | 'UNKNOWN_CAPABILITY_KIND'
+  | 'DUPLICATE_CANDIDATE_ID'
+  | 'INVALID_CANDIDATE_ID_FORMAT'
+  | 'INVALID_CONTENT_HASH';
+
+export type TransitionFailureCode =
+  | 'CANDIDATE_NOT_FOUND'
+  | 'ILLEGAL_TRANSITION'
+  | 'FROM_STATE_MISMATCH'
+  | 'MISSING_DRIVER'
+  | 'MISSING_APPROVERS'
+  | 'MISSING_SIGNATURE'
+  | 'SCAN_EVIDENCE_NOT_SAFE'
+  | 'MISSING_SCAN_EVIDENCE'
+  | 'QUARANTINE_RELEASE_BLOCKED'
+  | 'REVOKED_IS_TERMINAL'
+  | 'CANDIDATE_ID_MISMATCH';
+
+export type SubmitResult =
+  | { ok: true; candidate_id: string }
+  | { ok: false; code: SubmitFailureCode; detail?: string };
+
+export type TransitionResult =
+  | { ok: true; transition_id: string; to_state: SkillLifecycleState }
+  | { ok: false; code: TransitionFailureCode; detail?: string };
+
+// === Guard seam — candidate submit (Wave 5.2) ===
+
+export type CandidateSubmitFailureCode =
+  | SubmitFailureCode
+  | 'GUARD_EVIDENCE_MISSING';
+
+/**
+ * Output of a guarded candidate submit (Wave 5.2). SHADOW mode never
+ * blocks, so `ok` reflects whether the lifecycle registry accepted the
+ * record after the shadow guard produced evidence.
+ */
+export type GuardedSubmitResult =
+  | {
+      ok: true;
+      candidate_id: string;
+      guard_evidence_id: string;
+      guard_verdict: 'safe' | 'caution' | 'dangerous';
+      guard_mode: 'shadow';
+    }
+  | {
+      ok: false;
+      code: CandidateSubmitFailureCode;
+      detail?: string;
+      guard_evidence_id?: string;
+      guard_verdict?: 'safe' | 'caution' | 'dangerous';
+    };

--- a/tests/runtime/governance/capability/registry.test.ts
+++ b/tests/runtime/governance/capability/registry.test.ts
@@ -1,0 +1,260 @@
+/**
+ * BGHS Capability Registry tests — Sprint 4.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  CAPABILITY_KIND_RE,
+  CapabilityKindRegistry,
+  CapabilityRegistry,
+  DecisionAuthorityRegistry,
+  DecisionKind,
+  type CapabilityKindRegistration,
+  type CapabilityRegistration,
+  type DecisionAuthority,
+  type TrustBoundaryDecl,
+} from '../../../../src/runtime/governance/capability';
+
+function makeKindReg(overrides: Partial<CapabilityKindRegistration> = {}): CapabilityKindRegistration {
+  return {
+    kind: 'engine.write.amazon-ads-bid',
+    layer_introduced: 0,
+    contract_adr: 'ADR-OpenClaw-Capability-Boundary',
+    contract_schema: '_meta/contracts/capability/engine.write.amazon-ads-bid.schema.yaml',
+    introduced_at: '2026-04-17T00:00:00Z',
+    superseded_by: null,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+function makeTrustBoundary(overrides: Partial<TrustBoundaryDecl> = {}): TrustBoundaryDecl {
+  return {
+    fs_scope: { read_roots: ['{component_root}/data'], write_roots: ['{component_root}/artifacts'] },
+    network_scope: { egress_allowlist: ['advertising-api.amazon.com'], ingress: 'none' },
+    in_process: false,
+    credential_path: 'cred://amazon-growth-engine/ads-api-refresh-token',
+    ...overrides,
+  };
+}
+
+function makeCapReg(overrides: Partial<CapabilityRegistration> = {}): CapabilityRegistration {
+  return {
+    capability_id: 'amazon-growth-engine:bid_write',
+    kind: 'engine.write.amazon-ads-bid',
+    owner: {
+      layer: 2,
+      component: 'amazon-growth-engine',
+      declaration_path: '_meta/declarations/amazon-growth-engine.yaml',
+    },
+    trust_boundary: makeTrustBoundary(),
+    side_effects: [
+      { kind: 'network-egress', target: 'advertising-api.amazon.com' },
+      { kind: 'external-api', target: 'Amazon Advertising API' },
+    ],
+    observed_by: null,
+    registered_at: '2026-04-17T00:00:00Z',
+    status: 'active',
+    ...overrides,
+  };
+}
+
+// -------------------- CapabilityKindRegistry --------------------
+
+describe('CAPABILITY_KIND_RE (naming pattern)', () => {
+  it('accepts the primary reference kinds', () => {
+    for (const k of [
+      'engine.write.amazon-ads-bid',
+      'session.event-stream',
+      'guard.content-scan',
+      'memory.write.authoritative',
+    ]) {
+      expect(CAPABILITY_KIND_RE.test(k)).toBe(true);
+    }
+  });
+
+  it('rejects single-segment kinds', () => {
+    expect(CAPABILITY_KIND_RE.test('engine')).toBe(false);
+  });
+
+  it('rejects leading digit / uppercase / underscore', () => {
+    expect(CAPABILITY_KIND_RE.test('1engine.write')).toBe(false);
+    expect(CAPABILITY_KIND_RE.test('Engine.write')).toBe(false);
+    expect(CAPABILITY_KIND_RE.test('engine.write_bid')).toBe(false);
+  });
+
+  it('rejects trailing or doubled dots', () => {
+    expect(CAPABILITY_KIND_RE.test('engine.')).toBe(false);
+    expect(CAPABILITY_KIND_RE.test('engine..write')).toBe(false);
+  });
+});
+
+describe('CapabilityKindRegistry', () => {
+  let kinds: CapabilityKindRegistry;
+
+  beforeEach(() => {
+    kinds = new CapabilityKindRegistry();
+  });
+
+  it('accepts a well-formed kind registration', () => {
+    const r = kinds.register(makeKindReg());
+    expect(r.ok).toBe(true);
+    expect(kinds.has('engine.write.amazon-ads-bid')).toBe(true);
+  });
+
+  it('rejects invalid kind name', () => {
+    const r = kinds.register(makeKindReg({ kind: 'NotAKind' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('INVALID_KIND_NAME');
+  });
+
+  it('rejects duplicate kind', () => {
+    expect(kinds.register(makeKindReg()).ok).toBe(true);
+    const r = kinds.register(makeKindReg());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('DUPLICATE_KIND');
+  });
+
+  it('rejects layer_introduced != 0', () => {
+    const r = kinds.register(makeKindReg({ layer_introduced: 1 as unknown as 0 }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('LAYER_INTRODUCED_MUST_BE_ZERO');
+  });
+
+  it('rejects missing contract_adr or contract_schema', () => {
+    expect(kinds.register(makeKindReg({ contract_adr: '' })).ok).toBe(false);
+    expect(kinds.register(makeKindReg({ kind: 'engine.write.foo', contract_schema: '' })).ok).toBe(false);
+  });
+});
+
+// -------------------- CapabilityRegistry --------------------
+
+describe('CapabilityRegistry', () => {
+  let kinds: CapabilityKindRegistry;
+  let caps: CapabilityRegistry;
+
+  beforeEach(() => {
+    kinds = new CapabilityKindRegistry();
+    kinds.register(makeKindReg());
+    caps = new CapabilityRegistry(kinds);
+  });
+
+  it('registers the reference capability engine.write.amazon-ads-bid', () => {
+    const r = caps.register(makeCapReg());
+    expect(r.ok).toBe(true);
+    expect(caps.lookup('amazon-growth-engine:bid_write')?.kind).toBe(
+      'engine.write.amazon-ads-bid',
+    );
+  });
+
+  it('rejects unknown kind (B1)', () => {
+    const r = caps.register(makeCapReg({ kind: 'engine.write.not-registered' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('UNKNOWN_KIND');
+  });
+
+  it('rejects duplicate active capability_id (B2)', () => {
+    expect(caps.register(makeCapReg()).ok).toBe(true);
+    const r2 = caps.register(makeCapReg());
+    expect(r2.ok).toBe(false);
+    if (!r2.ok) expect(r2.code).toBe('DUPLICATE_ACTIVE');
+  });
+
+  it('accepts supersede when prior entry is non-active', () => {
+    expect(caps.register(makeCapReg({ status: 'quarantined' })).ok).toBe(true);
+    const r2 = caps.register(makeCapReg());
+    expect(r2.ok).toBe(true);
+  });
+
+  it('rejects invalid owner layer (Layer 0 cannot own capabilities)', () => {
+    const r = caps.register(makeCapReg({
+      owner: { layer: 0 as unknown as 1, component: 'x', declaration_path: 'x.yaml' },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('INVALID_OWNER_LAYER');
+  });
+
+  it('rejects missing trust_boundary (B4)', () => {
+    const r = caps.register(makeCapReg({ trust_boundary: null as unknown as TrustBoundaryDecl }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_TRUST_BOUNDARY');
+  });
+
+  it('rejects trust_boundary with missing fs_scope object (B4)', () => {
+    const tb = makeTrustBoundary();
+    (tb as unknown as { fs_scope: unknown }).fs_scope = undefined;
+    const r = caps.register(makeCapReg({ trust_boundary: tb }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_TRUST_BOUNDARY');
+  });
+
+  it('rejects network-egress side effect when egress_allowlist empty', () => {
+    const tb = makeTrustBoundary({
+      network_scope: { egress_allowlist: [], ingress: 'none' },
+    });
+    const r = caps.register(makeCapReg({ trust_boundary: tb }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('EMPTY_NETWORK_SCOPE_ON_NETWORK_SIDE_EFFECT');
+  });
+
+  it('accepts empty egress_allowlist when no network side effects declared', () => {
+    // A capability with only fs writes can have an empty egress list.
+    const tb = makeTrustBoundary({
+      network_scope: { egress_allowlist: [], ingress: 'none' },
+    });
+    const r = caps.register(makeCapReg({
+      trust_boundary: tb,
+      side_effects: [{ kind: 'fs-write', target: '{component_root}/artifacts' }],
+    }));
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects invalid capability_id format', () => {
+    const r = caps.register(makeCapReg({ capability_id: 'NoColonHere' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('INVALID_CAPABILITY_ID_FORMAT');
+  });
+});
+
+// -------------------- DecisionAuthorityRegistry --------------------
+
+describe('DecisionAuthorityRegistry', () => {
+  let reg: DecisionAuthorityRegistry;
+
+  beforeEach(() => {
+    reg = new DecisionAuthorityRegistry();
+  });
+
+  function makeAuth(overrides: Partial<DecisionAuthority> = {}): DecisionAuthority {
+    return {
+      kind: DecisionKind.CAPABILITY_ADMISSION,
+      authoritative_layer: 0,
+      authoritative_path: 'src/runtime/governance/capability/',
+      observers_allowed: ['loamwise.observer'],
+      override_allowed: false,
+      ...overrides,
+    };
+  }
+
+  it('accepts a valid authority with override_allowed=false', () => {
+    expect(reg.register(makeAuth()).ok).toBe(true);
+  });
+
+  it('rejects override_allowed=true', () => {
+    const r = reg.register(makeAuth({ override_allowed: true as unknown as false }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('OVERRIDE_ALLOWED_MUST_BE_FALSE');
+  });
+
+  it('rejects invalid authoritative_layer (Layer 2 not allowed)', () => {
+    const r = reg.register(makeAuth({ authoritative_layer: 2 as unknown as 0 }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('INVALID_AUTHORITATIVE_LAYER');
+  });
+
+  it('rejects missing authoritative_path', () => {
+    const r = reg.register(makeAuth({ authoritative_path: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_AUTHORITATIVE_PATH');
+  });
+});

--- a/tests/runtime/governance/guard/guard.test.ts
+++ b/tests/runtime/governance/guard/guard.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Guard runtime skeleton tests — Sprint 3 Wave 3.1.
+ *
+ * Coverage:
+ *   - redactSnippet / looksSensitive sanitization rules.
+ *   - ShadowRunner: appends GuardEvidence, never blocks, even on DANGEROUS.
+ *   - ShadowRunner: fail_open on scanner throw, scanner_failed=true recorded.
+ *   - GuardChainRegistry: rejects all 7 validator classes from ADR §7.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  AlwaysDangerousScanner,
+  GuardChainRegistry,
+  GuardEnforcementMode,
+  GuardKind,
+  GuardVerdict,
+  InMemoryGuardEvidenceSink,
+  NoopScanner,
+  ProtectedPathKind,
+  ShadowRunner,
+  looksSensitive,
+  redactSnippet,
+  type GuardChain,
+  type GuardRunInput,
+  type Scanner,
+} from '../../../../src/runtime/governance/guard';
+
+// -------------------- redactSnippet / looksSensitive --------------------
+
+describe('redactSnippet', () => {
+  it('returns [empty] for empty/null/undefined', () => {
+    expect(redactSnippet(null)).toBe('[empty]');
+    expect(redactSnippet(undefined)).toBe('[empty]');
+    expect(redactSnippet('')).toBe('[empty]');
+  });
+
+  it('passes short non-sensitive content through', () => {
+    expect(redactSnippet('hello')).toBe('hello');
+  });
+
+  it('hashes long non-sensitive content with length hint', () => {
+    // Uses spaces to avoid matching the base64/hex "sensitive" regexes.
+    const long = 'hello world '.repeat(10);    // 120 chars, not token-shaped
+    const r = redactSnippet(long);
+    expect(r).toMatch(/^sha256:[a-f0-9]{12}\.\.\. \[len=\d+\]$/);
+  });
+
+  it('hashes sensitive-looking short content', () => {
+    expect(redactSnippet('ya29.abc')).toMatch(/^sha256:[a-f0-9]{12}\.\.\.$/);
+    expect(redactSnippet('Bearer xyz')).toMatch(/^sha256:[a-f0-9]{12}\.\.\.$/);
+  });
+});
+
+describe('looksSensitive', () => {
+  it('flags ya29 and Atza prefixes', () => {
+    expect(looksSensitive('ya29.a-b-c')).toBe(true);
+    expect(looksSensitive('Atza|something')).toBe(true);
+  });
+
+  it('flags Bearer tokens', () => {
+    expect(looksSensitive('Authorization: Bearer abcdef')).toBe(true);
+  });
+
+  it('flags long base64-ish and hex runs', () => {
+    expect(looksSensitive('AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH')).toBe(true);
+    expect(looksSensitive('deadbeefcafebabedeadbeefcafebabe')).toBe(true);
+  });
+
+  it('passes ordinary text', () => {
+    expect(looksSensitive('hello world')).toBe(false);
+  });
+});
+
+// -------------------- ShadowRunner --------------------
+
+const RUN_INPUT: GuardRunInput = {
+  guard_id: 'test-guard',
+  guard_kind: GuardKind.CONTENT_SCAN,
+  scanner_version: '',              // overridden by scanner
+  pattern_catalog_version: '',
+  trace_id: 'trace-abc',
+  scanned_path: { path_kind: 'skill-candidate', target_ref: 'cand-1' },
+  payload: { text: 'dummy' },
+};
+
+describe('ShadowRunner', () => {
+  let sink: InMemoryGuardEvidenceSink;
+
+  beforeEach(() => {
+    sink = new InMemoryGuardEvidenceSink();
+  });
+
+  it('writes evidence and never blocks on SAFE', async () => {
+    const runner = new ShadowRunner(new NoopScanner(GuardKind.CONTENT_SCAN), { sink, fail_open: true });
+    const out = await runner.run(RUN_INPUT);
+    expect(out.blocked).toBe(false);
+    expect(out.verdict).toBe(GuardVerdict.SAFE);
+    expect(sink.list()).toHaveLength(1);
+    expect(sink.list()[0].mode).toBe(GuardEnforcementMode.SHADOW);
+  });
+
+  it('writes evidence and STILL does not block on DANGEROUS', async () => {
+    const runner = new ShadowRunner(
+      new AlwaysDangerousScanner(GuardKind.CONTENT_SCAN),
+      { sink, fail_open: true },
+    );
+    const out = await runner.run(RUN_INPUT);
+    expect(out.blocked).toBe(false);         // SHADOW never blocks
+    expect(out.verdict).toBe(GuardVerdict.DANGEROUS);
+    expect(sink.list()[0].verdict).toBe(GuardVerdict.DANGEROUS);
+    expect(sink.list()[0].hits).toHaveLength(1);
+  });
+
+  it('fails open on scanner throw and records scanner_failed=true', async () => {
+    const throwingScanner: Scanner = {
+      scanner_id: 'throwing',
+      scanner_version: '0',
+      pattern_catalog_version: '0',
+      supports_kind: GuardKind.CONTENT_SCAN,
+      async scan() {
+        throw new Error('scanner imploded');
+      },
+    };
+    const runner = new ShadowRunner(throwingScanner, { sink, fail_open: true });
+    const out = await runner.run(RUN_INPUT);
+    expect(out.blocked).toBe(false);
+    expect(out.verdict).toBe(GuardVerdict.SAFE);   // fail-open default
+    const ev = sink.list()[0];
+    expect(ev.scanner_failed).toBe(true);
+    expect(ev.failure_reason).toBe('scanner imploded');
+  });
+});
+
+// -------------------- GuardChainRegistry --------------------
+
+function makeChain(overrides: Partial<GuardChain> = {}): GuardChain {
+  return {
+    chain_id: 'chain.skill-candidate-submit.v1',
+    protected_path: {
+      kind: ProtectedPathKind.SKILL_CANDIDATE_SUBMIT,
+      required_guard_kinds: [GuardKind.CONTENT_SCAN],
+    },
+    steps: [
+      {
+        step_id: 'step-1',
+        guard_kind: GuardKind.CONTENT_SCAN,
+        mode: GuardEnforcementMode.SHADOW,
+        parallel_with: null,
+        on_verdict: {
+          on_safe: 'pass',
+          on_caution: 'pass-with-warning',
+          on_dangerous: 'block',
+        },
+        non_shadow_allowed_by: null,
+      },
+    ],
+    global_shadow: false,
+    declared_at: '2026-04-17T00:00:00Z',
+    declared_by_adr: 'ADR-Loamwise-Guard-Content-Security',
+    ...overrides,
+  };
+}
+
+describe('GuardChainRegistry', () => {
+  let reg: GuardChainRegistry;
+
+  beforeEach(() => {
+    reg = new GuardChainRegistry();
+  });
+
+  it('registers a valid SHADOW-only chain for skill-candidate-submit', () => {
+    const r = reg.register(makeChain());
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects duplicate chain_id', () => {
+    expect(reg.register(makeChain()).ok).toBe(true);
+    const r2 = reg.register(makeChain());
+    expect(r2.ok).toBe(false);
+    if (!r2.ok) expect(r2.code).toBe('DUPLICATE_CHAIN_ID');
+  });
+
+  it('rejects unknown protected_path.kind', () => {
+    const c = makeChain();
+    c.protected_path = {
+      kind: 'not.in.whitelist' as unknown as ProtectedPathKind,
+      required_guard_kinds: [GuardKind.CONTENT_SCAN],
+    };
+    const r = reg.register(c);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('PATH_NOT_IN_WHITELIST');
+  });
+
+  it('rejects chain missing a required_guard_kind', () => {
+    const c = makeChain({
+      protected_path: {
+        kind: ProtectedPathKind.MEMORY_WRITE_AUTH,
+        required_guard_kinds: [GuardKind.CONTENT_SCAN, GuardKind.TRUTH_WRITE],
+      },
+      // only CONTENT_SCAN in steps
+    });
+    const r = reg.register(c);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_REQUIRED_GUARD_KIND');
+  });
+
+  it('rejects SHADOW step with a non-null non_shadow_allowed_by', () => {
+    const c = makeChain();
+    c.steps[0].non_shadow_allowed_by = 'ADR-Foo';
+    const r = reg.register(c);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('SHADOW_STEP_HAS_NON_SHADOW_REF');
+  });
+
+  it('rejects ADVISORY/ACTIVE step without escalation ADR', () => {
+    const c = makeChain();
+    c.steps[0].mode = GuardEnforcementMode.ACTIVE;
+    c.steps[0].non_shadow_allowed_by = null;
+    const r = reg.register(c);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('NON_SHADOW_STEP_MISSING_ESCALATION_ADR');
+  });
+
+  it('accepts ACTIVE step when non_shadow_allowed_by is present', () => {
+    const c = makeChain();
+    c.steps[0].mode = GuardEnforcementMode.ACTIVE;
+    c.steps[0].non_shadow_allowed_by = 'ADR-Guard-Escalation-SkillSubmit';
+    const r = reg.register(c);
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects missing declared_by_adr', () => {
+    const c = makeChain({ declared_by_adr: '' });
+    const r = reg.register(c);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_CHAIN_ADR');
+  });
+
+  it('rejects global_shadow != false', () => {
+    const c = makeChain();
+    (c as unknown as { global_shadow: unknown }).global_shadow = true;
+    const r = reg.register(c);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('GLOBAL_SHADOW_DISALLOWED');
+  });
+
+  it('rejects on_dangerous = pass at runtime even if the TS type forbids it', () => {
+    const c = makeChain();
+    (c.steps[0].on_verdict as unknown as { on_dangerous: string }).on_dangerous = 'pass';
+    const r = reg.register(c);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('VERDICT_ROUTING_ALLOWS_DANGEROUS_PASS');
+  });
+});

--- a/tests/runtime/governance/memory/guard_wire.test.ts
+++ b/tests/runtime/governance/memory/guard_wire.test.ts
@@ -1,0 +1,290 @@
+/**
+ * guardedMemoryWrite + guardedAssemblyFragmentIngest tests — Sprint 6 Wave 6.2.
+ *
+ * Coverage:
+ *   - AUTHORITATIVE write uses TRUTH_WRITE guard; non-auth uses CONTENT_SCAN
+ *   - DANGEROUS verdict never blocks (SHADOW invariant)
+ *   - Policy tier mismatch rejected; guard evidence still reported
+ *   - Fragment ingest rejects non-frozen / expired / unknown record
+ *   - CONTEXT_INJECT guard runs for fragment ingest
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  AlwaysDangerousScanner,
+  GuardKind,
+  InMemoryGuardEvidenceSink,
+  NoopScanner,
+  ShadowRunner,
+} from '../../../../src/runtime/governance/guard';
+import {
+  MemoryPlanRegistry,
+  MemoryRecordRegistry,
+  MemoryTier,
+  MemoryUsePolicyRegistry,
+  guardedAssemblyFragmentIngest,
+  guardedMemoryWrite,
+  type MemoryUsePolicy,
+  type MemoryWriteRequest,
+} from '../../../../src/runtime/governance/memory';
+
+function basePolicy(overrides: Partial<MemoryUsePolicy> = {}): MemoryUsePolicy {
+  return {
+    policy_id: 'pol-ds',
+    tier: MemoryTier.DECISION_SUPPORT,
+    read_allowed_for: ['decision'],
+    write_allowed_by: [{ actor_kind: 'engine-cosign', guard_chain_required: ['content-scan'] }],
+    decision_consumers: [],
+    derivation_rule: { can_summarize_to: [MemoryTier.DECISION_SUPPORT, MemoryTier.CONTEXT_ONLY], can_index_into: [] },
+    revocation_path: 'adr://kill',
+    ...overrides,
+  };
+}
+
+function baseWrite(overrides: Partial<MemoryWriteRequest> = {}): MemoryWriteRequest {
+  return {
+    record: {
+      record_id: 'rec-w-1',
+      tier: MemoryTier.DECISION_SUPPORT,
+      content_kind: 'summary.session',
+      content_hash: 'sha256:' + 'c'.repeat(64),
+      source: { provider_id: 'loamwise', layer: 1, upstream_ref: null, trace_id: 'trace-1' },
+      created_at: '2026-04-17T00:00:00Z',
+      redaction_applied: false,
+      payload: { text: 'hi' },
+    } as unknown as MemoryWriteRequest['record'],
+    use_policy_id: 'pol-ds',
+    scan_payload: 'hi',
+    trace_id: 'trace-1',
+    ...overrides,
+  };
+}
+
+describe('guardedMemoryWrite', () => {
+  let policies: MemoryUsePolicyRegistry;
+  let records: MemoryRecordRegistry;
+  let sink: InMemoryGuardEvidenceSink;
+
+  beforeEach(() => {
+    policies = new MemoryUsePolicyRegistry();
+    records = new MemoryRecordRegistry();
+    sink = new InMemoryGuardEvidenceSink();
+    policies.register(basePolicy());
+    policies.register(basePolicy({
+      policy_id: 'pol-auth',
+      tier: MemoryTier.AUTHORITATIVE,
+      decision_consumers: ['approval'],
+      derivation_rule: { can_summarize_to: [MemoryTier.AUTHORITATIVE], can_index_into: [] },
+    }));
+  });
+
+  it('DECISION_SUPPORT write runs CONTENT_SCAN + registers record', async () => {
+    const runner = new ShadowRunner(new NoopScanner(GuardKind.CONTENT_SCAN), { sink, fail_open: true });
+    const r = await guardedMemoryWrite(baseWrite(), {
+      runner, sink, policies, records, scanner_id: 'noop',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.guard_kind).toBe('content-scan');
+      expect(r.guard_verdict).toBe('safe');
+    }
+    expect(sink.list().length).toBe(1);
+    expect(records.size()).toBe(1);
+    // Guard evidence ref was attached to the stored record.
+    const stored = records.lookup('rec-w-1')!;
+    expect(stored.guard_evidence.length).toBe(1);
+  });
+
+  it('AUTHORITATIVE write runs TRUTH_WRITE guard', async () => {
+    const runner = new ShadowRunner(new NoopScanner(GuardKind.TRUTH_WRITE), { sink, fail_open: true });
+    const r = await guardedMemoryWrite(baseWrite({
+      use_policy_id: 'pol-auth',
+      record: {
+        record_id: 'rec-auth-1',
+        tier: MemoryTier.AUTHORITATIVE,
+        content_kind: 'contract.adr',
+        content_hash: 'sha256:' + 'd'.repeat(64),
+        source: { provider_id: 'contract-adr-writer', layer: 0, upstream_ref: null, trace_id: 'trace-2' },
+        created_at: '2026-04-17T00:00:00Z',
+        redaction_applied: false,
+        payload: { text: 'auth content' },
+      } as unknown as MemoryWriteRequest['record'],
+      trace_id: 'trace-2',
+    }), {
+      runner, sink, policies, records, scanner_id: 'noop-truth',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.guard_kind).toBe('truth-write');
+  });
+
+  it('DANGEROUS verdict does not block (SHADOW invariant)', async () => {
+    const runner = new ShadowRunner(new AlwaysDangerousScanner(GuardKind.CONTENT_SCAN), { sink, fail_open: true });
+    const r = await guardedMemoryWrite(baseWrite(), {
+      runner, sink, policies, records, scanner_id: 'dangerous',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.guard_verdict).toBe('dangerous');
+    // Record still registered with the dangerous-verdict evidence attached.
+    const stored = records.lookup('rec-w-1')!;
+    expect(stored.guard_evidence[0].verdict).toBe('dangerous');
+  });
+
+  it('rejects unknown use_policy_id', async () => {
+    const runner = new ShadowRunner(new NoopScanner(GuardKind.CONTENT_SCAN), { sink, fail_open: true });
+    const r = await guardedMemoryWrite(baseWrite({ use_policy_id: 'no-such' }), {
+      runner, sink, policies, records, scanner_id: 'noop',
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('UNKNOWN_USE_POLICY');
+    // No guard scan was run for this particular branch — it fails before runner.
+    expect(sink.list().length).toBe(0);
+  });
+
+  it('rejects policy/record tier mismatch (evidence still recorded? — pre-scan check)', async () => {
+    const runner = new ShadowRunner(new NoopScanner(GuardKind.CONTENT_SCAN), { sink, fail_open: true });
+    const r = await guardedMemoryWrite(baseWrite({
+      record: {
+        record_id: 'rec-mismatch',
+        tier: MemoryTier.CONTEXT_ONLY,
+        content_kind: 'note',
+        content_hash: 'sha256:' + 'e'.repeat(64),
+        source: { provider_id: 'x', layer: 1, upstream_ref: null, trace_id: 'trace-3' },
+        created_at: '2026-04-17T00:00:00Z',
+        redaction_applied: false,
+        payload: null,
+      } as unknown as MemoryWriteRequest['record'],
+      trace_id: 'trace-3',
+    }), {
+      runner, sink, policies, records, scanner_id: 'noop',
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('POLICY_TIER_MISMATCH');
+  });
+
+  it('returns registry-level failure with evidence id attached', async () => {
+    const runner = new ShadowRunner(new NoopScanner(GuardKind.CONTENT_SCAN), { sink, fail_open: true });
+    // Bad content_hash → registry rejects, but guard already ran.
+    const r = await guardedMemoryWrite(baseWrite({
+      record: {
+        record_id: 'rec-bad',
+        tier: MemoryTier.DECISION_SUPPORT,
+        content_kind: 'summary.session',
+        content_hash: 'nope',
+        source: { provider_id: 'loamwise', layer: 1, upstream_ref: null, trace_id: 'trace-4' },
+        created_at: '2026-04-17T00:00:00Z',
+        redaction_applied: false,
+        payload: null,
+      } as unknown as MemoryWriteRequest['record'],
+      trace_id: 'trace-4',
+    }), {
+      runner, sink, policies, records, scanner_id: 'noop',
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('INVALID_CONTENT_HASH');
+      expect(r.guard_evidence_id).toBeTruthy();
+      expect(r.guard_verdict).toBe('safe');
+    }
+    expect(sink.list().length).toBe(1);
+  });
+});
+
+describe('guardedAssemblyFragmentIngest', () => {
+  let policies: MemoryUsePolicyRegistry;
+  let plans: MemoryPlanRegistry;
+  let records: MemoryRecordRegistry;
+  let sink: InMemoryGuardEvidenceSink;
+
+  beforeEach(() => {
+    policies = new MemoryUsePolicyRegistry();
+    policies.register(basePolicy());
+    plans = new MemoryPlanRegistry(policies);
+    plans.register({
+      plan_id: 'plan-frag',
+      intended_for: 'decision',
+      retrieval_specs: [{ provider_id: 'p', tiers: [MemoryTier.DECISION_SUPPORT], query_template: 'q', max_results: 10 }],
+      assembly_order: [{ step: 'system-prompt', fragments: [], fence_boundary: null }],
+      write_specs: [],
+      created_at: '2026-04-17T00:00:00Z',
+      expires_at: '2099-01-01T00:00:00Z',
+      frozen: false,
+    });
+    records = new MemoryRecordRegistry();
+    records.register({
+      record_id: 'rec-parent',
+      tier: MemoryTier.DECISION_SUPPORT,
+      content_kind: 'x',
+      content_hash: 'sha256:' + 'f'.repeat(64),
+      source: { provider_id: 'p', layer: 1, upstream_ref: null, trace_id: 't' },
+      created_at: '2026-04-17T00:00:00Z',
+      guard_evidence: [{ evidence_id: 'ev', guard_kind: 'content-scan', verdict: 'safe' }],
+      redaction_applied: false,
+      payload: null,
+    });
+    sink = new InMemoryGuardEvidenceSink();
+  });
+
+  it('rejects ingest when plan is not frozen', async () => {
+    const runner = new ShadowRunner(new NoopScanner(GuardKind.CONTEXT_INJECT), { sink, fail_open: true });
+    const r = await guardedAssemblyFragmentIngest({
+      fragment_id: 'frag-1',
+      plan_id: 'plan-frag',
+      step: 'system-prompt',
+      record_ref: 'rec-parent',
+      scan_payload: 'text',
+      trace_id: 'tr',
+    }, { runner, sink, plans, records, scanner_id: 'ctx' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('PLAN_NOT_FROZEN');
+      expect(r.guard_evidence_id).toBeTruthy();
+    }
+    // Guard evidence was still recorded so audits observe the attempt.
+    expect(sink.list().length).toBe(1);
+  });
+
+  it('accepts ingest against a frozen, unexpired plan with a known record_ref', async () => {
+    plans.freeze('plan-frag');
+    const runner = new ShadowRunner(new NoopScanner(GuardKind.CONTEXT_INJECT), { sink, fail_open: true });
+    const r = await guardedAssemblyFragmentIngest({
+      fragment_id: 'frag-2',
+      plan_id: 'plan-frag',
+      step: 'system-prompt',
+      record_ref: 'rec-parent',
+      scan_payload: 'text',
+      trace_id: 'tr',
+    }, { runner, sink, plans, records, scanner_id: 'ctx' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.guard_mode).toBe('shadow');
+  });
+
+  it('rejects when record_ref is unknown', async () => {
+    plans.freeze('plan-frag');
+    const runner = new ShadowRunner(new NoopScanner(GuardKind.CONTEXT_INJECT), { sink, fail_open: true });
+    const r = await guardedAssemblyFragmentIngest({
+      fragment_id: 'frag-3',
+      plan_id: 'plan-frag',
+      step: 'system-prompt',
+      record_ref: 'nope',
+      scan_payload: 'x',
+      trace_id: 'tr',
+    }, { runner, sink, plans, records, scanner_id: 'ctx' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('UNKNOWN_RECORD_REF');
+  });
+
+  it('DANGEROUS verdict does not block SHADOW ingest', async () => {
+    plans.freeze('plan-frag');
+    const runner = new ShadowRunner(new AlwaysDangerousScanner(GuardKind.CONTEXT_INJECT), { sink, fail_open: true });
+    const r = await guardedAssemblyFragmentIngest({
+      fragment_id: 'frag-4',
+      plan_id: 'plan-frag',
+      step: 'tool-context',
+      record_ref: 'rec-parent',
+      scan_payload: 'bad',
+      trace_id: 'tr',
+    }, { runner, sink, plans, records, scanner_id: 'ctx' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.guard_verdict).toBe('dangerous');
+  });
+});

--- a/tests/runtime/governance/memory/plan_registry.test.ts
+++ b/tests/runtime/governance/memory/plan_registry.test.ts
@@ -1,0 +1,197 @@
+/**
+ * MemoryPlanRegistry + snapshot tests — Sprint 6 Wave 6.1.
+ *
+ * Coverage:
+ *   - plan registration + write_specs policy reference
+ *   - write_specs.target_tier must match policy tier
+ *   - freeze flips plan to immutable; subsequent mutation throws (O5)
+ *   - expired plan cannot be frozen / cannot pass retrieval validator
+ *   - buildFrozenSnapshot sorts by tierRank then rank_in_tier
+ *   - snapshot is immutable
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  MemoryPlanRegistry,
+  MemoryTier,
+  MemoryUsePolicyRegistry,
+  buildFrozenSnapshot,
+  type MemoryAssemblyPlan,
+  type MemoryUsePolicy,
+  type RetrievalFragment,
+} from '../../../../src/runtime/governance/memory';
+
+function makePolicy(overrides: Partial<MemoryUsePolicy> = {}): MemoryUsePolicy {
+  return {
+    policy_id: 'pol-ds',
+    tier: MemoryTier.DECISION_SUPPORT,
+    read_allowed_for: ['decision', 'audit'],
+    write_allowed_by: [{ actor_kind: 'engine-cosign', guard_chain_required: ['content-scan'] }],
+    decision_consumers: [],
+    derivation_rule: { can_summarize_to: [MemoryTier.DECISION_SUPPORT, MemoryTier.CONTEXT_ONLY], can_index_into: [] },
+    revocation_path: 'adr://kill',
+    ...overrides,
+  };
+}
+
+function makePlan(overrides: Partial<MemoryAssemblyPlan> = {}): MemoryAssemblyPlan {
+  return {
+    plan_id: 'plan-1',
+    intended_for: 'decision',
+    retrieval_specs: [
+      { provider_id: 'loamwise:align.retrieval', tiers: [MemoryTier.DECISION_SUPPORT], query_template: 'q', max_results: 10 },
+    ],
+    assembly_order: [
+      { step: 'system-prompt', fragments: ['rec-1'], fence_boundary: null },
+    ],
+    write_specs: [
+      { target_tier: MemoryTier.DECISION_SUPPORT, content_kind: 'summary.session', use_policy_id: 'pol-ds' },
+    ],
+    created_at: '2026-04-17T00:00:00Z',
+    expires_at: '2099-01-01T00:00:00Z',
+    frozen: false,
+    ...overrides,
+  };
+}
+
+describe('MemoryPlanRegistry — register', () => {
+  let policies: MemoryUsePolicyRegistry;
+  let plans: MemoryPlanRegistry;
+
+  beforeEach(() => {
+    policies = new MemoryUsePolicyRegistry();
+    policies.register(makePolicy());
+    plans = new MemoryPlanRegistry(policies);
+  });
+
+  it('accepts a plan with a known policy and matching tier', () => {
+    expect(plans.register(makePlan()).ok).toBe(true);
+  });
+
+  it('rejects plan with unknown use_policy_id', () => {
+    const r = plans.register(makePlan({
+      write_specs: [{ target_tier: MemoryTier.DECISION_SUPPORT, content_kind: 'x', use_policy_id: 'no-such' }],
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('UNKNOWN_USE_POLICY');
+  });
+
+  it('rejects plan whose write_specs.target_tier differs from the policy tier', () => {
+    const r = plans.register(makePlan({
+      write_specs: [{ target_tier: MemoryTier.CONTEXT_ONLY, content_kind: 'x', use_policy_id: 'pol-ds' }],
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('WRITE_SPEC_TIER_MISMATCH');
+  });
+
+  it('rejects plan that arrives already frozen=true', () => {
+    const r = plans.register(makePlan({ frozen: true }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('PLAN_ALREADY_FROZEN_AT_REGISTER');
+  });
+
+  it('rejects duplicate plan_id', () => {
+    expect(plans.register(makePlan()).ok).toBe(true);
+    const r = plans.register(makePlan());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('DUPLICATE_PLAN_ID');
+  });
+});
+
+describe('MemoryPlanRegistry — freeze + immutability (O5)', () => {
+  let policies: MemoryUsePolicyRegistry;
+  let plans: MemoryPlanRegistry;
+
+  beforeEach(() => {
+    policies = new MemoryUsePolicyRegistry();
+    policies.register(makePolicy());
+    plans = new MemoryPlanRegistry(policies);
+  });
+
+  it('freeze flips frozen=true; double freeze rejected', () => {
+    plans.register(makePlan());
+    const r1 = plans.freeze('plan-1');
+    expect(r1.ok).toBe(true);
+    expect(plans.isFrozen('plan-1')).toBe(true);
+
+    const r2 = plans.freeze('plan-1');
+    expect(r2.ok).toBe(false);
+    if (!r2.ok) expect(r2.code).toBe('PLAN_ALREADY_FROZEN');
+  });
+
+  it('frozen plan is deep-Object.frozen — in-place mutation throws in strict mode', () => {
+    plans.register(makePlan());
+    plans.freeze('plan-1');
+    const plan = plans.lookup('plan-1')!;
+    expect(Object.isFrozen(plan)).toBe(true);
+    expect(Object.isFrozen(plan.retrieval_specs)).toBe(true);
+    expect(Object.isFrozen(plan.assembly_order)).toBe(true);
+
+    // Assignment attempts are silently ignored OR throw depending on
+    // strict mode; we assert via isFrozen + verifying the value didn't
+    // actually change after the attempt.
+    try { (plan as unknown as { frozen: boolean }).frozen = false; } catch { /* strict mode */ }
+    expect(plan.frozen).toBe(true);
+  });
+
+  it('rejects freeze on unknown plan', () => {
+    const r = plans.freeze('nope');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('PLAN_NOT_FOUND');
+  });
+
+  it('rejects freeze on expired plan', () => {
+    plans.register(makePlan({ plan_id: 'plan-exp', expires_at: '2000-01-01T00:00:00Z' }));
+    const r = plans.freeze('plan-exp');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('PLAN_EXPIRED');
+  });
+});
+
+describe('buildFrozenSnapshot', () => {
+  function frag(tier: MemoryTier, rank: number, record_id = `r-${tier}-${rank}`): RetrievalFragment {
+    return {
+      record: {
+        record_id,
+        tier,
+        content_kind: 'x',
+        content_hash: 'sha256:' + 'b'.repeat(64),
+        source: { provider_id: 'p', layer: 1, upstream_ref: null, trace_id: 't' },
+        created_at: '2026-04-17T00:00:00Z',
+        guard_evidence: [{ evidence_id: 'ev', guard_kind: 'content-scan', verdict: 'safe' }],
+        redaction_applied: false,
+        payload: null,
+      },
+      rank_in_tier: rank,
+      match_evidence: 'why',
+    };
+  }
+
+  it('sorts strict-truth: authoritative → decision-support → context-only', () => {
+    const snap = buildFrozenSnapshot('plan-1', [
+      frag(MemoryTier.CONTEXT_ONLY, 0),
+      frag(MemoryTier.AUTHORITATIVE, 1),
+      frag(MemoryTier.DECISION_SUPPORT, 0),
+      frag(MemoryTier.AUTHORITATIVE, 0),
+    ]);
+    const tiers = snap.fragments.map((f) => f.record.tier);
+    expect(tiers).toEqual([
+      MemoryTier.AUTHORITATIVE,
+      MemoryTier.AUTHORITATIVE,
+      MemoryTier.DECISION_SUPPORT,
+      MemoryTier.CONTEXT_ONLY,
+    ]);
+    // within a tier: ascending rank_in_tier
+    expect(snap.fragments[0].rank_in_tier).toBe(0);
+    expect(snap.fragments[1].rank_in_tier).toBe(1);
+  });
+
+  it('fragments array is immutable', () => {
+    const snap = buildFrozenSnapshot('plan-1', [frag(MemoryTier.AUTHORITATIVE, 0)]);
+    expect(Object.isFrozen(snap)).toBe(true);
+    expect(Object.isFrozen(snap.fragments)).toBe(true);
+    expect(() => {
+      (snap.fragments as unknown as RetrievalFragment[]).push(frag(MemoryTier.CONTEXT_ONLY, 0));
+    }).toThrow();
+  });
+});

--- a/tests/runtime/governance/memory/record_registry.test.ts
+++ b/tests/runtime/governance/memory/record_registry.test.ts
@@ -1,0 +1,171 @@
+/**
+ * MemoryRecordRegistry tests — Sprint 6 Wave 6.1.
+ *
+ * Coverage:
+ *   - Layer 3 cannot write memory (explicit code)
+ *   - content_hash format validation
+ *   - mandatory guard_evidence / trace_id
+ *   - O3 derivation: derived record may not elevate tier
+ *   - tierRank / canDeriveTo helpers
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  MemoryRecordRegistry,
+  MemoryTier,
+  canDeriveTo,
+  tierRank,
+  type MemoryRecord,
+} from '../../../../src/runtime/governance/memory';
+
+function makeRecord(overrides: Partial<MemoryRecord> = {}): MemoryRecord {
+  return {
+    record_id: 'rec-1',
+    tier: MemoryTier.DECISION_SUPPORT,
+    content_kind: 'summary.session',
+    content_hash: 'sha256:' + 'a'.repeat(64),
+    source: {
+      provider_id: 'loamwise:align.retrieval',
+      layer: 1,
+      upstream_ref: null,
+      trace_id: 'trace-1',
+    },
+    created_at: '2026-04-17T00:00:00Z',
+    guard_evidence: [{ evidence_id: 'ev-1', guard_kind: 'content-scan', verdict: 'safe' }],
+    redaction_applied: false,
+    payload: { text: 'hello' },
+    ...overrides,
+  };
+}
+
+describe('tierRank + canDeriveTo', () => {
+  it('ranks authoritative < decision-support < context-only', () => {
+    expect(tierRank(MemoryTier.AUTHORITATIVE)).toBe(0);
+    expect(tierRank(MemoryTier.DECISION_SUPPORT)).toBe(1);
+    expect(tierRank(MemoryTier.CONTEXT_ONLY)).toBe(2);
+  });
+
+  it('canDeriveTo prevents tier elevation', () => {
+    expect(canDeriveTo(MemoryTier.DECISION_SUPPORT, MemoryTier.AUTHORITATIVE)).toBe(false);
+    expect(canDeriveTo(MemoryTier.DECISION_SUPPORT, MemoryTier.DECISION_SUPPORT)).toBe(true);
+    expect(canDeriveTo(MemoryTier.DECISION_SUPPORT, MemoryTier.CONTEXT_ONLY)).toBe(true);
+    expect(canDeriveTo(MemoryTier.CONTEXT_ONLY, MemoryTier.AUTHORITATIVE)).toBe(false);
+  });
+});
+
+describe('MemoryRecordRegistry — structural rules', () => {
+  let reg: MemoryRecordRegistry;
+  beforeEach(() => { reg = new MemoryRecordRegistry(); });
+
+  it('accepts a valid Layer 1 record', () => {
+    expect(reg.register(makeRecord()).ok).toBe(true);
+  });
+
+  it('rejects Layer 3 writer (specific code)', () => {
+    const r = reg.register(makeRecord({
+      source: { provider_id: 'products', layer: 3 as unknown as 2, upstream_ref: null, trace_id: 'trace-x' },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('LAYER_3_CANNOT_WRITE_MEMORY');
+  });
+
+  it('rejects invalid content_hash', () => {
+    const r = reg.register(makeRecord({ content_hash: 'nope' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('INVALID_CONTENT_HASH');
+  });
+
+  it('rejects empty guard_evidence', () => {
+    const r = reg.register(makeRecord({ guard_evidence: [] }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_GUARD_EVIDENCE');
+  });
+
+  it('rejects missing trace_id', () => {
+    const r = reg.register(makeRecord({
+      source: { provider_id: 'x', layer: 1, upstream_ref: null, trace_id: '' },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_TRACE_ID');
+  });
+
+  it('rejects duplicate record_id', () => {
+    expect(reg.register(makeRecord()).ok).toBe(true);
+    const r = reg.register(makeRecord());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('DUPLICATE_RECORD_ID');
+  });
+});
+
+describe('MemoryRecordRegistry — O3 derivation cannot elevate tier', () => {
+  let reg: MemoryRecordRegistry;
+  beforeEach(() => { reg = new MemoryRecordRegistry(); });
+
+  it('rejects DECISION_SUPPORT upstream → AUTHORITATIVE derived (elevation)', () => {
+    expect(reg.register(makeRecord({
+      record_id: 'parent',
+      tier: MemoryTier.DECISION_SUPPORT,
+    })).ok).toBe(true);
+    const r = reg.register(makeRecord({
+      record_id: 'derived',
+      tier: MemoryTier.AUTHORITATIVE,
+      source: {
+        provider_id: 'loamwise:align.retrieval',
+        layer: 1,
+        upstream_ref: 'parent',
+        trace_id: 'trace-2',
+      },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('DERIVATION_ELEVATES_TIER');
+  });
+
+  it('accepts same-tier derivation', () => {
+    expect(reg.register(makeRecord({
+      record_id: 'parent2',
+      tier: MemoryTier.DECISION_SUPPORT,
+    })).ok).toBe(true);
+    const r = reg.register(makeRecord({
+      record_id: 'derived2',
+      tier: MemoryTier.DECISION_SUPPORT,
+      source: {
+        provider_id: 'loamwise:align.retrieval',
+        layer: 1,
+        upstream_ref: 'parent2',
+        trace_id: 'trace-3',
+      },
+    }));
+    expect(r.ok).toBe(true);
+  });
+
+  it('accepts descent from AUTHORITATIVE to DECISION_SUPPORT', () => {
+    expect(reg.register(makeRecord({
+      record_id: 'auth-parent',
+      tier: MemoryTier.AUTHORITATIVE,
+    })).ok).toBe(true);
+    const r = reg.register(makeRecord({
+      record_id: 'desc',
+      tier: MemoryTier.DECISION_SUPPORT,
+      source: {
+        provider_id: 'loamwise:align.retrieval',
+        layer: 1,
+        upstream_ref: 'auth-parent',
+        trace_id: 'trace-4',
+      },
+    }));
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects unknown upstream_ref', () => {
+    const r = reg.register(makeRecord({
+      source: {
+        provider_id: 'x',
+        layer: 1,
+        upstream_ref: 'does-not-exist',
+        trace_id: 'trace-5',
+      },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('UNKNOWN_UPSTREAM_REF');
+  });
+});

--- a/tests/runtime/governance/memory/retrieval.test.ts
+++ b/tests/runtime/governance/memory/retrieval.test.ts
@@ -1,0 +1,132 @@
+/**
+ * validateRetrievalRequest tests — Sprint 6 Wave 6.1.
+ *
+ * Coverage:
+ *   - tiers_allowed / providers_allowed must be explicit non-empty (O7)
+ *   - strict_truth is default; balanced_recency requires audit purpose
+ *   - plan must exist, be frozen, not expired
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_QUERY_MODE,
+  MemoryPlanRegistry,
+  MemoryTier,
+  MemoryUsePolicyRegistry,
+  validateRetrievalRequest,
+  type MemoryRetrievalRequest,
+} from '../../../../src/runtime/governance/memory';
+
+function makeReq(overrides: Partial<MemoryRetrievalRequest> = {}): MemoryRetrievalRequest {
+  return {
+    request_id: 'req-1',
+    query: 'find stuff',
+    tiers_allowed: [MemoryTier.AUTHORITATIVE, MemoryTier.DECISION_SUPPORT],
+    providers_allowed: ['loamwise:align.retrieval'],
+    query_mode: 'strict_truth',
+    max_fragments_per_tier: { [MemoryTier.AUTHORITATIVE]: 5 },
+    triggered_by: { component: 'loamwise:align.orchestrator', purpose: 'decision', plan_id: 'plan-1' },
+    ...overrides,
+  };
+}
+
+describe('DEFAULT_QUERY_MODE', () => {
+  it('is strict_truth', () => {
+    expect(DEFAULT_QUERY_MODE).toBe('strict_truth');
+  });
+});
+
+describe('validateRetrievalRequest', () => {
+  let policies: MemoryUsePolicyRegistry;
+  let plans: MemoryPlanRegistry;
+
+  beforeEach(() => {
+    policies = new MemoryUsePolicyRegistry();
+    policies.register({
+      policy_id: 'pol-ds',
+      tier: MemoryTier.DECISION_SUPPORT,
+      read_allowed_for: ['decision', 'audit'],
+      write_allowed_by: [{ actor_kind: 'engine-cosign', guard_chain_required: ['content-scan'] }],
+      decision_consumers: [],
+      derivation_rule: { can_summarize_to: [MemoryTier.DECISION_SUPPORT, MemoryTier.CONTEXT_ONLY], can_index_into: [] },
+      revocation_path: 'adr://kill',
+    });
+    plans = new MemoryPlanRegistry(policies);
+    plans.register({
+      plan_id: 'plan-1',
+      intended_for: 'decision',
+      retrieval_specs: [{ provider_id: 'loamwise:align.retrieval', tiers: [MemoryTier.DECISION_SUPPORT], query_template: 'q', max_results: 10 }],
+      assembly_order: [{ step: 'system-prompt', fragments: [], fence_boundary: null }],
+      write_specs: [],
+      created_at: '2026-04-17T00:00:00Z',
+      expires_at: '2099-01-01T00:00:00Z',
+      frozen: false,
+    });
+    plans.freeze('plan-1');
+  });
+
+  it('accepts a valid strict_truth request against a frozen plan', () => {
+    expect(validateRetrievalRequest(makeReq(), plans)).toEqual({ ok: true });
+  });
+
+  it('rejects empty tiers_allowed', () => {
+    const r = validateRetrievalRequest(makeReq({ tiers_allowed: [] }), plans);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('TIERS_ALLOWED_EMPTY');
+  });
+
+  it('rejects empty providers_allowed (O7)', () => {
+    const r = validateRetrievalRequest(makeReq({ providers_allowed: [] }), plans);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('PROVIDERS_ALLOWED_EMPTY');
+  });
+
+  it('rejects invalid query_mode string', () => {
+    const r = validateRetrievalRequest(makeReq({ query_mode: 'fast' as unknown as 'strict_truth' }), plans);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('INVALID_QUERY_MODE');
+  });
+
+  it('rejects balanced_recency with purpose=decision', () => {
+    const r = validateRetrievalRequest(makeReq({
+      query_mode: 'balanced_recency',
+      triggered_by: { component: 'x', purpose: 'decision', plan_id: 'plan-1' },
+    }), plans);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('BALANCED_RECENCY_REQUIRES_AUDIT_PURPOSE');
+  });
+
+  it('accepts balanced_recency only when purpose=audit', () => {
+    const r = validateRetrievalRequest(makeReq({
+      query_mode: 'balanced_recency',
+      triggered_by: { component: 'x', purpose: 'audit', plan_id: 'plan-1' },
+    }), plans);
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects unknown plan_id', () => {
+    const r = validateRetrievalRequest(makeReq({
+      triggered_by: { component: 'x', purpose: 'decision', plan_id: 'no-such' },
+    }), plans);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('PLAN_NOT_FOUND');
+  });
+
+  it('rejects non-frozen plan', () => {
+    plans.register({
+      plan_id: 'plan-open',
+      intended_for: 'decision',
+      retrieval_specs: [],
+      assembly_order: [],
+      write_specs: [],
+      created_at: '2026-04-17T00:00:00Z',
+      expires_at: '2099-01-01T00:00:00Z',
+      frozen: false,
+    });
+    const r = validateRetrievalRequest(makeReq({
+      triggered_by: { component: 'x', purpose: 'decision', plan_id: 'plan-open' },
+    }), plans);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('PLAN_NOT_FROZEN');
+  });
+});

--- a/tests/runtime/governance/memory/use_policy.test.ts
+++ b/tests/runtime/governance/memory/use_policy.test.ts
@@ -1,0 +1,132 @@
+/**
+ * MemoryUsePolicyRegistry tests — Sprint 6 Wave 6.1.
+ *
+ * Coverage:
+ *   - §5 AUTHORITATIVE ⇒ decision_consumers non-empty
+ *   - §5 non-AUTHORITATIVE ⇒ decision_consumers empty
+ *   - O3 derivation rule may not elevate tier
+ *   - duplicate policy_id rejected
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  MemoryTier,
+  MemoryUsePolicyRegistry,
+  type MemoryUsePolicy,
+} from '../../../../src/runtime/governance/memory';
+
+function makePolicy(overrides: Partial<MemoryUsePolicy> = {}): MemoryUsePolicy {
+  return {
+    policy_id: 'pol-1',
+    tier: MemoryTier.DECISION_SUPPORT,
+    read_allowed_for: ['decision', 'context', 'audit'],
+    write_allowed_by: [
+      { actor_kind: 'engine-cosign', guard_chain_required: ['content-scan'] },
+    ],
+    decision_consumers: [],
+    derivation_rule: { can_summarize_to: [MemoryTier.DECISION_SUPPORT, MemoryTier.CONTEXT_ONLY], can_index_into: [] },
+    revocation_path: 'ADR-kill-switch',
+    ...overrides,
+  };
+}
+
+describe('MemoryUsePolicyRegistry — §5 twin invariants', () => {
+  let reg: MemoryUsePolicyRegistry;
+  beforeEach(() => { reg = new MemoryUsePolicyRegistry(); });
+
+  it('accepts AUTHORITATIVE with non-empty decision_consumers', () => {
+    const r = reg.register(makePolicy({
+      policy_id: 'pol-auth',
+      tier: MemoryTier.AUTHORITATIVE,
+      decision_consumers: ['capability.admission', 'approval'],
+      derivation_rule: { can_summarize_to: [MemoryTier.AUTHORITATIVE], can_index_into: [] },
+    }));
+    expect(r.ok).toBe(true);
+  });
+
+  it('rejects AUTHORITATIVE with empty decision_consumers', () => {
+    const r = reg.register(makePolicy({
+      policy_id: 'pol-auth-bad',
+      tier: MemoryTier.AUTHORITATIVE,
+      decision_consumers: [],
+      derivation_rule: { can_summarize_to: [MemoryTier.AUTHORITATIVE], can_index_into: [] },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('AUTHORITATIVE_MUST_DECLARE_DECISION_CONSUMERS');
+  });
+
+  it('rejects DECISION_SUPPORT with non-empty decision_consumers', () => {
+    const r = reg.register(makePolicy({
+      decision_consumers: ['approval'],
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('NON_AUTH_MUST_HAVE_EMPTY_DECISION_CONSUMERS');
+  });
+
+  it('rejects CONTEXT_ONLY with non-empty decision_consumers', () => {
+    const r = reg.register(makePolicy({
+      tier: MemoryTier.CONTEXT_ONLY,
+      decision_consumers: ['approval'],
+      derivation_rule: { can_summarize_to: [MemoryTier.CONTEXT_ONLY], can_index_into: [] },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('NON_AUTH_MUST_HAVE_EMPTY_DECISION_CONSUMERS');
+  });
+});
+
+describe('MemoryUsePolicyRegistry — O3 derivation cannot elevate', () => {
+  let reg: MemoryUsePolicyRegistry;
+  beforeEach(() => { reg = new MemoryUsePolicyRegistry(); });
+
+  it('rejects DECISION_SUPPORT policy with can_summarize_to AUTHORITATIVE', () => {
+    const r = reg.register(makePolicy({
+      derivation_rule: { can_summarize_to: [MemoryTier.AUTHORITATIVE], can_index_into: [] },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('DERIVATION_CANNOT_ELEVATE_TIER');
+  });
+
+  it('rejects CONTEXT_ONLY policy with can_index_into DECISION_SUPPORT', () => {
+    const r = reg.register(makePolicy({
+      tier: MemoryTier.CONTEXT_ONLY,
+      derivation_rule: { can_summarize_to: [MemoryTier.CONTEXT_ONLY], can_index_into: [MemoryTier.DECISION_SUPPORT] },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('DERIVATION_CANNOT_ELEVATE_TIER');
+  });
+
+  it('accepts same-tier or lower-tier derivations', () => {
+    const r = reg.register(makePolicy({
+      tier: MemoryTier.DECISION_SUPPORT,
+      derivation_rule: {
+        can_summarize_to: [MemoryTier.DECISION_SUPPORT, MemoryTier.CONTEXT_ONLY],
+        can_index_into: [MemoryTier.CONTEXT_ONLY],
+      },
+    }));
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('MemoryUsePolicyRegistry — misc guards', () => {
+  let reg: MemoryUsePolicyRegistry;
+  beforeEach(() => { reg = new MemoryUsePolicyRegistry(); });
+
+  it('rejects duplicate policy_id', () => {
+    expect(reg.register(makePolicy()).ok).toBe(true);
+    const r = reg.register(makePolicy());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('DUPLICATE_POLICY_ID');
+  });
+
+  it('rejects empty write_allowed_by', () => {
+    const r = reg.register(makePolicy({ write_allowed_by: [] }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('WRITE_ACTOR_RULES_EMPTY');
+  });
+
+  it('rejects invalid tier', () => {
+    const r = reg.register(makePolicy({ tier: 'bogus' as unknown as MemoryTier }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('INVALID_TIER');
+  });
+});

--- a/tests/runtime/governance/skill_lifecycle/candidate_submit.test.ts
+++ b/tests/runtime/governance/skill_lifecycle/candidate_submit.test.ts
@@ -1,0 +1,181 @@
+/**
+ * guardedSubmitCandidate tests — Sprint 5 Wave 5.2.
+ *
+ * Coverage:
+ *   - SHADOW guard runs + emits GuardEvidence before submit
+ *   - DANGEROUS verdict never blocks (SHADOW non-blocking invariant)
+ *   - Registry rejection still returns the guard evidence id
+ *   - Scanner failure (fail_open) still produces evidence + allows submit
+ *   - scan_results on the persisted record includes the guard evidence ref
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  CapabilityKindRegistry,
+  type CapabilityKindRegistration,
+} from '../../../../src/runtime/governance/capability';
+import {
+  AlwaysDangerousScanner,
+  GuardKind,
+  InMemoryGuardEvidenceSink,
+  NoopScanner,
+  ShadowRunner,
+  type Scanner,
+} from '../../../../src/runtime/governance/guard';
+import {
+  SkillLifecycleRegistry,
+  SkillLifecycleState,
+  TrustSource,
+  guardedSubmitCandidate,
+  type SkillCandidateRecord,
+} from '../../../../src/runtime/governance/skill_lifecycle';
+
+const KIND: CapabilityKindRegistration = {
+  kind: 'engine.write.amazon-ads-bid',
+  layer_introduced: 0,
+  contract_adr: 'ADR-OpenClaw-Capability-Boundary',
+  contract_schema: '_meta/contracts/capability/engine.write.amazon-ads-bid.schema.yaml',
+  introduced_at: '2026-04-17T00:00:00Z',
+  superseded_by: null,
+  status: 'active',
+};
+
+function makeRecord(overrides: Partial<SkillCandidateRecord> = {}): SkillCandidateRecord {
+  return {
+    candidate_id: 'cand-submit-1',
+    skill_id: 'amazon-growth-engine:bid_recommend',
+    version: '0.1.0',
+    content_hash: 'sha256:' + 'b'.repeat(64),
+    source_trace_id: 'trace-xyz',
+    source_kind: TrustSource.AGENT_GENERATED,
+    generated_by: { component: 'loamwise:learning-loop', layer: 1 },
+    created_at: '2026-04-17T00:00:00Z',
+    expires_at: null,
+    risk_class: 'low',
+    scan_results: [],
+    state: SkillLifecycleState.CANDIDATE,
+    state_changed_at: '2026-04-17T00:00:00Z',
+    capability_kind: 'engine.write.amazon-ads-bid',
+    capability_registration_id: null,
+    ...overrides,
+  };
+}
+
+class ThrowingScanner implements Scanner {
+  readonly scanner_id = 'throwing';
+  readonly scanner_version = '0.0.0';
+  readonly pattern_catalog_version = '0.0.0';
+  readonly supports_kind = GuardKind.CONTENT_SCAN;
+  async scan(): Promise<never> {
+    throw new Error('scanner-blew-up');
+  }
+}
+
+describe('guardedSubmitCandidate', () => {
+  let kinds: CapabilityKindRegistry;
+  let registry: SkillLifecycleRegistry;
+  let sink: InMemoryGuardEvidenceSink;
+
+  beforeEach(() => {
+    kinds = new CapabilityKindRegistry();
+    kinds.register(KIND);
+    registry = new SkillLifecycleRegistry(kinds);
+    sink = new InMemoryGuardEvidenceSink();
+  });
+
+  it('accepts with SAFE verdict and records guard evidence', async () => {
+    const runner = new ShadowRunner(
+      new NoopScanner(GuardKind.CONTENT_SCAN, 'noop'),
+      { sink, fail_open: true },
+    );
+    const r = await guardedSubmitCandidate(makeRecord(), {
+      runner,
+      sink,
+      registry,
+      trace_id: 'trace-xyz',
+      payload: { body: 'hello world' },
+      scanner_id: 'noop',
+    });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.guard_verdict).toBe('safe');
+      expect(r.guard_mode).toBe('shadow');
+      expect(r.guard_evidence_id).toBeTruthy();
+    }
+    expect(sink.list().length).toBe(1);
+    expect(registry.getState('cand-submit-1')).toBe(SkillLifecycleState.CANDIDATE);
+
+    // scan_results on the persisted record contains the guard evidence ref
+    const stored = registry.lookup('cand-submit-1')!;
+    expect(stored.scan_results.length).toBe(1);
+    expect(stored.scan_results[0].verdict).toBe('safe');
+  });
+
+  it('SHADOW never blocks even when scanner reports DANGEROUS', async () => {
+    const runner = new ShadowRunner(
+      new AlwaysDangerousScanner(GuardKind.CONTENT_SCAN, 'dangerous'),
+      { sink, fail_open: true },
+    );
+    const r = await guardedSubmitCandidate(makeRecord(), {
+      runner,
+      sink,
+      registry,
+      trace_id: 'trace-xyz',
+      payload: 'suspicious',
+      scanner_id: 'dangerous',
+    });
+
+    expect(r.ok).toBe(true);        // SHADOW never blocks
+    if (r.ok) {
+      expect(r.guard_verdict).toBe('dangerous');
+    }
+    expect(sink.list().length).toBe(1);
+    expect(sink.list()[0].verdict).toBe('dangerous');
+    expect(registry.getState('cand-submit-1')).toBe(SkillLifecycleState.CANDIDATE);
+  });
+
+  it('returns registry failure but still reports guard evidence id', async () => {
+    const runner = new ShadowRunner(
+      new NoopScanner(GuardKind.CONTENT_SCAN, 'noop'),
+      { sink, fail_open: true },
+    );
+    // Unknown capability_kind — registry will reject after guard runs.
+    const r = await guardedSubmitCandidate(
+      makeRecord({ capability_kind: 'engine.write.not-registered' }),
+      {
+        runner,
+        sink,
+        registry,
+        trace_id: 'trace-xyz',
+        payload: 'x',
+        scanner_id: 'noop',
+      },
+    );
+
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('UNKNOWN_CAPABILITY_KIND');
+      expect(r.guard_evidence_id).toBeTruthy();
+      expect(r.guard_verdict).toBe('safe');
+    }
+    // Guard evidence is still written even when lifecycle rejects.
+    expect(sink.list().length).toBe(1);
+  });
+
+  it('scanner exception is swallowed by fail_open and candidate still submits', async () => {
+    const runner = new ShadowRunner(new ThrowingScanner(), { sink, fail_open: true });
+    const r = await guardedSubmitCandidate(makeRecord(), {
+      runner,
+      sink,
+      registry,
+      trace_id: 'trace-xyz',
+      payload: 'x',
+      scanner_id: 'throwing',
+    });
+
+    expect(r.ok).toBe(true);
+    expect(sink.list().length).toBe(1);
+    expect(sink.list()[0].scanner_failed).toBe(true);
+  });
+});

--- a/tests/runtime/governance/skill_lifecycle/registry.test.ts
+++ b/tests/runtime/governance/skill_lifecycle/registry.test.ts
@@ -1,0 +1,337 @@
+/**
+ * SkillLifecycleRegistry tests — Sprint 5 Wave 5.1.
+ *
+ * Coverage:
+ *   - submitCandidate enforces L2/L6/L7 + CapabilityKind admission
+ *   - applyPromotion enforces L1 whitelist, L3 approvers + signature,
+ *     L4 safe-scan requirement, QUARANTINED release block
+ *   - applyQuarantine enforces L1 whitelist + decided_by.signature
+ *   - REVOKED is terminal
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  CapabilityKindRegistry,
+  type CapabilityKindRegistration,
+} from '../../../../src/runtime/governance/capability';
+import {
+  ALLOWED_TRANSITIONS,
+  QuarantineReason,
+  SkillLifecycleRegistry,
+  SkillLifecycleState,
+  TrustSource,
+  type PromotionDecision,
+  type QuarantineDecision,
+  type SkillCandidateRecord,
+} from '../../../../src/runtime/governance/skill_lifecycle';
+
+const KIND: CapabilityKindRegistration = {
+  kind: 'engine.write.amazon-ads-bid',
+  layer_introduced: 0,
+  contract_adr: 'ADR-OpenClaw-Capability-Boundary',
+  contract_schema: '_meta/contracts/capability/engine.write.amazon-ads-bid.schema.yaml',
+  introduced_at: '2026-04-17T00:00:00Z',
+  superseded_by: null,
+  status: 'active',
+};
+
+function makeRecord(overrides: Partial<SkillCandidateRecord> = {}): SkillCandidateRecord {
+  return {
+    candidate_id: 'cand-001',
+    skill_id: 'amazon-growth-engine:bid_recommend',
+    version: '0.1.0',
+    content_hash: 'sha256:' + 'a'.repeat(64),
+    source_trace_id: 'trace-abc',
+    source_kind: TrustSource.AGENT_GENERATED,
+    generated_by: { component: 'loamwise:learning-loop', layer: 1 },
+    created_at: '2026-04-17T00:00:00Z',
+    expires_at: null,
+    risk_class: 'low',
+    scan_results: [],
+    state: SkillLifecycleState.CANDIDATE,
+    state_changed_at: '2026-04-17T00:00:00Z',
+    capability_kind: 'engine.write.amazon-ads-bid',
+    capability_registration_id: null,
+    ...overrides,
+  };
+}
+
+function makePromotion(overrides: Partial<PromotionDecision> = {}): PromotionDecision {
+  return {
+    decision_id: 'promo-1',
+    candidate_id: 'cand-001',
+    from_state: SkillLifecycleState.CANDIDATE,
+    to_state: SkillLifecycleState.ACTIVE,
+    decided_at: '2026-04-17T01:00:00Z',
+    approvers: [
+      {
+        approver_kind: 'human-maintainer',
+        approver_id: 'liye',
+        approved_at: '2026-04-17T01:00:00Z',
+        evidence_ref: 'pr://example/1',
+      },
+    ],
+    scan_evidence: [
+      { scanner_id: 'stub', scanned_at: '2026-04-17T00:30:00Z', verdict: 'safe', evidence_path: 'ev-safe' },
+    ],
+    policy_evaluations: [],
+    rollback_policy: { on_drift_detected: 'auto-quarantine', on_kill_switch: 'auto-revoke' },
+    decided_by: { actor_id: 'liye', actor_kind: 'human', signature: 'hmac-abc' },
+    ...overrides,
+  };
+}
+
+function makeQuarantine(overrides: Partial<QuarantineDecision> = {}): QuarantineDecision {
+  return {
+    decision_id: 'quar-1',
+    candidate_id: 'cand-001',
+    from_state: SkillLifecycleState.CANDIDATE,
+    to_state: SkillLifecycleState.QUARANTINED,
+    reason: QuarantineReason.SCAN_CAUTION,
+    reason_detail: 'caution from shadow guard',
+    reason_evidence: ['ev-caution'],
+    decided_at: '2026-04-17T02:00:00Z',
+    release_blocked_until: null,
+    decided_by: { actor_id: 'policy', actor_kind: 'policy-engine', signature: 'hmac-z' },
+    ...overrides,
+  };
+}
+
+describe('ALLOWED_TRANSITIONS whitelist', () => {
+  it('REVOKED is terminal', () => {
+    expect(ALLOWED_TRANSITIONS[SkillLifecycleState.REVOKED]).toEqual([]);
+  });
+
+  it('ACTIVE can only go to DEPRECATED or QUARANTINED', () => {
+    expect(ALLOWED_TRANSITIONS[SkillLifecycleState.ACTIVE]).toEqual([
+      SkillLifecycleState.DEPRECATED,
+      SkillLifecycleState.QUARANTINED,
+    ]);
+  });
+
+  it('QUARANTINED can only re-enter CANDIDATE or REVOKED (no direct ACTIVE)', () => {
+    const allowed = ALLOWED_TRANSITIONS[SkillLifecycleState.QUARANTINED];
+    expect(allowed).toContain(SkillLifecycleState.CANDIDATE);
+    expect(allowed).toContain(SkillLifecycleState.REVOKED);
+    expect(allowed).not.toContain(SkillLifecycleState.ACTIVE);
+  });
+});
+
+describe('SkillLifecycleRegistry.submitCandidate', () => {
+  let kinds: CapabilityKindRegistry;
+  let reg: SkillLifecycleRegistry;
+
+  beforeEach(() => {
+    kinds = new CapabilityKindRegistry();
+    kinds.register(KIND);
+    reg = new SkillLifecycleRegistry(kinds);
+  });
+
+  it('accepts a valid candidate', () => {
+    const r = reg.submitCandidate(makeRecord());
+    expect(r.ok).toBe(true);
+    expect(reg.getState('cand-001')).toBe(SkillLifecycleState.CANDIDATE);
+  });
+
+  it('rejects DRAFT initial state (L2)', () => {
+    const r = reg.submitCandidate(makeRecord({ state: SkillLifecycleState.DRAFT }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('INITIAL_STATE_MUST_BE_CANDIDATE');
+  });
+
+  it('rejects ACTIVE initial state (L2 — no shortcut to ACTIVE)', () => {
+    const r = reg.submitCandidate(makeRecord({ state: SkillLifecycleState.ACTIVE }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('INITIAL_STATE_MUST_BE_CANDIDATE');
+  });
+
+  it('rejects missing source_trace_id (L6)', () => {
+    const r = reg.submitCandidate(makeRecord({ source_trace_id: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_PROVENANCE');
+  });
+
+  it('rejects missing content_hash (L6)', () => {
+    const r = reg.submitCandidate(makeRecord({ content_hash: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_PROVENANCE');
+  });
+
+  it('rejects malformed content_hash (L6)', () => {
+    const r = reg.submitCandidate(makeRecord({ content_hash: 'not-a-sha' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('INVALID_CONTENT_HASH');
+  });
+
+  it('rejects Layer 0 candidate producer (L7)', () => {
+    const r = reg.submitCandidate(makeRecord({
+      generated_by: { component: 'liye_os:anything', layer: 0 as unknown as 1 },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('LAYER_0_CANNOT_PRODUCE_CANDIDATE');
+  });
+
+  it('rejects unknown capability_kind (L7 + P1-a B1)', () => {
+    const r = reg.submitCandidate(makeRecord({ capability_kind: 'engine.write.not-registered' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('UNKNOWN_CAPABILITY_KIND');
+  });
+
+  it('rejects duplicate candidate_id', () => {
+    expect(reg.submitCandidate(makeRecord()).ok).toBe(true);
+    const r = reg.submitCandidate(makeRecord());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('DUPLICATE_CANDIDATE_ID');
+  });
+});
+
+describe('SkillLifecycleRegistry.applyPromotion', () => {
+  let kinds: CapabilityKindRegistry;
+  let reg: SkillLifecycleRegistry;
+
+  beforeEach(() => {
+    kinds = new CapabilityKindRegistry();
+    kinds.register(KIND);
+    reg = new SkillLifecycleRegistry(kinds);
+    reg.submitCandidate(makeRecord());
+  });
+
+  it('promotes CANDIDATE → ACTIVE with safe scan + approver + signature', () => {
+    const r = reg.applyPromotion(makePromotion());
+    expect(r.ok).toBe(true);
+    expect(reg.getState('cand-001')).toBe(SkillLifecycleState.ACTIVE);
+  });
+
+  it('rejects from_state mismatch', () => {
+    const r = reg.applyPromotion(makePromotion({ from_state: SkillLifecycleState.ACTIVE }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('FROM_STATE_MISMATCH');
+  });
+
+  it('rejects illegal transition (CANDIDATE → DEPRECATED)', () => {
+    const r = reg.applyPromotion(makePromotion({ to_state: SkillLifecycleState.DEPRECATED }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('ILLEGAL_TRANSITION');
+  });
+
+  it('rejects missing approvers (L3)', () => {
+    const r = reg.applyPromotion(makePromotion({ approvers: [] }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_APPROVERS');
+  });
+
+  it('rejects empty signature (L3)', () => {
+    const r = reg.applyPromotion(makePromotion({
+      decided_by: { actor_id: 'x', actor_kind: 'human', signature: '' },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_SIGNATURE');
+  });
+
+  it('rejects missing scan evidence on ACTIVE promotion (L4)', () => {
+    const r = reg.applyPromotion(makePromotion({ scan_evidence: [] }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_SCAN_EVIDENCE');
+  });
+
+  it('rejects scan evidence without any safe verdict (L4)', () => {
+    const r = reg.applyPromotion(makePromotion({
+      scan_evidence: [
+        { scanner_id: 'x', scanned_at: '2026-04-17T00:00:00Z', verdict: 'caution', evidence_path: 'ev' },
+      ],
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('SCAN_EVIDENCE_NOT_SAFE');
+  });
+
+  it('rejects promotion for unknown candidate', () => {
+    const r = reg.applyPromotion(makePromotion({ candidate_id: 'nonexistent' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('CANDIDATE_NOT_FOUND');
+  });
+});
+
+describe('SkillLifecycleRegistry.applyQuarantine', () => {
+  let kinds: CapabilityKindRegistry;
+  let reg: SkillLifecycleRegistry;
+
+  beforeEach(() => {
+    kinds = new CapabilityKindRegistry();
+    kinds.register(KIND);
+    reg = new SkillLifecycleRegistry(kinds);
+    reg.submitCandidate(makeRecord());
+  });
+
+  it('quarantines CANDIDATE', () => {
+    const r = reg.applyQuarantine(makeQuarantine());
+    expect(r.ok).toBe(true);
+    expect(reg.getState('cand-001')).toBe(SkillLifecycleState.QUARANTINED);
+  });
+
+  it('blocks QUARANTINED → CANDIDATE re-admission when release_blocked_until is in the future', () => {
+    const future = '2099-01-01T00:00:00Z';
+    const q = reg.applyQuarantine(makeQuarantine({ release_blocked_until: future }));
+    expect(q.ok).toBe(true);
+    const p = reg.applyPromotion(makePromotion({
+      from_state: SkillLifecycleState.QUARANTINED,
+      to_state: SkillLifecycleState.CANDIDATE,
+    }));
+    expect(p.ok).toBe(false);
+    if (!p.ok) expect(p.code).toBe('QUARANTINE_RELEASE_BLOCKED');
+  });
+
+  it('allows QUARANTINED → CANDIDATE once release_blocked_until has passed', () => {
+    reg.applyQuarantine(makeQuarantine({ release_blocked_until: '2000-01-01T00:00:00Z' }));
+    const p = reg.applyPromotion(makePromotion({
+      from_state: SkillLifecycleState.QUARANTINED,
+      to_state: SkillLifecycleState.CANDIDATE,
+    }));
+    expect(p.ok).toBe(true);
+    expect(reg.getState('cand-001')).toBe(SkillLifecycleState.CANDIDATE);
+  });
+
+  it('rejects quarantine with empty signature', () => {
+    const r = reg.applyQuarantine(makeQuarantine({
+      decided_by: { actor_id: 'x', actor_kind: 'human', signature: '' },
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('MISSING_SIGNATURE');
+  });
+
+  it('rejects illegal quarantine (REVOKED → QUARANTINED)', () => {
+    // Drive to REVOKED via QUARANTINED → REVOKED path
+    reg.applyQuarantine(makeQuarantine());
+    reg.applyQuarantine(makeQuarantine({
+      from_state: SkillLifecycleState.QUARANTINED,
+      to_state: SkillLifecycleState.REVOKED,
+    }));
+    expect(reg.getState('cand-001')).toBe(SkillLifecycleState.REVOKED);
+
+    const r = reg.applyQuarantine(makeQuarantine({
+      from_state: SkillLifecycleState.REVOKED,
+      to_state: SkillLifecycleState.QUARANTINED,
+    }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('REVOKED_IS_TERMINAL');
+  });
+});
+
+describe('Transitions are append-only (audit chain)', () => {
+  it('records each accepted transition in order', () => {
+    const kinds = new CapabilityKindRegistry();
+    kinds.register(KIND);
+    const reg = new SkillLifecycleRegistry(kinds);
+    reg.submitCandidate(makeRecord());
+
+    reg.applyPromotion(makePromotion());                          // → ACTIVE
+    reg.applyQuarantine(makeQuarantine({                          // → QUARANTINED
+      from_state: SkillLifecycleState.ACTIVE,
+    }));
+
+    const chain = reg.transitions().getChain('cand-001');
+    expect(chain.length).toBe(2);
+    expect(chain[0].to_state).toBe(SkillLifecycleState.ACTIVE);
+    expect(chain[1].to_state).toBe(SkillLifecycleState.QUARANTINED);
+    expect(reg.transitions().verifyChain('cand-001')).toEqual({ ok: true });
+  });
+});

--- a/tests/runtime/governance/skill_lifecycle/transition_log.test.ts
+++ b/tests/runtime/governance/skill_lifecycle/transition_log.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Skill Lifecycle TransitionLog tests — Sprint 5 Wave 5.1.
+ *
+ * Coverage:
+ *   - canonicalJson produces stable output under key reordering
+ *   - TransitionLog.append assigns prev_transition_id and entry_hash
+ *   - verifyChain catches tampered entry_hash and prev mismatch
+ *   - Per-candidate chains are independent (no global single chain)
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  TransitionLog,
+  canonicalJson,
+  SkillLifecycleState,
+  type LifecycleDriver,
+  type PromotionDecision,
+  type QuarantineDecision,
+} from '../../../../src/runtime/governance/skill_lifecycle';
+import { QuarantineReason } from '../../../../src/runtime/governance/skill_lifecycle';
+
+function promoDriver(decision_id: string): LifecycleDriver {
+  const d: PromotionDecision = {
+    decision_id,
+    candidate_id: 'c1',
+    from_state: SkillLifecycleState.CANDIDATE,
+    to_state: SkillLifecycleState.ACTIVE,
+    decided_at: '2026-04-17T00:00:00Z',
+    approvers: [
+      {
+        approver_kind: 'human-maintainer',
+        approver_id: 'liye',
+        approved_at: '2026-04-17T00:00:00Z',
+        evidence_ref: 'pr://example',
+      },
+    ],
+    scan_evidence: [
+      { scanner_id: 'stub', scanned_at: '2026-04-17T00:00:00Z', verdict: 'safe', evidence_path: 'ev-1' },
+    ],
+    policy_evaluations: [],
+    rollback_policy: { on_drift_detected: 'auto-quarantine', on_kill_switch: 'auto-revoke' },
+    decided_by: { actor_id: 'liye', actor_kind: 'human', signature: 'hmac-abc' },
+  };
+  return { kind: 'promotion', decision: d };
+}
+
+function quarantineDriver(decision_id: string): LifecycleDriver {
+  const d: QuarantineDecision = {
+    decision_id,
+    candidate_id: 'c1',
+    from_state: SkillLifecycleState.CANDIDATE,
+    to_state: SkillLifecycleState.QUARANTINED,
+    reason: QuarantineReason.SCAN_CAUTION,
+    reason_detail: 'caution-from-shadow',
+    reason_evidence: [],
+    decided_at: '2026-04-17T00:00:00Z',
+    release_blocked_until: null,
+    decided_by: { actor_id: 'policy-engine', actor_kind: 'policy-engine', signature: 'hmac-xyz' },
+  };
+  return { kind: 'quarantine', decision: d };
+}
+
+describe('canonicalJson', () => {
+  it('produces identical output regardless of key order', () => {
+    const a = canonicalJson({ b: 1, a: 2, c: [3, { z: 1, a: 2 }] });
+    const b = canonicalJson({ c: [3, { a: 2, z: 1 }], a: 2, b: 1 });
+    expect(a).toBe(b);
+  });
+
+  it('stringifies primitives natively', () => {
+    expect(canonicalJson(null)).toBe('null');
+    expect(canonicalJson('x')).toBe('"x"');
+    expect(canonicalJson(3)).toBe('3');
+  });
+});
+
+describe('TransitionLog.append + verifyChain', () => {
+  it('chains entries: prev_transition_id points at prior id', () => {
+    const log = new TransitionLog();
+    const e1 = log.append({
+      candidate_id: 'c1',
+      from_state: SkillLifecycleState.CANDIDATE,
+      to_state: SkillLifecycleState.ACTIVE,
+      driver: promoDriver('d1'),
+    });
+    expect(e1.prev_transition_id).toBeNull();
+
+    const e2 = log.append({
+      candidate_id: 'c1',
+      from_state: SkillLifecycleState.ACTIVE,
+      to_state: SkillLifecycleState.QUARANTINED,
+      driver: quarantineDriver('d2'),
+    });
+    expect(e2.prev_transition_id).toBe(e1.transition_id);
+    expect(log.tip('c1')).toBe(e2.transition_id);
+  });
+
+  it('verifyChain returns ok for untouched chain', () => {
+    const log = new TransitionLog();
+    log.append({
+      candidate_id: 'c1',
+      from_state: SkillLifecycleState.CANDIDATE,
+      to_state: SkillLifecycleState.ACTIVE,
+      driver: promoDriver('d1'),
+    });
+    log.append({
+      candidate_id: 'c1',
+      from_state: SkillLifecycleState.ACTIVE,
+      to_state: SkillLifecycleState.QUARANTINED,
+      driver: quarantineDriver('d2'),
+    });
+    expect(log.verifyChain('c1')).toEqual({ ok: true });
+  });
+
+  it('verifyChain detects tampered entry_hash', () => {
+    const log = new TransitionLog();
+    log.append({
+      candidate_id: 'c1',
+      from_state: SkillLifecycleState.CANDIDATE,
+      to_state: SkillLifecycleState.ACTIVE,
+      driver: promoDriver('d1'),
+    });
+    const chain = log.getChain('c1');
+    // Cast away readonly for the test; production code never does this.
+    (chain as unknown as { entry_hash: string }[])[0].entry_hash = 'tampered';
+    const r = log.verifyChain('c1');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/entry_hash/);
+  });
+
+  it('verifyChain detects tampered prev_transition_id', () => {
+    const log = new TransitionLog();
+    log.append({
+      candidate_id: 'c1',
+      from_state: SkillLifecycleState.CANDIDATE,
+      to_state: SkillLifecycleState.ACTIVE,
+      driver: promoDriver('d1'),
+    });
+    log.append({
+      candidate_id: 'c1',
+      from_state: SkillLifecycleState.ACTIVE,
+      to_state: SkillLifecycleState.QUARANTINED,
+      driver: quarantineDriver('d2'),
+    });
+    const chain = log.getChain('c1');
+    (chain as unknown as { prev_transition_id: string }[])[1].prev_transition_id = 'bogus';
+    const r = log.verifyChain('c1');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.at).toBe(1);
+  });
+
+  it('per-candidate chains are independent', () => {
+    const log = new TransitionLog();
+    log.append({
+      candidate_id: 'c1',
+      from_state: SkillLifecycleState.CANDIDATE,
+      to_state: SkillLifecycleState.ACTIVE,
+      driver: promoDriver('d-a'),
+    });
+    log.append({
+      candidate_id: 'c2',
+      from_state: SkillLifecycleState.CANDIDATE,
+      to_state: SkillLifecycleState.ACTIVE,
+      driver: promoDriver('d-b'),
+    });
+    expect(log.getChain('c1').length).toBe(1);
+    expect(log.getChain('c2').length).toBe(1);
+    // Neither chain's first entry points at the other's tip.
+    expect(log.getChain('c1')[0].prev_transition_id).toBeNull();
+    expect(log.getChain('c2')[0].prev_transition_id).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
BGHS governance runtime — 4 sibling subsystems (G/G/C/S/M ⇒ Guard, Capability, Skill Lifecycle, Memory) landed in their commit-order. Sprint 2 Wave 2.x scope.

All 4 are new modules under `src/runtime/governance/`; no existing code touched. Tests 170/170 across the full governance tree.

## Commits (4, in dependency order)

**1. `feat(guard)`** — Guard runtime skeleton with SHADOW-only runner
- `src/runtime/governance/guard/` — types, chain registry, evidence buffer, shadow runner, barrel
- 21 tests
- Foundation for the next 3 — they all wire into Guard

**2. `feat(capability)`** — BGHS CapabilityRegistry with kind + decision plane
- `src/runtime/governance/capability/` — kind registry, capability registry, types, README, barrel
- Lays the kind-based capability lookup that the orchestrator (already on main from #129) plugs into later

**3. `feat(skill_lifecycle)`** — BGHS skill lifecycle state machine + Guard wire to candidate_submit
- `src/runtime/governance/skill_lifecycle/` — registry, transition log, candidate-submit wire, types, README, barrel
- 3 test files (registry / transition_log / candidate_submit)
- First Guard wire-in: candidate_submit posts a SHADOW evidence record per submission

**4. `feat(memory)`** — BGHS memory governance surface + Guard wire-2
- `src/runtime/governance/memory/` — plan_registry, record_registry, use_policy_registry, retrieval, snapshot, guard_wire, types, README, barrel
- 5 test files (guard_wire / plan_registry / record_registry / retrieval / use_policy)
- Second Guard wire-in: memory ops emit SHADOW evidence

## Verification
- `npx vitest run tests/runtime/governance` — **170/170 pass** across 12 test files (session 15 + wake 22 + guard 21 + capability tests + skill_lifecycle 30 + memory 52)
- No existing files touched; no overlap with PRs 1–5

## Test plan
- [ ] `Test (18/20/22)` green
- [ ] `Layer Dependency Check` green (all imports stay within Layer 0 / governance subtree)
- [ ] `Architecture Check` / `architecture-gate` green
- [ ] `governance_kernel_regression` green
- [ ] `Memory Governance Gate (SSOT)` / `memory` green
- [ ] `env-hygiene-gate` green (new gate from #132 — should pass since these files don't read env)
- [ ] `Lint` / `Phase 1 Contracts Validation` green

6/8 in the topic-decomposition sequence (#127 → #128 → #129 → #130 → #131 → #132 → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)