### PR TITLE
feat(governance): Managed Agent Harvest — ADR + FSI map + agent contract

### DIFF
--- a/_meta/adr/ADR-Managed-Agent-Harvest.md
+++ b/_meta/adr/ADR-Managed-Agent-Harvest.md
@@ -1,0 +1,295 @@
+---
+artifact_scope: meta
+artifact_name: Managed-Agent-Harvest
+artifact_role: harvest
+target_layer: cross
+is_bghs_doctrine: no
+---
+
+# ADR — Managed Agent Harvest
+
+**Status**: Proposed
+**Date**: 2026-05-10
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-Managed-Agent-Harvest.md`
+**References**:
+- `_meta/adr/ADR-Architecture-Doctrine-BGHS-Separation.md`
+- `_meta/adr/ADR-Hermes-Skill-Lifecycle.md`
+- `_meta/adr/ADR-Loamwise-Guard-Content-Security.md`
+- `_meta/adr/ADR-Session-and-Session-Adjacent-Taxonomy-Federated-Query.md`
+- `_meta/adr/ADR-Credential-Mediation.md`
+**Source**: `/Users/liye/github/financial-services/` (Anthropic financial-services reference repo, read-only)
+
+---
+
+## Context
+
+LiYe Systems already uses Anthropic Managed Agents as an architectural reference for BGHS. The cloned `financial-services` repo adds a more concrete pattern: a high-trust vertical system where named agents, skills, MCP connectors, managed wrappers, subagents, handoffs, and validation harnesses are all represented as files.
+
+This ADR harvests the transferable architecture patterns. It does not import the financial-services repo, install its plugins, execute its scripts, or adopt Anthropic product assumptions as LiYe doctrine.
+
+The relevant LiYe question is:
+
+> How should LiYe represent and govern agent-shaped domain workflows so they can run under multiple runtime surfaces without losing trust boundaries, evidence, or human signoff discipline?
+
+---
+
+## Upstream Core Practices
+
+### M1. One canonical source, multiple runtime surfaces
+
+Each named agent ships as both:
+
+- a Cowork / Claude Code plugin under `plugins/agent-plugins/<slug>/`
+- a Managed Agent cookbook under `managed-agent-cookbooks/<slug>/`
+
+The cookbook references the same agent prompt and skills. Runtime wrappers adapt the same source to a different execution surface.
+
+### M2. Plugin package is self-contained, but skills have a source of truth
+
+Vertical plugins own source skills. Agent plugins vendor copies of those skills so each agent package is installable by itself. `scripts/check.py` detects drift, and `scripts/sync-agent-skills.py` propagates source changes.
+
+### M3. Managed wrapper resolves references before deployment
+
+`agent.yaml` is a manifest-like wrapper. The deploy harness resolves file references, uploads skills, creates subagents, and posts the final payload.
+
+Important field behavior:
+
+| Field pattern | Resolution |
+|---|---|
+| `system.file` | inline canonical agent prompt |
+| `skills.from_plugin` | upload all bundled skills |
+| `skills.path` | upload one skill |
+| `callable_agents.manifest` | create leaf worker first |
+| `output_schema` | validate harness-side; not posted as API field |
+
+### M4. Depth-1 subagents encode permission topology
+
+The most important subagent role split is not "more agents"; it is permission separation:
+
+- reader: touches untrusted input, no write, no bash, often no MCP
+- critic: re-verifies against trusted sources, read-only
+- writer / resolver / publisher: only worker with Write, does not read raw untrusted input
+- orchestrator: coordinates, but does not hold write in high-risk flows
+
+### M5. Untrusted input is defanged before context merge
+
+Reader workers return schema-validated JSON only. Schemas use:
+
+- `additionalProperties: false`
+- max lengths
+- character-class regexes
+- item caps
+
+This prevents raw adversarial document text from surviving intact into the orchestrator context.
+
+### M6. Handoff is outside direct agent calls
+
+Named agents do not call one another directly. They emit a handoff request, and an external event loop routes it after target allowlist and payload schema validation.
+
+The reference implementation parses text, but explicitly recommends typed tool calls or typed SSE events for production.
+
+### M7. High-stakes actions are staged for human signoff
+
+Financial workflows produce drafts, reports, workbooks, exception lists, or signoff packages. They do not:
+
+- publish research
+- email clients
+- post to a ledger
+- approve KYC
+- execute trades
+- make final investment, tax, legal, or accounting decisions
+
+---
+
+## Absorb
+
+| ID | Pattern | LiYe absorption |
+|---|---|---|
+| A1 | One source, many runtime wrappers | Agent source and runtime surface must be separate contract fields |
+| A2 | Agent prompt + skills as canonical source | Agent unit declares canonical system prompt and skill sources |
+| A3 | Worker topology as permission model | Worker manifests must declare tools, connectors, write, shell, untrusted-input exposure |
+| A4 | Single-writer leaf | High-risk flows must have at most one write-capable worker by default |
+| A5 | Untrusted-reader isolation | Workers touching untrusted input cannot hold Write, Bash, or privileged connectors |
+| A6 | Schema-validated worker outputs | Reader output schema validation is Governance, not a best-effort prompt instruction |
+| A7 | Independent critic pattern | Material facts from untrusted input should be re-verified against trusted sources before write |
+| A8 | Externalized handoff | Cross-agent routing belongs to Session / Loamwise event bus, not direct agent-to-agent calls |
+| A9 | Staged outputs and human signoff | System-of-record writes and external distribution require explicit approval outside the agent |
+| A10 | Drift check for bundled skills | Vendored skill copies require source hash, provenance, and drift gate |
+
+---
+
+## Do Not Absorb
+
+| ID | Upstream pattern | Reason |
+|---|---|---|
+| R1 | Claude-specific model names in contracts | Model choice is Brain / runtime policy, not Layer 0 invariant |
+| R2 | Marketplace listing as trust | Marketplace is discovery only; LiYe requires lifecycle admission |
+| R3 | Regex extraction of handoff JSON from model text | Acceptable reference script; production should use typed Session events |
+| R4 | Markdown guardrails as sole enforcement | Guardrails must compile into Loamwise / contract checks where safety matters |
+| R5 | Vendored skills without explicit source hash in manifest | LiYe needs provenance and drift receipts |
+| R6 | API preview depth limit as doctrine | One-level delegation is current vendor capability, not LiYe architecture |
+| R7 | Direct upload/deploy script as source of truth | Harness behavior must be generated from contract, not define the contract |
+| R8 | Financial product worldview | Only architecture patterns transfer; financial workflows remain reference examples |
+
+---
+
+## BGHS Mapping
+
+| Anthropic artifact | LiYe concern | Notes |
+|---|---|---|
+| Agent prompt | Brain | Model-contingent workflow identity |
+| Skill body | Brain, secondary Hands | Professional method; executable only after lifecycle admission |
+| Plugin manifest | Governance | Ownership and package boundary |
+| MCP connector | Hands | Credential-mediated tool surface |
+| `output_schema` | Governance | Validation gate outside model discretion |
+| Worker tool config | Governance, secondary Hands | Permissions are enforceable topology |
+| Steering event | Session | Wake/resume input |
+| Handoff request | Session, secondary Governance | Must be typed and allowlisted |
+| Human signoff rule | Governance | Model-independent invariant |
+| `./out/` artifact writing | Hands | Staged output surface |
+
+---
+
+## Decision
+
+LiYe Systems will define a first-class **Agent Unit Contract** for agent-shaped domain workflows.
+
+This contract will:
+
+1. separate canonical source from runtime wrapper
+2. declare runtime surfaces without binding to a vendor
+3. declare worker topology and permission profiles
+4. represent untrusted-input exposure explicitly
+5. require schema validation for reader / extractor outputs
+6. route cross-agent handoffs through typed Session events
+7. require human signoff declarations for high-stakes actions
+8. connect every agent unit to BGHS Component Declaration fields
+
+Initial schema sketch:
+
+- `_meta/contracts/agent/liye_agent_contract.schema.yaml`
+
+This is a cross-layer contract:
+
+- Layer 0 defines the schema and invariants.
+- Layer 1 Loamwise enforces dispatch, GuardChain, output validation, Session writes, and WriteGate.
+- Layer 2 Domain Engines publish concrete agent units or playbooks that conform.
+- Layer 3 products may consume staged outputs but do not own the governance rules.
+
+---
+
+## Boundary Rules
+
+### MA1. Runtime surface cannot be the source of truth
+
+A Cowork plugin, Managed Agent wrapper, CLI command, or product embed is only a surface. The canonical source must be declared separately:
+
+- agent prompt source
+- skill source list
+- connector declarations
+- worker topology
+- output and handoff schemas
+
+### MA2. Worker topology must be explicit
+
+Every worker must declare:
+
+- role
+- whether it touches untrusted input
+- allowed tools
+- connector access
+- write capability
+- shell capability
+- output schema, if its output enters another agent's context
+
+### MA3. Untrusted-input workers are least-privilege by default
+
+If `touches_untrusted_input = true`, default policy is:
+
+- no Write
+- no Bash / shell
+- no privileged MCP connector
+- no external send
+- structured output only
+
+Exceptions require a separate policy ADR.
+
+### MA4. Writer cannot consume raw untrusted content
+
+The write-capable worker receives only validated, bounded, and preferably critic-checked summaries or references. It must not open raw external documents directly in high-risk workflows.
+
+### MA5. Orchestrator handoff is typed Session, not free text
+
+Cross-agent handoff must be represented as a typed Session event:
+
+```
+AgentHandoffRequested
+  source_agent_id
+  target_agent_id
+  event_schema_ref
+  payload
+  context_ref
+  guard_evidence_ref
+```
+
+The target must be allowlisted and the payload must validate before dispatch.
+
+### MA6. High-stakes outputs are staged
+
+Any action that can externally bind the business or alter a system of record must be staged for human signoff:
+
+- ledger posting
+- client / investor / regulator distribution
+- KYC approval
+- trade / bid / budget execution
+- legal, tax, accounting, or investment recommendation publication
+
+### MA7. Vendored skill copies require provenance
+
+If an agent package includes copied skills, each copy must carry:
+
+- source path or URI
+- source hash
+- copied_at
+- lifecycle state
+- drift check receipt
+
+---
+
+## Consequences
+
+Positive:
+
+- LiYe can model agent workflows without binding itself to one vendor runtime.
+- Loamwise gets a concrete shape for WriteGate, GuardChain, and Session routing.
+- Domain Engines can expose agent-shaped work without bypassing engine manifests.
+- High-risk workflows gain auditable least-privilege decomposition.
+
+Costs:
+
+- More manifest fields before an agent can be dispatchable.
+- Vendored skill copies require provenance tooling.
+- Loamwise must enforce topology, not just read prompts.
+- Existing D0 engines need migration work before D2/D3.
+
+---
+
+## Adoption Plan
+
+1. Add `_meta/contracts/agent/liye_agent_contract.schema.yaml` as schema sketch.
+2. Create one non-runtime example for AGE or Chaming using read-only workers.
+3. Add Loamwise validator for single-writer and untrusted-reader invariants.
+4. Add typed `AgentHandoffRequested` Session event under the P1-e taxonomy.
+5. Extend engine manifest integration so Domain Engines can publish agent units alongside playbooks.
+
+---
+
+## Non-Goals
+
+- Do not import Anthropic financial-services code.
+- Do not adopt a vendor-specific Managed Agents API as LiYe's contract.
+- Do not make BGHS a runtime directory structure.
+- Do not treat marketplace installation as trust.
+- Do not turn Layer 3 product workflows into Layer 0 governance logic.
+

--- a/_meta/contracts/agent/liye_agent_contract.schema.yaml
+++ b/_meta/contracts/agent/liye_agent_contract.schema.yaml
@@ -1,0 +1,390 @@
+# LiYe Agent Unit Contract v0.1.0
+# SSOT: _meta/contracts/agent/liye_agent_contract.schema.yaml
+#
+# Defines the manifest shape for agent-shaped workflows that can run under
+# Loamwise or another runtime surface without losing governance boundaries.
+# This is a schema sketch harvested from Anthropic financial-services patterns;
+# it is vendor-neutral and does not imply Claude Managed Agents as runtime.
+
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://liye.com/contracts/agent/liye_agent_contract.v0_1"
+title: "LiYe Agent Unit Contract"
+description: "Agent-shaped workflow declaration: canonical source, runtime surfaces, worker topology, trust boundaries, handoffs, outputs, and human signoff."
+version: "0.1.0"
+type: object
+additionalProperties: false
+
+required:
+  - agent_id
+  - agent_version
+  - owner_layer
+  - purpose
+  - source
+  - runtime_surfaces
+  - bghs
+  - skills
+  - workers
+  - trust_boundaries
+  - outputs
+  - handoffs
+  - human_signoff
+  - invariants
+
+properties:
+  agent_id:
+    type: string
+    pattern: "^[a-z0-9][a-z0-9-]{2,63}$"
+    description: "Stable agent identifier, lowercase kebab-case."
+
+  agent_version:
+    type: string
+    pattern: "^\\d+\\.\\d+\\.\\d+$"
+    description: "SemVer for this agent unit contract instance."
+
+  owner_layer:
+    type: integer
+    enum: [0, 1, 2, 3]
+    description: "LiYe layer owning this agent unit declaration."
+
+  purpose:
+    type: string
+    minLength: 1
+    maxLength: 500
+    description: "Human-readable workflow purpose."
+
+  source:
+    type: object
+    additionalProperties: false
+    required:
+      - canonical_system_prompt
+      - source_of_truth
+      - bundled_skill_policy
+    properties:
+      canonical_system_prompt:
+        type: string
+        minLength: 1
+        description: "Path or URI to the canonical agent prompt / instruction artifact."
+      source_of_truth:
+        type: string
+        enum:
+          - repo-local
+          - engine-manifest
+          - external-reference
+          - generated-candidate
+        description: "Where authority for this agent source lives."
+      bundled_skill_policy:
+        type: string
+        enum:
+          - none
+          - vendored-with-drift-check
+          - referenced-only
+          - generated-candidate
+        description: "How skills are packaged relative to their canonical source."
+      source_hash:
+        type: string
+        pattern: "^sha256:[0-9a-f]{64}$"
+        description: "Optional hash of canonical source bundle."
+
+  runtime_surfaces:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - surface
+        - wrapper_manifest
+      properties:
+        surface:
+          type: string
+          enum:
+            - loamwise-dispatch
+            - managed-agent
+            - cowork-plugin
+            - cli-command
+            - product-embedded
+            - dry-run-reference
+          description: "Runtime surface. This is not the source of truth."
+        wrapper_manifest:
+          type: string
+          minLength: 1
+          description: "Path or URI to surface-specific wrapper manifest."
+        enabled:
+          type: boolean
+          default: false
+
+  bghs:
+    type: object
+    additionalProperties: false
+    required:
+      - primary_concern
+      - model_contingent_items
+      - model_independent_invariants
+      - session_source_of_truth
+      - credential_path
+      - wake_resume_entrypoint
+    properties:
+      primary_concern:
+        $ref: "#/definitions/bghs_concern"
+      secondary_concern:
+        type: array
+        items:
+          $ref: "#/definitions/bghs_concern"
+      model_contingent_items:
+        type: array
+        items:
+          type: string
+      model_independent_invariants:
+        type: array
+        items:
+          type: string
+      session_source_of_truth:
+        type: string
+        minLength: 1
+      credential_path:
+        type: string
+        minLength: 1
+      wake_resume_entrypoint:
+        type: string
+        minLength: 1
+
+  skills:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - skill_id
+        - source_path
+        - trust_source
+        - lifecycle_state
+      properties:
+        skill_id:
+          type: string
+          pattern: "^[a-z0-9][a-z0-9-]{1,63}$"
+        source_path:
+          type: string
+          minLength: 1
+        source_hash:
+          type: string
+          pattern: "^sha256:[0-9a-f]{64}$"
+        trust_source:
+          type: string
+          enum:
+            - internal-vetted
+            - engine-published
+            - agent-generated
+            - external
+        lifecycle_state:
+          type: string
+          enum:
+            - quarantine
+            - candidate
+            - active
+            - disabled
+            - rejected
+        required_tools:
+          type: array
+          items:
+            $ref: "#/definitions/tool_name"
+
+  workers:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - worker_id
+        - role
+        - touches_untrusted_input
+        - can_write
+        - can_shell
+        - allowed_tools
+      properties:
+        worker_id:
+          type: string
+          pattern: "^[a-z0-9][a-z0-9-]{1,63}$"
+        role:
+          type: string
+          enum:
+            - orchestrator
+            - reader
+            - extractor
+            - critic
+            - resolver
+            - writer
+            - publisher
+            - executor
+        touches_untrusted_input:
+          type: boolean
+        can_write:
+          type: boolean
+        can_shell:
+          type: boolean
+        allowed_tools:
+          type: array
+          items:
+            $ref: "#/definitions/tool_name"
+        mcp_servers:
+          type: array
+          items:
+            type: string
+            pattern: "^[a-z0-9][a-z0-9-]{1,63}$"
+        output_schema_ref:
+          type: string
+          description: "Schema that must validate this worker output before context merge."
+        input_contract_ref:
+          type: string
+          description: "Optional schema for worker input."
+
+  trust_boundaries:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - boundary_id
+        - input_kind
+        - isolation_rule
+      properties:
+        boundary_id:
+          type: string
+          pattern: "^[a-z0-9][a-z0-9-]{1,63}$"
+        input_kind:
+          type: string
+          enum:
+            - trusted-internal
+            - untrusted-external
+            - mixed
+        isolation_rule:
+          type: string
+          minLength: 1
+          maxLength: 1000
+        applies_to_workers:
+          type: array
+          items:
+            type: string
+
+  outputs:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - artifact_type
+        - path_policy
+        - stage
+        - evidence_required
+      properties:
+        artifact_type:
+          type: string
+          enum:
+            - report
+            - workbook
+            - presentation
+            - json
+            - receipt
+            - staged-action
+            - evidence-package
+            - other
+        path_policy:
+          type: string
+          description: "Allowed output location policy, e.g. ./out/ only."
+        stage:
+          type: string
+          enum:
+            - draft
+            - staged
+            - final
+        evidence_required:
+          type: boolean
+
+  handoffs:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+        - target_agent_id
+        - event_schema_ref
+        - allowlisted
+      properties:
+        target_agent_id:
+          type: string
+          pattern: "^[a-z0-9][a-z0-9-]{2,63}$"
+        event_schema_ref:
+          type: string
+          minLength: 1
+        allowlisted:
+          type: boolean
+        context_ref_policy:
+          type: string
+          description: "How much context may cross the handoff boundary."
+
+  human_signoff:
+    type: object
+    additionalProperties: false
+    required:
+      - required_for
+    properties:
+      required_for:
+        type: array
+        items:
+          type: string
+          enum:
+            - external-send
+            - system-of-record-write
+            - ledger-posting
+            - kyc-approval
+            - trade-execution
+            - bid-budget-keyword-write
+            - legal-tax-accounting-advice
+            - investment-recommendation-publication
+      approver_role:
+        type: string
+        maxLength: 120
+      signoff_receipt_ref:
+        type: string
+
+  invariants:
+    type: array
+    minItems: 1
+    items:
+      type: string
+      enum:
+        - single-writer-leaf
+        - untrusted-reader-no-write
+        - untrusted-reader-no-shell
+        - untrusted-reader-no-privileged-connector
+        - writer-no-raw-untrusted-input
+        - reader-output-schema-required
+        - handoff-typed-session-event
+        - handoff-target-allowlist-required
+        - staged-high-risk-output
+        - skill-provenance-required
+
+definitions:
+  bghs_concern:
+    type: string
+    enum:
+      - Brain
+      - Governance
+      - Hands
+      - Session
+
+  tool_name:
+    type: string
+    enum:
+      - read
+      - grep
+      - glob
+      - write
+      - edit
+      - bash
+      - mcp
+      - agent
+      - browser
+      - external-send
+

--- a/_meta/docs/Anthropic-FSI-Architecture-Map.md
+++ b/_meta/docs/Anthropic-FSI-Architecture-Map.md
@@ -1,0 +1,214 @@
+# Anthropic FSI Architecture Map
+
+**Status**: Research map
+**Date**: 2026-05-10
+**Source**: `/Users/liye/github/financial-services/`
+**Use**: Reference only. No plugin registration, script execution, or runtime dependency.
+
+---
+
+## 研究结论
+
+Anthropic `financial-services` repo 的核心价值不是金融模型本身，而是把高信任领域工作流产品化成一组边界清晰的 artifacts：
+
+```
+marketplace
+  -> plugin package
+    -> canonical agent prompt
+    -> skills / commands / MCP connectors
+  -> managed-agent cookbook
+    -> agent.yaml wrapper
+    -> depth-1 subagents
+    -> steering events
+    -> harness-side schema validation
+```
+
+对 LiYe Systems 最有价值的迁移点是：
+
+1. 同一份 agent / skill source 可以被不同 runtime surface 包装。
+2. agent orchestrator、reader、critic、writer 的权限分离是治理结构，不是 prompt 风格。
+3. 不可信输入经过只读 reader 和 schema validation 后才能进入调度上下文。
+4. 写能力集中到唯一 leaf worker，且高风险动作只 staged，不发布、不入账、不审批。
+5. agent 之间不直接互调，handoff 由外部 orchestrator allowlist + schema validate。
+
+---
+
+## Artifact Graph
+
+| Artifact | Source | Anthropic 用法 | LiYe 解释 |
+|---|---|---|---|
+| Marketplace manifest | `.claude-plugin/marketplace.json` | 注册可安装插件列表和 source path | 外部 capability index，不等于 trust |
+| Plugin manifest | `plugins/**/.claude-plugin/plugin.json` | 插件最小元数据 | Ownership boundary |
+| Agent prompt | `plugins/agent-plugins/<slug>/agents/<slug>.md` | workflow identity + guardrails | Brain artifact with Governance hints |
+| Vertical skill | `plugins/vertical-plugins/<vertical>/skills/*/SKILL.md` | skill source of truth | Professional operating procedure |
+| Bundled skill copy | `plugins/agent-plugins/<slug>/skills/*` | self-contained agent package | Vendored dependency requiring drift check |
+| Command | `plugins/vertical-plugins/*/commands/*.md` | explicit slash workflow | Manual dispatch surface |
+| MCP config | `plugins/vertical-plugins/*/.mcp.json` | data connector registry | Hands, credential-mediated |
+| Managed wrapper | `managed-agent-cookbooks/<slug>/agent.yaml` | `POST /v1/agents` deploy manifest | Runtime surface adapter |
+| Subagent manifest | `managed-agent-cookbooks/<slug>/subagents/*.yaml` | leaf worker definitions | Worker topology + permission profile |
+| Steering examples | `managed-agent-cookbooks/<slug>/steering-examples.json` | event examples | Session entrypoints |
+| Deploy script | `scripts/deploy-managed-agent.sh` | resolves refs, uploads skills, creates agents | Harness behavior, not contract source |
+| Orchestrator script | `scripts/orchestrate.py` | routes `handoff_request` | External Session router pattern |
+| Validator script | `scripts/validate.py` | validates worker output schema | Governance gate outside model text |
+
+---
+
+## Representative Workflows
+
+### Pitch Agent
+
+Files:
+
+- `plugins/agent-plugins/pitch-agent/agents/pitch-agent.md`
+- `managed-agent-cookbooks/pitch-agent/agent.yaml`
+- `managed-agent-cookbooks/pitch-agent/subagents/researcher.yaml`
+- `managed-agent-cookbooks/pitch-agent/subagents/modeler.yaml`
+- `managed-agent-cookbooks/pitch-agent/subagents/deck-writer.yaml`
+
+Pattern:
+
+```
+orchestrator: read/grep/glob + market data MCPs
+  -> researcher: read-only + market data MCPs -> structured comps / precedents
+  -> modeler: read + bash + market data MCPs -> calculations
+  -> deck-writer: only worker with Write/Edit -> ./out/model.xlsx + ./out/pitch.pptx
+```
+
+LiYe takeaway:
+
+- This is primarily task decomposition and artifact isolation.
+- Trusted data connectors can exist upstream, but final artifact writing remains isolated.
+- The writer owns file production but does not own data-source access.
+
+### GL Reconciler
+
+Files:
+
+- `plugins/agent-plugins/gl-reconciler/agents/gl-reconciler.md`
+- `plugins/agent-plugins/gl-reconciler/skills/gl-recon/SKILL.md`
+- `managed-agent-cookbooks/gl-reconciler/agent.yaml`
+- `managed-agent-cookbooks/gl-reconciler/subagents/reader.yaml`
+- `managed-agent-cookbooks/gl-reconciler/subagents/critic.yaml`
+- `managed-agent-cookbooks/gl-reconciler/subagents/resolver.yaml`
+
+Pattern:
+
+```
+untrusted counterparty/custodian docs
+  -> reader: Read/Grep only, no MCP, no bash, no Write
+  -> schema validation: length caps + character class restrictions
+  -> critic: trusted GL/subledger MCPs, read-only re-verification
+  -> resolver: only worker with Write/Edit, no external docs, writes ./out/
+```
+
+LiYe takeaway:
+
+- This is the strongest pattern for Loamwise GuardChain evolution.
+- The untrusted reader is deliberately deprived of tools that could cause side effects.
+- The writer never sees raw outsider content; it receives validated, critic-checked facts.
+- Ledger adjustment remains outside the agent and requires human approval.
+
+---
+
+## Security Pattern
+
+### P1. Marketplace does not grant trust
+
+The marketplace lists plugin sources. Trust still needs lifecycle validation, provenance, and policy admission. For LiYe, marketplace import must map to the Hermes-inspired quarantine lifecycle, not direct activation.
+
+### P2. Source of truth and bundle are separate
+
+Anthropic keeps vertical skills as source and copies them into agent bundles. `scripts/check.py` detects drift and `scripts/sync-agent-skills.py` propagates source changes.
+
+LiYe should not copy this blindly. If vendoring is needed, every bundled skill copy must carry source hash / provenance / lifecycle state.
+
+### P3. Wrapper manifests are runtime adapters
+
+`agent.yaml` files reference canonical prompts and skills, then the deploy harness resolves:
+
+| Manifest convention | Runtime resolution |
+|---|---|
+| `system.file` | inline prompt text |
+| `skills.from_plugin` | upload every bundled skill |
+| `skills.path` | upload one custom skill |
+| `callable_agents.manifest` | create subagent and reference id |
+| `output_schema` | harness-side validation, removed before API POST |
+
+For LiYe, wrapper manifests belong to Hands / Session runtime surfaces. The contract must live above the wrapper.
+
+### P4. Depth-1 delegation is a runtime limit, not doctrine
+
+Anthropic states callable agents support one delegation level in this preview. LiYe should absorb the topology declaration and isolation discipline, not the depth limit as a permanent architectural rule.
+
+### P5. Handoff is externalized
+
+Named agents do not call each other directly. They emit a handoff request, and `scripts/orchestrate.py` routes it with:
+
+- target allowlist
+- payload schema validation
+- new steering event to target session
+
+The reference script parses text; its own comment says production should prefer typed tool calls or typed SSE events. LiYe should implement handoff as typed Session events, not regex over model text.
+
+---
+
+## BGHS Mapping
+
+| Anthropic FSI item | BGHS concern | LiYe placement |
+|---|---|---|
+| Agent prompt | Brain | Loamwise / Engine harness prompt artifact |
+| Skill instructions | Brain, secondary Hands | Skill lifecycle artifact, dispatchable only after Governance admission |
+| Plugin manifest | Governance | Capability ownership declaration |
+| MCP connector config | Hands | Credential-mediated connector declaration |
+| Output schema | Governance | GuardChain / validation contract |
+| Deploy script resolution | Hands | Runtime adapter behavior |
+| Steering event | Session | Wake / resume entrypoint |
+| Handoff routing | Session, secondary Governance | Loamwise event bus with allowlist |
+| Human signoff rule | Governance | Policy invariant |
+| Writer-only leaf | Governance, secondary Hands | WriteGate worker topology |
+
+---
+
+## LiYe Evolution Implications
+
+### Layer 0: LiYe OS
+
+Define a contract for agent units that separates:
+
+- canonical source artifacts
+- runtime wrappers
+- worker topology
+- trust boundaries
+- output schemas
+- handoff schemas
+- human signoff rules
+
+Candidate contract: `_meta/contracts/agent/liye_agent_contract.schema.yaml`.
+
+### Layer 1: Loamwise
+
+Loamwise should become the execution authority for:
+
+- dispatching agent units
+- enforcing single-writer topology
+- validating reader outputs before context merge
+- writing handoff events to Session
+- attaching GuardEvidence to every worker transition
+
+### Layer 2: Domain Engines
+
+Domain Engines should expose playbooks and agent units through manifest contracts, not bespoke prompts. AGE and Chaming can start with read-only or staged-write agent units before D2 dispatch.
+
+### Layer 3: Product Lines
+
+Product systems may consume staged artifacts, but should not directly host Loamwise governance rules. UI can show signoff queues; policy remains Layer 0/1.
+
+---
+
+## Immediate Research Verdict
+
+Absorb the pattern, not the product:
+
+- Absorb: one source / multiple runtime wrappers, single-writer leaf, untrusted-reader isolation, schema-validated worker output, external typed handoff, staged high-risk actions.
+- Do not absorb: Claude-specific model pinning, marketplace-as-trust, regex text handoff as production, markdown guardrails as sole enforcement, unmanaged vendored skill drift.
+


### PR DESCRIPTION
## Summary

Harvest Anthropic financial-services managed-agent patterns into LiYe governance vocabulary as a single evidence chain.

- `_meta/docs/Anthropic-FSI-Architecture-Map.md` — external reference map (read-only ingestion of upstream patterns)
- `_meta/adr/ADR-Managed-Agent-Harvest.md` — harvest ADR (Status: Proposed)
- `_meta/contracts/agent/liye_agent_contract.schema.yaml` — vendor-neutral agent contract schema

## Scope

Cross-layer governance vocabulary only. No runtime code, no upstream plugin install, no LiYe doctrine change to BGHS / Hermes lifecycle / credential mediation (those ADRs referenced, not amended).

## Why split from PR #138

Per decision #56716, GHL (learning-system evolution) and Managed Agent Harvest (workflow / permission topology) share the governance foundation but have **distinct review surfaces and implementation paths**. Bundling would mix cognitive loads. PR #138 lands first as foundation; this PR follows.

## Test plan

- [ ] Pre-commit hooks pass (guardrail + env hygiene + blocklist scan) — verified locally
- [ ] Contract validator accepts `liye_agent_contract.schema.yaml` shape
- [ ] No imports / no executable code touched — pure docs + schema addition
- [ ] BGHS / Hermes / Credential ADRs only referenced, not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)