### PR TITLE
feat(0c.4): add validate_manifest_reality.py — Hard Gate 5 enforcement

### DIFF
--- a/_meta/contracts/scripts/validate_manifest_reality.py
+++ b/_meta/contracts/scripts/validate_manifest_reality.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+validate_manifest_reality.py — Engine Manifest Reality Validator (Phase 0c.4)
+
+SSOT: _meta/contracts/scripts/validate_manifest_reality.py
+Schema: _meta/contracts/engine/engine_manifest.schema.v2.yaml (delegated)
+
+Schema validation answers "is the manifest shape correct?" (validate-contracts.mjs).
+Reality validation answers "does the manifest claim match the filesystem / git
+state it depends on?" — this script.
+
+Hard Gate 5 binding: any source接入 must pass manifest reality validator.
+
+Reality checks (minimal set per Phase 0c.4 design):
+  R1  playbooks[].entrypoint        — file exists at engine repo root
+  R2  data_sources[].path           — if a path key is present, file/dir exists
+  R3  capability runtime_gate_refs  — every ref resolves to a runtime_gates[].id
+  R4  effective ≤ declared          — write_capability_effective not wider than declared
+  R5  schema_version routing        — "2.0" routes to v2 schema $id
+  R6  Pilot 1 invariant             — engine_id=amazon-growth-engine → effective=none
+
+CLI:
+  validate_manifest_reality.py --manifest-path <path> [--engine-repo <dir>] [--json]
+  validate_manifest_reality.py --self-test
+
+Exit codes:
+  0  all reality checks PASS
+  1  at least one reality check FAIL
+  2  schema FAIL (delegated to 0c.2 schema check)
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft7Validator
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SCRIPT_DIR.parent.parent.parent
+V2_SCHEMA_PATH = PROJECT_ROOT / "_meta/contracts/engine/engine_manifest.schema.v2.yaml"
+V2_SCHEMA_ID = "https://liye.com/contracts/engine/engine_manifest.v2"
+FIXTURES_DIR = SCRIPT_DIR / "validate_manifest_reality_fixtures"
+
+# Total order on write_capability levels (per v2 schema enum semantics).
+CAPABILITY_LEVELS = {"none": 0, "limited": 1, "full": 2}
+
+PILOT1_ENGINE_ID = "amazon-growth-engine"
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def schema_check(manifest: dict[str, Any]) -> list[str]:
+    """Delegate-equivalent: run jsonschema Draft7Validator on manifest.
+
+    Returns list of error messages. Empty list = schema valid.
+    """
+    schema = load_yaml(V2_SCHEMA_PATH)
+    validator = Draft7Validator(schema)
+    errors = sorted(validator.iter_errors(manifest), key=lambda e: list(e.absolute_path))
+    return [
+        f"{'/'.join(str(p) for p in e.absolute_path) or '<root>'}: {e.message}"
+        for e in errors
+    ]
+
+
+def check_r1_playbook_entrypoints(manifest: dict[str, Any], engine_repo: Path) -> list[str]:
+    failures = []
+    for pb in manifest.get("playbooks", []):
+        entry = pb.get("entrypoint")
+        if not entry:
+            continue
+        resolved_path = engine_repo / entry
+        if not resolved_path.exists():
+            failures.append(
+                f"R1 playbook '{pb.get('id', '?')}' entrypoint missing: {entry} "
+                f"(resolved to {resolved_path})"
+            )
+    return failures
+
+
+def check_r2_data_source_paths(manifest: dict[str, Any], engine_repo: Path) -> list[str]:
+    failures = []
+    for idx, ds in enumerate(manifest.get("data_sources", [])):
+        path_value = ds.get("path")
+        if path_value is None:
+            continue
+        resolved_path = engine_repo / path_value
+        if not resolved_path.exists():
+            failures.append(
+                f"R2 data_sources[{idx}] path missing: {path_value} "
+                f"(resolved to {resolved_path})"
+            )
+    return failures
+
+
+def check_r3_capability_gate_refs(manifest: dict[str, Any]) -> list[str]:
+    failures = []
+    gate_ids = {g.get("id") for g in manifest.get("runtime_gates", []) if g.get("id")}
+    for cap in manifest.get("capabilities", []):
+        for ref in cap.get("runtime_gate_refs", []) or []:
+            if ref not in gate_ids:
+                failures.append(
+                    f"R3 capability '{cap.get('id', '?')}' references undefined "
+                    f"runtime_gate '{ref}' (known gates: {sorted(gate_ids) or 'none'})"
+                )
+    return failures
+
+
+def check_r4_effective_within_declared(manifest: dict[str, Any]) -> list[str]:
+    declared = manifest.get("write_capability_declared")
+    effective = manifest.get("write_capability_effective")
+    if declared is None or effective is None:
+        return []  # schema check already enforces presence; nothing to assert here
+    if declared not in CAPABILITY_LEVELS or effective not in CAPABILITY_LEVELS:
+        return []  # schema check already enforces enum
+    if CAPABILITY_LEVELS[effective] > CAPABILITY_LEVELS[declared]:
+        return [
+            f"R4 write_capability_effective='{effective}' exceeds "
+            f"write_capability_declared='{declared}' (effective must be ≤ declared)"
+        ]
+    return []
+
+
+def check_r5_schema_version_routing(manifest: dict[str, Any]) -> list[str]:
+    sv = manifest.get("schema_version")
+    schema = load_yaml(V2_SCHEMA_PATH)
+    actual_id = schema.get("$id")
+    if sv == "2.0":
+        if actual_id != V2_SCHEMA_ID:
+            return [
+                f"R5 routing mismatch: schema_version='2.0' but v2 schema $id "
+                f"is '{actual_id}', expected '{V2_SCHEMA_ID}'"
+            ]
+        return []
+    return [
+        f"R5 unsupported schema_version: {sv!r}. validate_manifest_reality.py "
+        f"binds to v2 ('2.0') only; v1 manifests are out-of-scope here."
+    ]
+
+
+def check_r6_pilot1_invariant(manifest: dict[str, Any]) -> list[str]:
+    if manifest.get("engine_id") != PILOT1_ENGINE_ID:
+        return []
+    effective = manifest.get("write_capability_effective")
+    if effective != "none":
+        return [
+            f"R6 Pilot 1 invariant violated: engine_id='{PILOT1_ENGINE_ID}' but "
+            f"write_capability_effective='{effective}' (Hard Gate 8 requires "
+            f"effective='none' during Pilot 1)"
+        ]
+    return []
+
+
+REALITY_CHECKS = [
+    ("R1_playbook_entrypoints", check_r1_playbook_entrypoints, True),
+    ("R2_data_source_paths", check_r2_data_source_paths, True),
+    ("R3_capability_gate_refs", check_r3_capability_gate_refs, False),
+    ("R4_effective_within_declared", check_r4_effective_within_declared, False),
+    ("R5_schema_version_routing", check_r5_schema_version_routing, False),
+    ("R6_pilot1_invariant", check_r6_pilot1_invariant, False),
+]
+
+
+def run_all_checks(manifest: dict[str, Any], engine_repo: Path) -> dict[str, Any]:
+    """Run every reality check, return structured report."""
+    results = []
+    for name, fn, needs_repo in REALITY_CHECKS:
+        failures = fn(manifest, engine_repo) if needs_repo else fn(manifest)
+        results.append(
+            {"check": name, "status": "PASS" if not failures else "FAIL", "messages": failures}
+        )
+    return {
+        "manifest_engine_id": manifest.get("engine_id"),
+        "schema_version": manifest.get("schema_version"),
+        "engine_repo": str(engine_repo),
+        "checks": results,
+        "overall": "PASS" if all(r["status"] == "PASS" for r in results) else "FAIL",
+    }
+
+
+def print_report(report: dict[str, Any], json_mode: bool) -> None:
+    if json_mode:
+        print(json.dumps(report, indent=2))
+        return
+    print("═" * 60)
+    print(f"  Manifest Reality Validator (Phase 0c.4)")
+    print(f"  engine_id      = {report['manifest_engine_id']}")
+    print(f"  schema_version = {report['schema_version']}")
+    print(f"  engine_repo    = {report['engine_repo']}")
+    print("═" * 60)
+    for r in report["checks"]:
+        mark = "✅" if r["status"] == "PASS" else "❌"
+        print(f"  {mark} {r['check']}: {r['status']}")
+        for msg in r["messages"]:
+            print(f"       · {msg}")
+    print("═" * 60)
+    print(f"  Overall: {report['overall']}")
+    print("═" * 60)
+
+
+def validate_one(manifest_path: Path, engine_repo: Path, json_mode: bool) -> int:
+    manifest = load_yaml(manifest_path)
+
+    # Step 1: schema check (delegated-equivalent — use jsonschema since
+    # validate-contracts.mjs has no --check-manifest <path> CLI surface).
+    schema_errors = schema_check(manifest)
+    if schema_errors:
+        if json_mode:
+            print(json.dumps({"overall": "SCHEMA_FAIL", "schema_errors": schema_errors}, indent=2))
+        else:
+            print("❌ Schema invalid (exit 2). Errors:")
+            for e in schema_errors:
+                print(f"   · {e}")
+        return 2
+
+    # Step 2: reality checks
+    report = run_all_checks(manifest, engine_repo)
+    print_report(report, json_mode)
+    return 0 if report["overall"] == "PASS" else 1
+
+
+def run_self_test() -> int:
+    """Iterate bundled fixtures; must_pass expect 0, must_fail expect 1."""
+    if not FIXTURES_DIR.is_dir():
+        print(f"❌ fixtures dir not found: {FIXTURES_DIR}")
+        return 1
+
+    must_pass = sorted((FIXTURES_DIR / "must_pass").glob("*.yaml"))
+    must_fail = sorted((FIXTURES_DIR / "must_fail").glob("*.yaml"))
+
+    print("═" * 60)
+    print(f"  Self-test: {len(must_pass)} must_pass + {len(must_fail)} must_fail")
+    print("═" * 60)
+
+    failures = []
+
+    for manifest_path in must_pass:
+        repo = manifest_path.parent / (manifest_path.stem + "_repo")
+        manifest = load_yaml(manifest_path)
+        schema_errors = schema_check(manifest)
+        if schema_errors:
+            failures.append(f"must_pass {manifest_path.name}: schema invalid: {schema_errors}")
+            print(f"  ❌ {manifest_path.name}: expected PASS, got SCHEMA_FAIL")
+            continue
+        report = run_all_checks(manifest, repo)
+        if report["overall"] == "PASS":
+            print(f"  ✅ {manifest_path.name}: PASS (as expected)")
+        else:
+            fails = [c for c in report["checks"] if c["status"] == "FAIL"]
+            failures.append(
+                f"must_pass {manifest_path.name}: expected PASS but {len(fails)} check(s) failed: "
+                f"{[c['check'] for c in fails]}"
+            )
+            print(f"  ❌ {manifest_path.name}: expected PASS, got FAIL ({[c['check'] for c in fails]})")
+
+    for manifest_path in must_fail:
+        repo = manifest_path.parent / (manifest_path.stem + "_repo")
+        manifest = load_yaml(manifest_path)
+        schema_errors = schema_check(manifest)
+        if schema_errors:
+            # A must_fail fixture failing schema would be ambiguous (would exit 2,
+            # not 1). Self-test asserts each must_fail isolates one reality check.
+            failures.append(
+                f"must_fail {manifest_path.name}: leaked into schema-fail bucket "
+                f"(should isolate a single reality-check failure, not a schema break): {schema_errors}"
+            )
+            print(f"  ❌ {manifest_path.name}: expected reality FAIL, got SCHEMA_FAIL")
+            continue
+        report = run_all_checks(manifest, repo)
+        if report["overall"] == "FAIL":
+            failed_checks = [c["check"] for c in report["checks"] if c["status"] == "FAIL"]
+            if len(failed_checks) == 1:
+                print(f"  ✅ {manifest_path.name}: FAIL (isolated to {failed_checks[0]})")
+            else:
+                failures.append(
+                    f"must_fail {manifest_path.name}: expected single isolated failure but "
+                    f"{len(failed_checks)} checks failed: {failed_checks}"
+                )
+                print(f"  ❌ {manifest_path.name}: multi-check failure {failed_checks} — fixture not isolated")
+        else:
+            failures.append(f"must_fail {manifest_path.name}: expected FAIL, got PASS")
+            print(f"  ❌ {manifest_path.name}: expected FAIL, got PASS")
+
+    print("═" * 60)
+    if failures:
+        print(f"  Self-test FAILED ({len(failures)} issue(s))")
+        for f in failures:
+            print(f"   · {f}")
+        return 1
+    print(f"  Self-test PASSED ({len(must_pass)} must_pass + {len(must_fail)} must_fail)")
+    print("═" * 60)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Engine Manifest Reality Validator (Phase 0c.4, Hard Gate 5)"
+    )
+    parser.add_argument("--manifest-path", type=Path, help="Path to engine_manifest.yaml")
+    parser.add_argument(
+        "--engine-repo",
+        type=Path,
+        help="Engine repo root (entrypoint resolution base). Default: dirname(manifest-path).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON report on stdout")
+    parser.add_argument("--self-test", action="store_true", help="Run bundled fixture self-test")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return run_self_test()
+
+    if not args.manifest_path:
+        parser.error("--manifest-path is required unless --self-test is given")
+
+    manifest_path = args.manifest_path.resolve()
+    if not manifest_path.is_file():
+        print(f"❌ manifest not found: {manifest_path}")
+        return 1
+
+    engine_repo = (args.engine_repo or manifest_path.parent).resolve()
+    if not engine_repo.is_dir():
+        print(f"❌ engine repo dir not found: {engine_repo}")
+        return 1
+
+    return validate_one(manifest_path, engine_repo, args.json)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_dangling_gate_ref.yaml
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_dangling_gate_ref.yaml
@@ -1,0 +1,62 @@
+# Self-test fixture: R3 FAIL only — capability references runtime_gate id
+# that is not declared in runtime_gates[]. All other checks pass.
+schema_version: "2.0"
+engine_id: amazon-growth-engine
+engine_version: "1.0.0"
+domain: amazon-advertising
+contracts_compat: ">=2.0 <3.0"
+
+playbooks:
+  - id: anomaly_detect
+    entrypoint: src/playbooks/anomaly_detect.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:metrics
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+  - id: alert_score
+    entrypoint: src/playbooks/alert_score.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:alert_history
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+  - id: bid_recommend
+    entrypoint: src/playbooks/bid_recommend.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:ads_api
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+
+data_sources:
+  - type: ads_api
+    description: "fixture placeholder"
+    required: true
+
+write_capability_declared: none
+write_capability_effective: none
+
+capabilities:
+  - id: emit_fact_run_outcome
+    description: "fixture placeholder — gate_refs has a typo to trip R3"
+    boundary: fact_emit
+    required_permissions:
+      - write:fact_events
+    runtime_gate_refs:
+      - emit_fact_enabled_typo
+    status: placeholder
+
+runtime_gates:
+  - id: emit_fact_enabled
+    kind: env_var
+    var_name: AGE_FACT_EMIT_ENABLED
+    description: "fixture placeholder — id mismatches the capability ref above"
+    default_state: closed
+    evidence_required_for_open: "Phase 1a impl + 30d PASS"

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_dangling_gate_ref_repo/src/playbooks/alert_score.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_dangling_gate_ref_repo/src/playbooks/alert_score.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_dangling_gate_ref_repo/src/playbooks/anomaly_detect.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_dangling_gate_ref_repo/src/playbooks/anomaly_detect.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_dangling_gate_ref_repo/src/playbooks/bid_recommend.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_dangling_gate_ref_repo/src/playbooks/bid_recommend.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_effective_superset.yaml
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_effective_superset.yaml
@@ -1,0 +1,64 @@
+# Self-test fixture: R4 FAIL only — effective='full' exceeds declared='limited'.
+# engine_id deliberately != 'amazon-growth-engine' so R6 (Pilot 1 invariant)
+# does not also fire, isolating the failure to R4.
+schema_version: "2.0"
+engine_id: fixture-non-pilot1-engine
+engine_version: "1.0.0"
+domain: fixture-domain
+contracts_compat: ">=2.0 <3.0"
+
+playbooks:
+  - id: anomaly_detect
+    entrypoint: src/playbooks/anomaly_detect.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:metrics
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+  - id: alert_score
+    entrypoint: src/playbooks/alert_score.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:alert_history
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+  - id: bid_recommend
+    entrypoint: src/playbooks/bid_recommend.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:ads_api
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+
+data_sources:
+  - type: ads_api
+    description: "fixture placeholder"
+    required: true
+
+# effective='full' > declared='limited' → R4 trips
+write_capability_declared: limited
+write_capability_effective: full
+
+capabilities:
+  - id: emit_fact_run_outcome
+    description: "fixture placeholder"
+    boundary: fact_emit
+    required_permissions:
+      - write:fact_events
+    runtime_gate_refs:
+      - emit_fact_enabled
+    status: placeholder
+
+runtime_gates:
+  - id: emit_fact_enabled
+    kind: env_var
+    var_name: AGE_FACT_EMIT_ENABLED
+    description: "fixture placeholder"
+    default_state: closed
+    evidence_required_for_open: "Phase 1a impl + 30d PASS"

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_effective_superset_repo/src/playbooks/alert_score.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_effective_superset_repo/src/playbooks/alert_score.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_effective_superset_repo/src/playbooks/anomaly_detect.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_effective_superset_repo/src/playbooks/anomaly_detect.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_effective_superset_repo/src/playbooks/bid_recommend.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_effective_superset_repo/src/playbooks/bid_recommend.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_missing_entrypoint.yaml
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_missing_entrypoint.yaml
@@ -1,0 +1,63 @@
+# Self-test fixture: R1 FAIL only — alert_score.py intentionally missing
+# from paired _repo (anomaly_detect.py + bid_recommend.py present). All
+# other reality checks pass.
+schema_version: "2.0"
+engine_id: amazon-growth-engine
+engine_version: "1.0.0"
+domain: amazon-advertising
+contracts_compat: ">=2.0 <3.0"
+
+playbooks:
+  - id: anomaly_detect
+    entrypoint: src/playbooks/anomaly_detect.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:metrics
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+  - id: alert_score
+    entrypoint: src/playbooks/alert_score.py
+    description: "fixture placeholder — intentionally missing on disk"
+    required_permissions:
+      - read:alert_history
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+  - id: bid_recommend
+    entrypoint: src/playbooks/bid_recommend.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:ads_api
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+
+data_sources:
+  - type: ads_api
+    description: "fixture placeholder"
+    required: true
+
+write_capability_declared: none
+write_capability_effective: none
+
+capabilities:
+  - id: emit_fact_run_outcome
+    description: "fixture placeholder"
+    boundary: fact_emit
+    required_permissions:
+      - write:fact_events
+    runtime_gate_refs:
+      - emit_fact_enabled
+    status: placeholder
+
+runtime_gates:
+  - id: emit_fact_enabled
+    kind: env_var
+    var_name: AGE_FACT_EMIT_ENABLED
+    description: "fixture placeholder"
+    default_state: closed
+    evidence_required_for_open: "Phase 1a impl + 30d PASS"

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_missing_entrypoint_repo/src/playbooks/anomaly_detect.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_missing_entrypoint_repo/src/playbooks/anomaly_detect.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_missing_entrypoint_repo/src/playbooks/bid_recommend.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_missing_entrypoint_repo/src/playbooks/bid_recommend.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_pilot1_violation.yaml
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_pilot1_violation.yaml
@@ -1,0 +1,64 @@
+# Self-test fixture: R6 FAIL only — engine_id=amazon-growth-engine but
+# write_capability_effective='limited' (Pilot 1 requires effective='none').
+# declared also set to 'limited' so R4 (effective ≤ declared) still passes.
+schema_version: "2.0"
+engine_id: amazon-growth-engine
+engine_version: "1.0.0"
+domain: amazon-advertising
+contracts_compat: ">=2.0 <3.0"
+
+playbooks:
+  - id: anomaly_detect
+    entrypoint: src/playbooks/anomaly_detect.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:metrics
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+  - id: alert_score
+    entrypoint: src/playbooks/alert_score.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:alert_history
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+  - id: bid_recommend
+    entrypoint: src/playbooks/bid_recommend.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:ads_api
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+
+data_sources:
+  - type: ads_api
+    description: "fixture placeholder"
+    required: true
+
+# declared = limited so R4 (effective ≤ declared) passes; only R6 fires
+write_capability_declared: limited
+write_capability_effective: limited
+
+capabilities:
+  - id: emit_fact_run_outcome
+    description: "fixture placeholder"
+    boundary: fact_emit
+    required_permissions:
+      - write:fact_events
+    runtime_gate_refs:
+      - emit_fact_enabled
+    status: placeholder
+
+runtime_gates:
+  - id: emit_fact_enabled
+    kind: env_var
+    var_name: AGE_FACT_EMIT_ENABLED
+    description: "fixture placeholder"
+    default_state: closed
+    evidence_required_for_open: "Phase 1a impl + 30d PASS"

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_pilot1_violation_repo/src/playbooks/alert_score.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_pilot1_violation_repo/src/playbooks/alert_score.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_pilot1_violation_repo/src/playbooks/anomaly_detect.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_pilot1_violation_repo/src/playbooks/anomaly_detect.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_pilot1_violation_repo/src/playbooks/bid_recommend.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_fail/manifest_pilot1_violation_repo/src/playbooks/bid_recommend.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_pilot1_proper.yaml
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_pilot1_proper.yaml
@@ -1,0 +1,61 @@
+# Self-test fixture: AGE-shaped clean Pilot 1 manifest. All reality checks PASS.
+schema_version: "2.0"
+engine_id: amazon-growth-engine
+engine_version: "1.0.0"
+domain: amazon-advertising
+contracts_compat: ">=2.0 <3.0"
+
+playbooks:
+  - id: anomaly_detect
+    entrypoint: src/playbooks/anomaly_detect.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:metrics
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+  - id: alert_score
+    entrypoint: src/playbooks/alert_score.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:alert_history
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+  - id: bid_recommend
+    entrypoint: src/playbooks/bid_recommend.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:ads_api
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+
+data_sources:
+  - type: ads_api
+    description: "Amazon Ads API (read-only)"
+    required: true
+
+write_capability_declared: none
+write_capability_effective: none
+
+capabilities:
+  - id: emit_fact_run_outcome
+    description: "fixture placeholder D-14 fact emit"
+    boundary: fact_emit
+    required_permissions:
+      - write:fact_events
+    runtime_gate_refs:
+      - emit_fact_enabled
+    status: placeholder
+
+runtime_gates:
+  - id: emit_fact_enabled
+    kind: env_var
+    var_name: AGE_FACT_EMIT_ENABLED
+    description: "fixture placeholder"
+    default_state: closed
+    evidence_required_for_open: "Phase 1a impl + 30d PASS"

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_pilot1_proper_repo/src/playbooks/alert_score.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_pilot1_proper_repo/src/playbooks/alert_score.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_pilot1_proper_repo/src/playbooks/anomaly_detect.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_pilot1_proper_repo/src/playbooks/anomaly_detect.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_pilot1_proper_repo/src/playbooks/bid_recommend.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_pilot1_proper_repo/src/playbooks/bid_recommend.py
@@ -1,0 +1,1 @@
+# fixture placeholder — do not import


