### PR TITLE
fix(0b-parser): envelope contract conformance — parser_version + scope_covered + disk_duplicate_records_count (1.0.1)

### DIFF
--- a/tools/phase-0b-parser/CHANGELOG.md
+++ b/tools/phase-0b-parser/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to phase-0b-parser. SSOT: `PHASE-0B-SPEC.md` v3.
 
+## [1.0.1] - 2026-05-23 — Group 0 envelope conformance fix
+
+Surfaced during v3→v4 SPEC ceremony prep. M6 envelope was missing 3
+SPEC-required fields. Pure additive impl-side fix — no SPEC change, no
+breaking change for existing consumers.
+
+### Added
+
+- `envelope.parser_version` (per SPEC §5.1 line 121) — emits `__version__`
+  string. Critical for §9 line 428 "0B↔0C envelope compatibility contract".
+- `envelope.scope_covered` (per SPEC §5.1 lines 123-133) — 9-item list
+  declaring the parser's coverage surface (user_claude_json, repo_claude_json,
+  envstar, envrc, medusa_db_api_key, admin_credential_registry_framework,
+  ghost_orphan_live_classification, multi_consumer_sync,
+  disk_duplicate_detection). Module-level `SCOPE_COVERED` constant.
+- `summary.disk_duplicate_records_count` (per SPEC §5.4 line 215) —
+  count of records whose `disk_duplicate_paths` is non-empty.
+- 5 new pytest cases under `TestEnvelopeConformance` covering all 3 fields
+  (parser_version matches `__version__` + literal `0B-1.0.1` /
+  scope_covered exact list / disk_duplicate_records_count: zero / single /
+  multi-record).
+
+### Changed
+
+- Version `0B-1.0.0` → `0B-1.0.1` (`__init__.py` `__version__`,
+  `pyproject.toml` `version` synced).
+- `test_round_trip_envelope_shape` extended to assert the 2 new envelope
+  fields exist with correct values (regression coverage for SPEC §5.1
+  required envelope shape).
+
+### Rationale
+
+V4 ceremony prep verification (2026-05-23) revealed 3 impl-side gaps where
+M6 was missing SPEC-required fields. Choosing impl-align over SPEC-drop
+preserves 0C handoff envelope check capability. This patch is intentionally
+narrow — only `report_sealed_registry.py` + `__init__.py` + `pyproject.toml`
++ tests. No SPEC modification, no PR #138 work, no Phase 0B-2 planning.
+
+After this patch lands, v4 SPEC ceremony resumes with 3 fewer Behavior
+Divergence drifts (D14a / D14b / D18d closed via conformance fix instead of
+ceremony decision).
+
 ## [1.0.0] - 2026-05-21 — Phase 0B-1 SHIP
 
 ### M7 — CI integration + production ship

