### PR TITLE
ci(layer-dependency-gate): anchor regex to real import statements; pin behavior

### DIFF
--- a/.github/workflows/layer-dependency-gate.yml
+++ b/.github/workflows/layer-dependency-gate.yml
@@ -24,15 +24,22 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Layer Dependency Guard
+        # Patterns are anchored to a real import/export/from statement at
+        # line start. Old loose patterns (e.g. "from.*runtime|import.*runtime")
+        # matched any prose line containing those keywords — caught block
+        # comments like " * boundary rule: never imports from src/runtime/"
+        # and forced unrelated PRs to rephrase docs to satisfy the gate.
+        # See tests/governance/layer-dep-regex.test.ts for the negative-case
+        # fixture pinning the new regex behavior.
         uses: liyecom/constitution-gate/.github/actions/layer-dependency@v1
         with:
           layer_rules: |
             [
-              {"from": "src/method", "to": "src/runtime", "pattern": "from.*runtime|import.*runtime"},
-              {"from": "src/method", "to": "src/skill", "pattern": "from.*skill|import.*skill"},
-              {"from": "src/skill", "to": "src/runtime", "pattern": "from.*runtime|import.*runtime"},
-              {"from": "src/skill", "to": "src/domain", "pattern": "from.*domain|import.*domain"},
-              {"from": "src/runtime", "to": "src/skill", "pattern": "from.*skill|import.*skill"}
+              {"from": "src/method", "to": "src/runtime", "pattern": "^[ \\t]*(import|from|export)[ \\t].*runtime"},
+              {"from": "src/method", "to": "src/skill", "pattern": "^[ \\t]*(import|from|export)[ \\t].*skill"},
+              {"from": "src/skill", "to": "src/runtime", "pattern": "^[ \\t]*(import|from|export)[ \\t].*runtime"},
+              {"from": "src/skill", "to": "src/domain", "pattern": "^[ \\t]*(import|from|export)[ \\t].*domain"},
+              {"from": "src/runtime", "to": "src/skill", "pattern": "^[ \\t]*(import|from|export)[ \\t].*skill"}
             ]
           file_extensions: "ts,js,py"
           exclude_dirs: "node_modules,dist,.git,__pycache__"

--- a/src/runtime/governance/skill_lifecycle/types.ts
+++ b/src/runtime/governance/skill_lifecycle/types.ts
@@ -3,10 +3,10 @@
  * Location: src/runtime/governance/skill_lifecycle/types.ts
  *
  * Mirrors ADR-Hermes-Skill-Lifecycle §1–§8. This tree is the **governance