### PR DESCRIPTION
## Scope

Phase 0c.4 of Checkpoint B2: `validate_manifest_reality.py` — runtime reality validator for `engine_manifest.yaml` beyond schema shape. Single commit (`5f7caba`).

## Context

- PR #138 squash-merged to main as `437e3e1` (2026-05-28) — v2 schema + dual-routing validator + 0c.2 hotfix bundle landed
- AGE PR #370 (https://github.com/loudmirror/amazon-growth-engine/pull/370) — empirical reality target (engine_manifest.yaml v2 migration, commit `6cd4847`)
- Sprint 9 readout SIGNED (loamwise `cb4d4b0`) — gate condition上层

## What landed

`_meta/contracts/scripts/validate_manifest_reality.py` (335 LOC) + 5 self-test fixtures (1 must_pass + 4 must_fail) with placeholder entrypoint files.

**6 reality checks**:
- `R1 playbook_entrypoints`: each `playbooks[].entrypoint` file exists in engine_repo
- `R2 data_source_paths`: each `data_sources[].path` (if declared) exists — vacuous on current AGE manifest since v2 schema doesn't define `path` field; check is wired for future engines
- `R3 capability_gate_refs`: each `capabilities[].runtime_gate_refs` resolves to an entry in `runtime_gates[]`
- `R4 effective_within_declared`: `write_capability_effective` ⊆ `write_capability_declared`
- `R5 schema_version_routing`: declared `schema_version` matches routed schema `$id`
- `R6 pilot1_invariant`: for `engine_id=amazon-growth-engine`, all `write_capability_effective` are disabled/dry_run (GHL Hard Gate 8)

