### PR TITLE
ci(phase-1b): add learning-importer-tests workflow

### DIFF
--- a/.github/workflows/learning-importer-tests.yml
+++ b/.github/workflows/learning-importer-tests.yml
@@ -1,0 +1,70 @@
+# Phase 1b Importer Tests
+#
+# Dedicated test gate for the liye_os fact importer (Phase 1b):
+#   .claude/scripts/learning/import_facts.mjs   — fact importer (dual-hash decision tree)
+#   .claude/scripts/learning/canonical_json.mjs — token-preserving JSON canonicalizer
+#   .claude/scripts/learning/tests/*.test.mjs   — 55 node:test (incl. golden.test.mjs)
+#
+# Why a dedicated workflow: these suites use the Node built-in runner (node:test),
+# which the root `npm test` (vitest) deliberately EXCLUDES — vitest.config.ts
+# excludes `.claude/scripts/learning/tests/**`. Without this workflow nothing in
+# CI runs them, so canonical_json / import_facts / fixture drift could silently
+# break the cross-language byte-equality contract.
+#
+# Scope decision (Phase 1b CI-wiring): this workflow runs ONLY the self-contained
+# Node test surface. golden.test.mjs already asserts the cross-language
+# byte-equality contract — it recomputes identity/content/record hashes with
+# import_facts.mjs and compares BYTE-for-byte against the committed
+# golden_sidecar.json (REAL emit_fact ground truth) — with zero AGE dependency.
+#
+# DEFERRED (FU-2, separate AGE-side PR): golden_harness.py --check re-runs the
+# LIVE AGE emit_fact to detect committed-fixture drift, so it must import AGE
+# (cross-repo). Detecting emit_fact drift belongs to AGE's own CI. This liye_os
+# workflow intentionally does NOT check out amazon-growth-engine and does NOT run
+# golden_harness.py --check (no cross-repo / network dependency).
+#
+# Reference: liye_os .planning/phase-1b/SPEC.md (blob 4a606e18) §3 DoD;
+#            Phase 1b IMPL closure d5a90ed.
+
+name: Phase 1b Importer Tests
+
+on:
+  pull_request:
+    paths:
+      - '.claude/scripts/learning/import_facts.mjs'
+      - '.claude/scripts/learning/canonical_json.mjs'
+      - '.claude/scripts/learning/tests/**'
+      - '_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml'
+      - '_meta/contracts/learning/fact_run_outcome_record_v1.schema.yaml'
+      - '.github/workflows/learning-importer-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude/scripts/learning/import_facts.mjs'
+      - '.claude/scripts/learning/canonical_json.mjs'
+      - '.claude/scripts/learning/tests/**'
+      - '_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml'
+      - '_meta/contracts/learning/fact_run_outcome_record_v1.schema.yaml'
+      - '.github/workflows/learning-importer-tests.yml'
+
+jobs:
+  node-tests:
+    name: node:test (importer)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies (ajv + yaml for import_facts.mjs)
+        run: npm ci
+
+      - name: Run importer node:test (55 tests, incl. golden.test.mjs byte-equality)
+        run: node --test .claude/scripts/learning/tests/*.test.mjs


### PR DESCRIPTION
## Phase 1b CI-wiring — `learning-importer-tests` workflow

Closes the documented Phase 1b IMPL follow-up (memory `project_ghl_phase_1b_impl`, review finding **#2**): the importer's 55 `node:test` were **not wired into CI**. The root `npm test` is vitest, and `vitest.config.ts` deliberately **excludes** `.claude/scripts/learning/tests/**` (the C7 fix in the IMPL PR), so nothing in CI ran them. A future Phase 1c+ change to `canonical_json.mjs` / `import_facts.mjs` / the fixtures could silently break the cross-language byte-equality contract. This workflow is that gate.

### What this adds
Single new file: `.github/workflows/learning-importer-tests.yml`. One job `node:test (importer)` — `node 18/20/22` matrix (mirrors `ci.yml`'s `Test` job) → `npm ci` (installs `ajv` + `yaml` that `import_facts.mjs` imports) → `node --test .claude/scripts/learning/tests/*.test.mjs` (**55 tests**, incl. `golden.test.mjs`).

### Path triggers (6) — on `pull_request` + `push:[main]`
- `.claude/scripts/learning/import_facts.mjs`
- `.claude/scripts/learning/canonical_json.mjs`
- `.claude/scripts/learning/tests/**`
- `_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml`
- `_meta/contracts/learning/fact_run_outcome_record_v1.schema.yaml`
- `.github/workflows/learning-importer-tests.yml` (self)

### Scope decision — `golden_harness.py --check` is DEFERRED (FU-2, AGE-side)
**Ground truth (empirically verified this session):** `golden_harness.py --check` unconditionally runs `build_golden()`, which does `from scripts.learning import emit_fact` (AGE code) **before** the fixture comparison. With no AGE on `sys.path` it exits 1 (`No module named 'scripts'`). Wiring it into liye_os CI would therefore require `actions/checkout` of `amazon-growth-engine` (a cross-repo dependency) — out of this PR's scope.

This is acceptable because the **cross-language byte-equality contract is already enforced** by `golden.test.mjs` inside the `node:test` job: it recomputes identity/content/record hashes with `import_facts.mjs` and asserts they **byte-equal** the committed `golden_sidecar.json` (REAL `emit_fact` ground truth) — with zero AGE dependency. What `--check` adds on top is **live-`emit_fact`-drift detection** (whether the committed fixtures have gone stale vs AGE's current `emit_fact`). Since `emit_fact` lives in AGE, that drift gate belongs to **AGE's own CI** and is tracked as **FU-2** (separate AGE-side PR).

### Guarantees (Hard NO — all retained)
- 0 changes to `.claude/scripts/learning/**` (importer code / tests / fixtures frozen)
- 0 changes to any existing `.github/workflows/*.yml`
- 0 changes to `_meta/contracts/` schemas / `vitest.config.ts`
- 0 cross-repo (`actions/checkout` of AGE) / 0 network deps (`curl` / `wget` / external API)
- 0 new dependencies (uses the existing root `package-lock.json` toolchain)
- no `--no-verify` / amend / force-push

### Test plan
This PR changes a file inside the workflow's own path triggers, so the workflow **self-runs on this PR** — expect the `node:test (importer)` job green on node 18/20/22. (Verified locally: `node --test …/*.test.mjs` → **55/55 pass**.)

### DoD
- [x] Single new workflow file; only file changed
- [x] 6 path triggers (importer + canonical + tests + 2 schemas + self)
- [x] `node:test` job incl. `golden.test.mjs` Node-side byte-equality assertion
- [ ] **DEFER**: `golden_harness.py --check` — AGE `emit_fact`-drift gate, tracked as FU-2 (AGE-side)
- [x] No `actions/checkout` of AGE / no cross-repo / no network step
- [x] Node matrix 18/20/22 matches `ci.yml` `Test`; `npm ci` + `cache:'npm'`
- [x] No new deps / no `vitest.config.ts` / no importer-code change
- [x] pre-commit hooks PASS (no `--no-verify`)

Reference: liye_os `.planning/phase-1b/SPEC.md` blob `4a606e18` §3 DoD; Phase 1b IMPL squash `d5a90ed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