--- a/tools/phase-0b-parser/pyproject.toml
+++ b/tools/phase-0b-parser/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "phase-0b-parser"
-version = "1.0.0"
+version = "1.0.1"
 description = "Phase 0B-1 parser per PHASE-0B-SPEC.md v3 — credential scan + classifier + sealed-registry emitter (read-only)"
 requires-python = ">=3.10"
 dependencies = [

--- a/tools/phase-0b-parser/src/phase_0b_parser/__init__.py
+++ b/tools/phase-0b-parser/src/phase_0b_parser/__init__.py
@@ -6,4 +6,4 @@ Per SPEC §1, §10: zero mutation. scan + classify + report only.
 Mutation (audit append / DB revoke / consumer sync / hook install) is Phase 0C scope.
 """
 
-__version__ = "0B-1.0.0"
+__version__ = "0B-1.0.1"

--- a/tools/phase-0b-parser/src/phase_0b_parser/report_sealed_registry.py
+++ b/tools/phase-0b-parser/src/phase_0b_parser/report_sealed_registry.py
@@ -44,9 +44,25 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from . import __version__ as PARSER_VERSION
 from .models import FingerprintRecord
 
 logger = logging.getLogger(__name__)
+
+# Per SPEC §5.1 lines 123-133 — 9 scope identifiers the parser covers.
+# This is the canonical scope tracked on every sealed-registry.json emit;
+# Phase 0C consumers may depend on this list for envelope compatibility checks.
+SCOPE_COVERED: list[str] = [
+    "user_claude_json",
+    "repo_claude_json",
+    "envstar",
+    "envrc",
+    "medusa_db_api_key",
+    "admin_credential_registry_framework",
+    "ghost_orphan_live_classification",
+    "multi_consumer_sync",
+    "disk_duplicate_detection",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -194,6 +210,7 @@ def _summarize(records: set[FingerprintRecord]) -> dict[str, Any]:
     system_seed_count = 0
     unknown_db_validity_count = 0
     requires_human_count = 0
+    disk_duplicate_records_count = 0
 
     for rec in records:
         cls = rec.classification or "ghost"  # defensive: unclassified counts as ghost bucket
@@ -205,6 +222,8 @@ def _summarize(records: set[FingerprintRecord]) -> dict[str, Any]:
             unknown_db_validity_count += 1
         if rec.requires_human_confirmation:
             requires_human_count += 1
+        if rec.disk_duplicate_paths:  # non-empty list per SPEC §5.4 line 215
+            disk_duplicate_records_count += 1
 
     return {
         "total_records": len(records),
@@ -213,6 +232,7 @@ def _summarize(records: set[FingerprintRecord]) -> dict[str, Any]:
         "system_seed_suspected_count": system_seed_count,
         "unknown_db_validity_count": unknown_db_validity_count,
         "requires_human_confirmation_count": requires_human_count,
+        "disk_duplicate_records_count": disk_duplicate_records_count,
     }
 
 
@@ -392,6 +412,8 @@ def report_sealed_registry(
     envelope: dict[str, Any] = {
         "schema_version": 1,
         "schema": "sealed_registry",
+        "parser_version": PARSER_VERSION,  # per SPEC §5.1 line 121 — 0C envelope check contract
+        "scope_covered": SCOPE_COVERED,  # per SPEC §5.1 lines 123-133 — 9-item coverage list
         "generated_at": generated_at,
         "summary": summary,
         "records": records_serialized,

--- a/tools/phase-0b-parser/tests/test_report_M6.py
+++ b/tools/phase-0b-parser/tests/test_report_M6.py
@@ -129,6 +129,20 @@ class TestRoundTrip:
         assert payload["generated_at"].endswith("Z")
         assert "T" in payload["generated_at"]  # ISO 8601
 
+        # Group 0 conformance — SPEC §5.1 required envelope fields
+        assert payload["parser_version"] == "0B-1.0.1"
+        assert payload["scope_covered"] == [
+            "user_claude_json",
+            "repo_claude_json",
+            "envstar",
+            "envrc",
+            "medusa_db_api_key",
+            "admin_credential_registry_framework",
+            "ghost_orphan_live_classification",
+            "multi_consumer_sync",
+            "disk_duplicate_detection",
+        ]
+
         # Summary matches return value
         assert payload["summary"] == summary
         assert summary["total_records"] == 3
@@ -173,6 +187,90 @@ class TestRoundTrip:
         # The original record remains in the input set with sealed=False
         for rec in records:
             assert rec.sealed is False
+
+
+# ===========================================================================
+# Group 0 — SPEC §5.1 / §5.4 envelope conformance fields (2026-05-23)
+# ===========================================================================
+class TestEnvelopeConformance:
+    """Verify M6 envelope satisfies SPEC v3 §5.1 + §5.4 required fields.
+
+    Group 0 fix closes the impl-side gap surfaced during v4 ceremony prep:
+    parser_version + scope_covered (envelope) + disk_duplicate_records_count
+    (summary) are SPEC-required but were missing in the original M6 emit.
+    """
+
+    def test_envelope_parser_version_matches_module_version(self, tmp_path):
+        from phase_0b_parser import __version__
+
+        out = tmp_path / "var" / "sealed-registry.json"
+        report_sealed_registry(set(), out)
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert payload["parser_version"] == __version__
+        assert payload["parser_version"] == "0B-1.0.1"
+
+    def test_envelope_scope_covered_is_spec_9_item_list(self, tmp_path):
+        out = tmp_path / "var" / "sealed-registry.json"
+        report_sealed_registry(set(), out)
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        # Per SPEC §5.1 lines 123-133 — exact list, exact order.
+        assert payload["scope_covered"] == [
+            "user_claude_json",
+            "repo_claude_json",
+            "envstar",
+            "envrc",
+            "medusa_db_api_key",
+            "admin_credential_registry_framework",
+            "ghost_orphan_live_classification",
+            "multi_consumer_sync",
+            "disk_duplicate_detection",
+        ]
+
+    def test_summary_disk_duplicate_records_count_zero_when_no_duplicates(self, tmp_path):
+        records = {_live_record("a" * 12), _ghost_record("b" * 12)}
+        out = tmp_path / "var" / "sealed-registry.json"
+        summary = report_sealed_registry(records, out)
+        assert summary["disk_duplicate_records_count"] == 0
+
+    def test_summary_disk_duplicate_records_count_counts_records_with_duplicates(self, tmp_path):
+        # Build a record with non-empty disk_duplicate_paths (>= 2 disk sources).
+        rec = _live_record("a" * 12)
+        rec = dataclasses.replace(
+            rec,
+            disk_sources=[
+                DiskSource(path="storefronts/sf-a/.env.local", line=1, env_var="X"),
+                DiskSource(path="storefronts/sf-b/.env.local", line=1, env_var="X"),
+            ],
+            disk_duplicate_paths=[
+                "storefronts/sf-a/.env.local",
+                "storefronts/sf-b/.env.local",
+            ],
+        )
+        out = tmp_path / "var" / "sealed-registry.json"
+        summary = report_sealed_registry({rec}, out)
+        assert summary["disk_duplicate_records_count"] == 1
+
+    def test_summary_disk_duplicate_records_count_multi_records(self, tmp_path):
+        dup_paths = [
+            "storefronts/sf-x/.env.local",
+            "storefronts/sf-y/.env.local",
+        ]
+        dup_sources = [DiskSource(path=p, line=1, env_var="X") for p in dup_paths]
+        rec1 = dataclasses.replace(
+            _live_record("a" * 12),
+            disk_sources=dup_sources,
+            disk_duplicate_paths=dup_paths,
+        )
+        rec2 = dataclasses.replace(
+            _ghost_record("b" * 12),
+            disk_sources=dup_sources,
+            disk_duplicate_paths=dup_paths,
+        )
+        # rec3 has no duplicates — should not count.
+        rec3 = _live_record("c" * 12)
+        out = tmp_path / "var" / "sealed-registry.json"
+        summary = report_sealed_registry({rec1, rec2, rec3}, out)
+        assert summary["disk_duplicate_records_count"] == 2
 
 
 # ===========================================================================
@@ -412,6 +510,7 @@ class TestSummaryAggregation:
             "system_seed_suspected_count": 0,
             "unknown_db_validity_count": 0,
             "requires_human_confirmation_count": 0,
+            "disk_duplicate_records_count": 0,
         }
 
     def test_summary_counts_all_dimensions(self):

--- a/tools/phase-0b-parser/tests/test_signatures.py
+++ b/tools/phase-0b-parser/tests/test_signatures.py
@@ -26,7 +26,7 @@ from phase_0b_parser.verbs import is_ghost, is_live, is_orphan, is_sealed
 
 def test_version_string():
     """SPEC §5.2 line 187 — parser_version semver-like."""
-    assert __version__ == "0B-1.0.0"
+    assert __version__ == "0B-1.0.1"
 
 
 def test_scan_disk_callable_returns_set(tmp_path):


### PR DESCRIPTION
## Summary

Group 0 conformance fix surfaced during v3→v4 SPEC ceremony prep on 2026-05-23. M6 envelope was missing 3 fields **required by SPEC v3**:

| Field | SPEC ref | Why critical |
|---|---|---|
| `envelope.parser_version` | §5.1 line 121 | §9 line 428 "0B↔0C envelope compatibility contract" core field |
| `envelope.scope_covered` | §5.1 lines 123-133 | 9-item coverage declaration for downstream consumers |
| `summary.disk_duplicate_records_count` | §5.4 line 215 | Per-record duplicate detection summary count |

## Decision: impl-align (Path α), not SPEC-drop (Path β)

When verification revealed impl-side gaps, two options surfaced:
- **Path α (this PR)**: add 3 fields to M6 output — preserves 0C handoff contract
- **Path β (rejected)**: drop these from SPEC §5.1 + §5.4 — would lose 0C envelope check capability permanently

Authorized by user 2026-05-23. Pure additive, zero breaking change.

## Scope (narrow per user constraints)

- ✅ Only `report_sealed_registry.py` + `__init__.py` + `pyproject.toml` + 2 test files + CHANGELOG
- ❌ Did NOT touch SPEC
- ❌ Did NOT touch PR #138 (GHL learned_policy SSOT — still parked)
- ❌ Did NOT plan Phase 0B-2
- ❌ Did NOT do target_class migration

## Implementation

- Module-level `SCOPE_COVERED` constant — frozen 9-item list per SPEC §5.1
- Import `__version__ as PARSER_VERSION` at top of report module
- `_summarize()` counts records with non-empty `disk_duplicate_paths`
- 5 new pytest cases in `TestEnvelopeConformance` class:
  - `test_envelope_parser_version_matches_module_version`
  - `test_envelope_scope_covered_is_spec_9_item_list`
  - `test_summary_disk_duplicate_records_count_zero_when_no_duplicates`
  - `test_summary_disk_duplicate_records_count_counts_records_with_duplicates`
  - `test_summary_disk_duplicate_records_count_multi_records`
- `test_round_trip_envelope_shape` extended with new envelope assertions
- `test_empty_summary_shape` + `test_version_string` updated for new key / bumped `__version__`

## Versioning

- Module `__version__`: `0B-1.0.0` → `0B-1.0.1`
- pyproject `version`: `1.0.0` → `1.0.1`
- Patch bump signals additive conformance, no breaking API change

## Verification

- **131/131 pytest pass** (126 prior + 5 Group 0)
- `lint-verb-whitelist.sh` ✓
- `lint-mutation-ban.sh` ✓ (3-layer full enforcement)
- CLI smoke test: `python -m phase_0b_parser.cli --portfolio-root /tmp --output /tmp/sealed-smoke.json` → emitted JSON contains all 3 new fields with correct values

## Post-merge effect on v4 SPEC ceremony

v4 SPEC ceremony will resume with 3 fewer Behavior Divergence drifts (D14a / D14b / D18d) — these are closed via conformance fix instead of ceremony decision. Drift count reduces from 23 to 20.

## Test plan

- [ ] All ~30 portfolio CI gates green
- [ ] `phase-0b-parser-ci.yml` runs `Test + Lint (verb whitelist + mutation ban)` — full 131 pytest must pass
- [ ] Scope verify: only `tools/phase-0b-parser/**` touched
- [ ] No `contracts/learning/` touched (still isolated from PR #138 issue)

## Related

- PR #138 (parked): GHL `learned_policy.schema` SSOT cleanup
- PR #139 ✅ merged 23b6607: portfolio governance docs
- PR #140 ✅ merged 96d400e: Phase 0B-1 parser ship 1.0.0
- This PR: Group 0 conformance fix → 1.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)