## Validation evidence

**Self-test** (1 must_pass + 4 must_fail, each must_fail isolated to 1 check)
```
✅ manifest_pilot1_proper.yaml: PASS
✅ manifest_dangling_gate_ref.yaml: FAIL on R3 only
✅ manifest_effective_superset.yaml: FAIL on R4 only
✅ manifest_missing_entrypoint.yaml: FAIL on R1 only
✅ manifest_pilot1_violation.yaml: FAIL on R6 only
Self-test PASSED
```

**End-to-end against AGE PR #370** (commit `6cd4847`, blob extracted via `git show` — AGE working tree untouched)
```
engine_id      = amazon-growth-engine
schema_version = 2.0
  ✅ R1_playbook_entrypoints: PASS
  ✅ R2_data_source_paths: PASS  (NO-OP — schema 无 path 字段)
  ✅ R3_capability_gate_refs: PASS  (emit_fact_enabled resolves)
  ✅ R4_effective_within_declared: PASS  (none ≤ none)
  ✅ R5_schema_version_routing: PASS  (2.0 → v2 schema $id)
  ✅ R6_pilot1_invariant: PASS  (effective=none, Pilot 1 OK)
Overall: PASS  exit=0
```

## CLI

```bash
python3 _meta/contracts/scripts/validate_manifest_reality.py \
  --manifest-path <yaml> \
  [--engine-repo <dir>] \
  [--json] \
  [--self-test]
```

