### PR TITLE
feat(policy): add Policy 9 Surgical Scope + portfolio inheritance pointer

### DIFF
--- a/.claude/packs/protocols.md
+++ b/.claude/packs/protocols.md
@@ -125,6 +125,24 @@ Claude:
   4. Please see: [file path]
 ```
 
+## Surgical Changes
+
+**Touch only what the task requires; clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting that the task didn't ask you to touch.
+- Don't refactor things that aren't broken; match the existing style even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+- Remove only the imports/variables/functions that YOUR change made unused; leave pre-existing dead code unless asked.
+
+**The test:** every changed line should trace directly to the request.
+
+**Distinct from Write Preflight:** amazon-growth-engine `CLAUDE.md` "Write Preflight Discipline" checks *whether the environment matches* before you mutate (branch / repo / dirty); Surgical Scope governs *what* you change once you proceed. Complementary, not the same rule.
+
+**Authority:** governed by Policy 9 (Surgical Scope) in `_meta/policies/DEFAULT_SKILL_POLICY.md`. This section is the longer-form playbook, not a second source of truth.
+
+**Source:** paraphrased from karpathy-guidelines §3.
+
 ## Quality Gates
 
 ### Pre-commit Checklist

--- a/_meta/policies/DEFAULT_SKILL_POLICY.md
+++ b/_meta/policies/DEFAULT_SKILL_POLICY.md
@@ -27,7 +27,7 @@ Playbook (SKILL.md)       →  defines HOW (implementation)
 
 ---
 
-## Default Policies (8)
+## Default Policies (9)
 
 ### Policy 1: Test Before Code (TDD)
 
@@ -164,6 +164,25 @@ Playbook (SKILL.md)       →  defines HOW (implementation)
 
 ---
 
+### Policy 9: Surgical Scope
+
+**Statement:** When editing existing code, change only what the task requires — every changed line should trace to the request. Don't improve adjacent code, refactor what isn't broken, or reformat to taste. Note unrelated dead code rather than deleting it; remove only the orphans your own change created.
+
+**applies_to:** Editing or refactoring existing files, multi-file changes, any state-mutating Write/Edit on code or config
+
+**can_override:** Yes
+
+**typical_override_reason:**
+- User explicitly scopes a broader cleanup or refactor
+- Mechanical codebase-wide migration with a stated blast radius
+- Isolated, clearly-labeled formatting-only commits
+
+**Source:** karpathy-guidelines §3 (paraphrased); related repo discipline: amazon-growth-engine CLAUDE.md "Write Preflight Discipline"
+
+**Related authority (not restated here):** anti-overengineering / YAGNI → `_meta/docs/ARCHITECTURE_CONSTITUTION.md` 第2条 (最小完备原则); evidence-before-claims → `_meta/governance/SKILL_CONSTITUTION_v0.1.md` Rule 1 + Rule 6
+
+---
+
 ## Override Protocol
 
 To override a policy in a specific Skill:
@@ -198,3 +217,4 @@ A Policy may be promoted to Constitutional Rule when:
 | Version | Date | Changes |
 |---------|------|---------|
 | v0.1 | 2026-01-16 | Initial release - 8 policies promoted from skill-guidelines.md |
+| v0.2 | 2026-05-29 | Add Policy 9 (Surgical Scope), paraphrased from karpathy-guidelines §3; anti-overengineering and evidence-before-claims referenced as pointers, not restated |

--- a/_meta/portfolio/SYSTEMS.md
+++ b/_meta/portfolio/SYSTEMS.md
@@ -7,6 +7,8 @@
 > **优先级规则：** 当 repo-local CLAUDE.md 与本文件冲突时，
 > 系统角色、层级、依赖方向以本文件为准；
 > 本地开发约束（编码规则、commit 纪律）以 repo CLAUDE.md 为准。
+> commit 纪律 = portfolio 执行基线（指针）+ repo delta；repo delta 可收紧、不得放松。
+> 执行基线定义见 `_meta/policies/DEFAULT_SKILL_POLICY.md` Policy 9 (Surgical Scope)。
 
 ## 四层架构
 


### PR DESCRIPTION
## What

Distill the one genuinely-new Karpathy guideline (**Surgical Scope**) into LiYe's existing governance surfaces. Of Karpathy's 4 principles, only Surgical Scope is a real gap for LiYe — the other 3 are already covered at higher governance tiers and are referenced as **pointers, not restated**.

## Changes (3 versioned files · 41+/1-)

- **`_meta/policies/DEFAULT_SKILL_POLICY.md`** — new **Policy 9: Surgical Scope** (English paraphrase, not verbatim). Anti-overengineering/YAGNI and evidence-before-claims are NOT restated — referenced as pointers to `ARCHITECTURE_CONSTITUTION.md` 第2条 and `SKILL_CONSTITUTION_v0.1.md` Rule 1+6 (which already cover them, at HARD-BLOCK tier). Title (8)→(9), changelog v0.2.
- **`_meta/portfolio/SYSTEMS.md`** — commit-discipline inheritance line (`baseline 指针 + repo delta`; repo may tighten, not loosen). Makes the thin-repo delta model real.
- **`.claude/packs/protocols.md`** — `## Surgical Changes` playbook section, explicitly **distinct** from AGE Write Preflight (environment-check vs change-scope).

> A 4th edit — Canonical pointer in the portfolio navigator `/Users/liye/github/CLAUDE.md` — is **local-only / not versioned** (that dir is not a git repo). Noted for completeness; not part of this PR.

## Scope guard

0 new files · 0 assembler/regex change · 0 hooks · 0 `~/.claude`. guardrail char gate + all pre-commit gates pass.

## Out of scope — follow-ups (NOT this PR)

- **Two-Speed hooks not registered** — discovered during this work: `liye_os/.claude/settings.local.json` has no `hooks` key, so the `CLAUDE.md:220` Two-Speed / Stop-Gate / 3-strike policy is currently **not running**. Independent defect → separate issue.
- **C-shadow (surgical diff observer)** — deferred until Policy 9 accumulates 20-30 real samples + a carrier hook is registered. Building it now would itself violate Policy 9 (Anti-Overengineering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