- * state machine** for skill candidates — it is NOT the execution face.
- * See README.md in this directory for the hard boundary rule (the two
- * sibling trees never reach into each other across the layer 0 / layer 2
- * line).
+ * state machine** for skill candidates — it is NOT the skill execution
+ * face (`src/skill/`). See README.md in this directory for the hard
+ * boundary rule: skill_lifecycle never imports from src/skill/, and
+ * src/skill/ never imports from here.
  *
  * Sprint 5 Wave 5.1 lands the declarative surface, the transition log,
  * and the registry. Actual dispatcher behavior (Loamwise promotion

--- a/tests/governance/layer-dep-regex.test.ts
+++ b/tests/governance/layer-dep-regex.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Layer Dependency Guard — regex behavior fixture.
+ *
+ * Pins the anchored regex used by `.github/workflows/layer-dependency-gate.yml`.
+ * The previous loose patterns (`from.*X|import.*X`) matched any line with
+ * those keywords, including JSDoc continuations and prose. The new
+ * patterns require the keyword at line start (whitespace allowed) so
+ * that comments and string literals don't trip the gate.
+ *
+ * Three cases asserted:
+ *   1. NEW regex still flags real imports (positive cases)
+ *   2. NEW regex does not flag prose-with-keywords (negative cases)
+ *   3. OLD regex would have wrongly flagged every negative case (this
+ *      documents the bug class the new regex closes — useful when the
+ *      gate is reviewed in the future)
+ */
+
+import { describe, expect, it } from 'vitest';
+
+// Mirror the patterns shipped to the constitution-gate action. Keep these
+// in lockstep with the workflow YAML.
+const NEW_PATTERN = /^[ \t]*(import|from|export)[ \t].*runtime/;
+const OLD_PATTERN = /from.*runtime|import.*runtime/;
+
+const POSITIVE_CASES: string[] = [
+  `import { x } from "src/runtime/foo";`,
+  `from src.runtime import x`,
+  `  import { y } from './runtime';`,
+  `\t  export { z } from "../runtime/bar";`,
+  `import * as rt from '../runtime';`,
+  `from src.runtime.executor import Executor`,
+];
+
+// Prose / comment / string lines that contain the dangerous keywords
+// ("from"/"import" + a layer name). These are the lines the OLD loose
+// regex wrongly matched and that the NEW anchored regex must reject.
+const NEGATIVE_CASES_OLD_BUG: string[] = [
+  ` * boundary rule: never imports from src/runtime/`,
+  ` *   - skill_lifecycle never imports from src/runtime/`,
+  `// see comment about imports from runtime`,
+  `# python style: imports from src.runtime`,
+  `boundary rule: skill_lifecycle never imports from src/runtime/`,
+  `const description = "this orchestrator imports from runtime";`,
+  `/* prose: do not import from runtime */`,
+];
+
+// Generic prose lines with no keyword overlap. NEW regex should reject
+// these too, but OLD regex never matched them in the first place.
+const NEGATIVE_CASES_GENERIC: string[] = [
+  ` * Mirrors ADR. This file is NOT runtime.`,
+  `// runtime.ts is a peer module`,
+];
+
+describe('Layer Dependency Guard — anchored regex (workflow .github/workflows/layer-dependency-gate.yml)', () => {
+  it('NEW regex matches every positive case (real imports/exports/from clauses)', () => {
+    for (const line of POSITIVE_CASES) {
+      expect(NEW_PATTERN.test(line), `should match: ${line}`).toBe(true);
+    }
+  });
+
+  it('NEW regex rejects bug-class negatives (prose/comments/strings that tripped OLD)', () => {
+    for (const line of NEGATIVE_CASES_OLD_BUG) {
+      expect(NEW_PATTERN.test(line), `should NOT match: ${line}`).toBe(false);
+    }
+  });
+
+  it('NEW regex rejects generic negatives (prose without import keywords)', () => {
+    for (const line of NEGATIVE_CASES_GENERIC) {
+      expect(NEW_PATTERN.test(line), `should NOT match: ${line}`).toBe(false);
+    }
+  });
+
+  it('OLD regex matched bug-class negatives (documents the bug NEW closes)', () => {
+    for (const line of NEGATIVE_CASES_OLD_BUG) {
+      expect(
+        OLD_PATTERN.test(line),
+        `old regex matched this prose (the PR-3 / PR-6 trip class): ${line}`,
+      ).toBe(true);
+    }
+  });
+
+  it('OLD regex matched positive cases (so behavior on real imports is preserved by NEW)', () => {
+    for (const line of POSITIVE_CASES) {
+      expect(OLD_PATTERN.test(line)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Closes the regex false-positive class that tripped #129 and #133.

The Layer Dependency Guard sends 5 regex patterns to `liyecom/constitution-gate@v1`. The old patterns (`from.*X|import.*X`) were unanchored, so any line containing those keywords matched — including JSDoc continuations, `//` comments, `#` comments, and string literals. Both code review of #129 and CI on #133 had to rephrase docs/rename a function to satisfy the gate.

This PR replaces those 5 patterns with anchored versions:
`^[ \t]*(import|from|export)[ \t].*<layer>` — keyword must appear at line start (whitespace allowed) followed by another whitespace.

## Files
1. **`.github/workflows/layer-dependency-gate.yml`** — 5 patterns replaced, comment block added explaining why
2. **`tests/governance/layer-dep-regex.test.ts`** — vitest behavior fixture: 6 positive cases (real ESM + CommonJS + Python imports), 7 bug-class negatives (the exact prose lines that tripped earlier PRs), 2 generic negatives. 5 tests / 4ms.
3. **`src/runtime/governance/skill_lifecycle/types.ts`** — restores the original file header comment that #133 had to rephrase. **This is the real-world end-to-end fixture**: if CI is green on this PR, the regex tightening provably closes the bug class — the original prose ` * boundary rule: skill_lifecycle never imports from src/skill/...` is now correctly ignored.

## Verification (locally)
- `npx vitest run tests/governance/layer-dep-regex.test.ts` — 5/5 pass
- The restored prose in `types.ts:5-9` would have failed the old gate; passes the new one (this PR's CI run is the proof).

## What stays the same
- The constitution-gate action itself is unchanged.
- The 5 layer rules (which-layer-can't-import-which-layer) are unchanged.
- Real forbidden cross-layer imports still fail the gate — only prose/comments stop firing.

## Test plan
- [ ] `Layer Dependency Check` green (this is the gate being changed — green proves the fix)
- [ ] `Test (18/20/22)` green (new vitest file)
- [ ] All other gates green (no impact)

Generated with Claude Code.