Exit codes: `0` = all PASS · `1` = reality FAIL · `2` = schema shape FAIL (delegated to 0c.2 — uses Python `jsonschema` Draft7Validator matching v2 schema's `$schema`).

## Merge sequencing

This PR should **NOT merge yet**. Cross-repo dependency with AGE PR #370 is symmetric:
- AGE `6cd4847` 已通过 0c.4 reality validation (above evidence)
- 0c.4 已通过 self-test + e2e against AGE `6cd4847`
- Either can merge first; user decides order based on contract evolution preference

## Coverage gaps (acceptable, not blocker)

- **R2 has no must_fail fixture** — vacuous on AGE because v2 schema doesn't define `data_sources[].path`. Wired for future engines that do; add fixture then.
- **R5 has no must_fail fixture** — `schema_version` mismatch is caught at schema-shape layer (exit 2), not reality layer (exit 1). Correct that R5 isolation isn't reachable in reality validator.

## Pre-commit lint证伪

Pre-commit hook (`64164be` forbidden-name lint, Phase 0f) intercepted a bare `candidate` identifier during development → renamed `resolved_path` → 通过. First production-grade catch of the lint gate built in B1.

## Out-of-scope

- Phase 1a `emit_fact.py` (separate gating sequence)
- pre-commit / CI integration of `validate_manifest_reality.py` (Phase 1 timing per原 Task 2b instruction)
- AGE-side runtime changes

## Refs

- GHL Hard Gate 5: "任何接入 source 必须通过 manifest reality validator"
- errata-v1 §D-14 — AGE explicit emit_fact gate
- PR #138 squash `437e3e1` — prerequisites landed
- AGE PR #370 — cross-repo reality target
- loamwise Sprint 9 readout `cb4d4b0` — upstream signoff