### PR TITLE
feat(1c): policy_trial_evaluator.mjs — GHL Phase 1c IMPL (SPEC blob c6975a6)

### DIFF
--- a/.github/workflows/learning-policy-trial-evaluator-tests.yml
+++ b/.github/workflows/learning-policy-trial-evaluator-tests.yml
@@ -1,0 +1,67 @@
+# Phase 1c Policy-Trial Evaluator Tests
+#
+# Dedicated test gate for the liye_os policy-trial evaluator (Phase 1c):
+#   src/reasoning/policy_trial_evaluator.mjs        — GHL policy-trial evaluator
+#   src/reasoning/tests/*.test.mjs                  — node:test suite
+#   .claude/scripts/learning/canonical_json.mjs     — reused canonicalizer (dependency)
+#   _meta/contracts/learning/policy_trial_v1.schema.yaml      — output contract (sealed)
+#   _meta/contracts/learning/operator_feedback_v1.schema.yaml — $ref target loaded by ajv
+#
+# Why a dedicated workflow (A7, learning from the Phase 1b CI-wiring split #149):
+# these suites use the Node built-in runner (node:test), which the root `npm test`
+# (vitest) deliberately EXCLUDES — vitest.config.ts excludes `src/reasoning/tests/**`.
+# Without this workflow nothing in CI runs them, so the evaluator / binding /
+# provenance-overlay / sealed-schema-validate / dangling-symlink-defense logic
+# could silently drift. The evaluator tests are CI-wired in the IMPLEMENTATION PR
+# (no follow-up CI-wiring PR).
+#
+# Scope (Phase 1b CI scope tightening, retained): node-only, self-contained. The
+# suite has ZERO cross-repo dependency — artifact-deref tests build a synthetic
+# engine repo in a tmp dir. This workflow intentionally does NOT check out
+# amazon-growth-engine and introduces no cross-repo / network dependency.
+#
+# Reference: liye_os .planning/phase-1c/SPEC.md (blob c6975a6) §3 DoD #13 + §4;
+#            Phase 1b importer tests workflow learning-importer-tests.yml (#149).
+
+name: Phase 1c Policy-Trial Evaluator Tests
+
+on:
+  pull_request:
+    paths:
+      - 'src/reasoning/policy_trial_evaluator.mjs'
+      - 'src/reasoning/tests/**'
+      - '.claude/scripts/learning/canonical_json.mjs'
+      - '_meta/contracts/learning/policy_trial_v1.schema.yaml'
+      - '_meta/contracts/learning/operator_feedback_v1.schema.yaml'
+      - '.github/workflows/learning-policy-trial-evaluator-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/reasoning/policy_trial_evaluator.mjs'
+      - 'src/reasoning/tests/**'
+      - '.claude/scripts/learning/canonical_json.mjs'
+      - '_meta/contracts/learning/policy_trial_v1.schema.yaml'
+      - '_meta/contracts/learning/operator_feedback_v1.schema.yaml'
+      - '.github/workflows/learning-policy-trial-evaluator-tests.yml'
+
+jobs:
+  node-tests:
+    name: node:test (policy_trial_evaluator)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies (ajv + yaml for policy_trial_evaluator.mjs)
+        run: npm ci
+
+      - name: Run policy-trial evaluator node:test
+        run: node --test src/reasoning/tests/*.test.mjs

--- a/src/reasoning/policy_trial_evaluator.mjs
+++ b/src/reasoning/policy_trial_evaluator.mjs
@@ -284,20 +284,30 @@ function writeExclusive(filePath, data) {
   return true;
 }
 
-/** Serialize the evidence-ledger side-car (hand-built, mirrors 1b conflict_meta style; all values ASCII-safe). */
+/**
+ * Serialize the evidence-ledger side-car (hand-built, mirrors 1b conflict_meta style).
+ * String scalars sourced from event / policy inputs are emitted via JSON.stringify,
+ * which produces a valid YAML 1.2 double-quoted scalar (YAML and JSON share the
+ * same escaping for ", \, control chars, and U+2028/U+2029). A hostile or corrupt
+ * trace_id / policy_id / validator-status string therefore cannot break the YAML
+ * or inject keys -- the importer is the trust boundary, but the evaluator must not
+ * assume its inputs are YAML-safe. bound_via and provenance_dirty are controlled
+ * module values (enum constant / boolean).
+ */
 function ledgerToYaml(ledger) {
-  const reasons = ledger.provenance_reasons.map((r) => `"${r}"`).join(', ');
+  const q = (v) => JSON.stringify(String(v));
+  const reasons = ledger.provenance_reasons.map((r) => q(r)).join(', ');
   return [
-    `trial_id: "${ledger.trial_id}"`,
-    `policy_id: "${ledger.policy_id}"`,
-    `canonical_record_hash: "${ledger.canonical_record_hash}"`,
-    `source_event_identity_key: "${ledger.source_event_identity_key}"`,
-    `trace_id: "${ledger.trace_id}"`,
+    `trial_id: ${q(ledger.trial_id)}`,
+    `policy_id: ${q(ledger.policy_id)}`,
+    `canonical_record_hash: ${q(ledger.canonical_record_hash)}`,
+    `source_event_identity_key: ${q(ledger.source_event_identity_key)}`,
+    `trace_id: ${q(ledger.trace_id)}`,
     `bound_via: ${ledger.bound_via}`,
     `provenance_dirty: ${ledger.provenance_dirty ? 'true' : 'false'}`,
     `provenance_reasons: [${reasons}]`,
-    `conflict_dir: "${ledger.conflict_dir}"`,
-    `evaluated_at: "${ledger.evaluated_at}"`,
+    `conflict_dir: ${q(ledger.conflict_dir)}`,
+    `evaluated_at: ${q(ledger.evaluated_at)}`,
     '',
   ].join('\n');
 }

--- a/src/reasoning/policy_trial_evaluator.mjs
+++ b/src/reasoning/policy_trial_evaluator.mjs
@@ -1,0 +1,691 @@
+#!/usr/bin/env node
+/**
+ * policy_trial_evaluator.mjs - Phase 1c GHL policy-trial evaluator (liye_os, NEW file).
+ * SSOT: src/reasoning/policy_trial_evaluator.mjs
+ *
+ * Normative: SPEC `.planning/phase-1c/SPEC.md` v1.0 (blob c6975a6).
+ * Upstream: Phase 1b importer `.claude/scripts/learning/import_facts.mjs` (blob 39f02581)
+ *           + `canonical_json.mjs` (blob 42b05d04), both FROZEN CODE-SSOT.
+ *
+ * WHAT THIS DOES (SPEC scope):
+ *   Reads the 1b importer output:
+ *     - state/runtime/learning/fact_conflicts/<source_system>/<identityHex>/  (duplicate_conflict 情形2 = the only trial source)
+ *     - state/memory/facts/fact_run_outcome_records.jsonl                     (metrics + artifact-deref binding rehearsal; produces NO trial in 1c)
+ *   Binds policy_id by EXPLICIT reference only (A6), renders the Pilot 1
+ *   negative-learning verdict (A5: only duplicate_conflict 情形2 -> NEEDS_HUMAN
+ *   with provenance overlay), and writes:
+ *     - state/runtime/learning/policy_trials.jsonl                 (policy_trial_v1, sealed schema)
+ *     - state/runtime/learning/policy_trials_evidence/<trial_id>.yaml  (evidence-ledger side-car, A3)
+ *
+ * POSTURE (SPEC §1.8 / §2):
+ *   dry-run-first (default; 0 disk writes), manual CLI only, NO scheduler.
+ *   observability-only (Hard Gate 8): no production_write, no AGE / loamwise /
+ *   heartbeat / schema mutation, no learned_policy write-back (trial_history
+ *   deferred to 1d/2a). Expected `bound=0` at 1c runtime is BY-DESIGN (SPEC §1.3 F5).
+ *
+ * REUSE (SPEC: do not self-implement canonicalization):
+ *   canonical_record_hash is recomputed via canonical_json.mjs `hashCanonical`.
+ *   For a raw conflict event (incoming.json = the 20 event fields, no importer
+ *   fields), hashCanonical(eventAst) == the 1b canonical_record_hash invariant
+ *   (import_facts.computeCanonicalRecordHash drops only the 4 importer fields,
+ *   none of which are present in incoming.json). We deliberately depend on the
+ *   SPEC-named canonical module, not on import_facts internals.
+ */
+
+import {
+  readFileSync, readdirSync, existsSync, realpathSync,
+  lstatSync, readlinkSync, mkdirSync, openSync, writeSync, closeSync, appendFileSync,
+} from 'fs';
+import { join, dirname, resolve, sep, relative } from 'path';
+import { fileURLToPath } from 'url';
+import { createHash } from 'crypto';
+import { parse as parseYaml } from 'yaml';
+import Ajv from 'ajv';
+
+import {
+  parseCanonical, hashCanonical, getEntry, astToValue,
+} from '../../.claude/scripts/learning/canonical_json.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = join(__dirname, '..', '..');
+
+// --------------------------------------------------------------------------- //
+// Locked constants
+// --------------------------------------------------------------------------- //
+
+export const SCHEMA_VERSION = '1.0.0';
+
+// RFC 4122 URL namespace + the policy_trial.v1 contract $id -> the GHL trial namespace.
+const NAMESPACE_URL = '6ba7b811-9dad-11d1-80b4-00c04fd430c8';
+export const POLICY_TRIAL_V1_URI = 'https://liye.com/contracts/learning/policy_trial.v1';
+
+// Default I/O paths (repo-relative; resolved under rootDir test seam).
+const DEFAULT_RECORDS = 'state/memory/facts/fact_run_outcome_records.jsonl';
+const DEFAULT_CONFLICTS = 'state/runtime/learning/fact_conflicts';
+const DEFAULT_POLICIES = 'state/memory/learned/policies';
+const DEFAULT_TRIALS_OUT = 'state/runtime/learning/policy_trials.jsonl';
+const EVIDENCE_LEDGER_DIR = 'state/runtime/learning/policy_trials_evidence';
+
+// learned_policy lifecycle dirs (binding scan target). Both legacy + GHL schema
+// instances live here and both carry evidence[].trace_id (SPEC §0 N0).
+const POLICY_STATUS_DIRS = ['sandbox', 'candidate', 'production', 'disabled', 'quarantine'];
+
+// Stricter-than-emit repo-relative path regex for artifact-deref (mirrors 1b
+// import_facts STRICT_PATH_RE: no leading '/' or '~', no '..' segment).
+const STRICT_PATH_RE = /^(?![~/])(?!.*\.\.)[a-zA-Z0-9_./-]+$/;
+
+// The ONLY reason codes referenced by this module (SPEC A5: the other 7 negative
+// codes + the 8th non-negative all-clear code have ZERO code reference here --
+// surgical, no scaffolding; enforced by a grep assertion in the test suite).
+const REASON_DUPLICATE_CONFLICT = 'duplicate_conflict';
+const REASON_SOURCE_DIRTY = 'source_dirty';
+const REASON_MANIFEST_VALIDATOR_FAILED = 'manifest_validator_failed';
+
+// bound_via channels (SPEC §1.3).
+const BOUND_VIA_CONFLICT_TRACE = 'conflict_trace_evidence';
+const BOUND_VIA_ARTIFACT_DEREF = 'artifact_deref';
+
+const EXIT = { SUCCESS: 0, FAIL_CLOSED: 2, UNEXPECTED: 1 };
+
+// --------------------------------------------------------------------------- //
+// uuidv5 (RFC 4122, sha1-based, dependency-free). NOT canonicalization; a
+// standard deterministic hash-to-UUID. Verified against the published vectors
+// uuidv5(DNS,"python.org") and uuidv5(DNS,"example.com") in the test suite.
+// --------------------------------------------------------------------------- //
+
+export function uuidv5(name, namespaceUuid) {
+  const nsHex = String(namespaceUuid).replace(/-/g, '');
+  if (nsHex.length !== 32 || /[^0-9a-fA-F]/.test(nsHex)) {
+    throw new Error(`uuidv5: bad namespace uuid ${namespaceUuid}`);
+  }
+  const nsBytes = Buffer.from(nsHex, 'hex');
+  const nameBytes = Buffer.from(String(name), 'utf-8');
+  const digest = createHash('sha1').update(Buffer.concat([nsBytes, nameBytes])).digest();
+  const out = Buffer.from(digest.subarray(0, 16));
+  out[6] = (out[6] & 0x0f) | 0x50; // version 5
+  out[8] = (out[8] & 0x3f) | 0x80; // RFC 4122 variant
+  const hex = out.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+// Pinned GHL trial namespace (SPEC A4: pin the computed literal + assert in test).
+export const NAMESPACE_GHL = uuidv5(POLICY_TRIAL_V1_URI, NAMESPACE_URL);
+export const NAMESPACE_GHL_PINNED = '639e6922-8cd2-5f67-807d-f2759a14ad20';
+
+/** trial_id = uuidv5(NAMESPACE_GHL, canonical_record_hash + "|" + policy_id) (SPEC A4; no verdict_context_tag). */
+export function computeTrialId(canonicalRecordHash, policyId) {
+  return uuidv5(`${canonicalRecordHash}|${policyId}`, NAMESPACE_GHL);
+}
+
+// --------------------------------------------------------------------------- //
+// Path defense for artifact-deref (SPEC §1.3 channel 2).
+//
+// `resolveSymlinksAllowingMissing` is reproduced VERBATIM from the FROZEN 1b
+// import_facts.mjs (CODE-SSOT). It is module-private there and cannot be
+// exported without modifying a frozen Phase-1b artifact (Hard NO), so the
+// proven dangling-symlink defense is reproduced here. DO NOT diverge; if the 1b
+// implementation changes, sync this copy. (1b adversarial finding #1: a naive
+// realpath walk treats a dangling-outside symlink as a safe missing leaf and
+// lets it escape; this resolver follows the link TEXT even when the target is
+// missing, so 1c/1d dereferencing consumers inherit the same trust boundary.)
+// --------------------------------------------------------------------------- //
+
+function resolveSymlinksAllowingMissing(absPath) {
+  const resolved = [];
+  let queue = absPath.startsWith(sep) ? absPath.slice(1).split(sep) : absPath.split(sep);
+  let iterations = 0;
+  while (queue.length) {
+    if (++iterations > 8192) break; // symlink-cycle guard
+    const name = queue.shift();
+    if (name === '' || name === '.') continue;
+    if (name === '..') { resolved.pop(); continue; }
+    const probePath = sep + [...resolved, name].join(sep);
+    let st;
+    try { st = lstatSync(probePath); }
+    catch (err) { if (err.code === 'ENOENT') { resolved.push(name); continue; } throw err; }
+    if (st.isSymbolicLink()) {
+      let target;
+      try { target = readlinkSync(probePath); } catch { resolved.push(name); continue; }
+      if (target.startsWith(sep)) { resolved.length = 0; queue = target.slice(1).split(sep).concat(queue); }
+      else { queue = target.split(sep).concat(queue); } // relative to the symlink's parent
+    } else {
+      resolved.push(name);
+    }
+  }
+  return sep + resolved.join(sep);
+}
+
+/**
+ * Resolve a repo-relative artifact path within the engine repo. Lexical strict
+ * regex always; realpath must stay within the engine repo (symlink-escape
+ * defense). Returns the resolved absolute path if safe, else null.
+ */
+function resolveArtifactWithinRepo(engineRepoReal, relPath) {
+  if (!engineRepoReal || typeof relPath !== 'string' || !STRICT_PATH_RE.test(relPath)) return null;
+  const abs = resolve(engineRepoReal, relPath);
+  const real = resolveSymlinksAllowingMissing(abs);
+  if (real !== engineRepoReal && !real.startsWith(engineRepoReal + sep)) return null; // escape
+  return real;
+}
+
+// --------------------------------------------------------------------------- //
+// Schema validation (ajv Draft-07; matches 1b: strict off, no format).
+// policy_trial_v1 references operator_feedback_v1 via a relative $ref; ajv must
+// have that schema registered under the resolved absolute URI before compile.
+// --------------------------------------------------------------------------- //
+
+export function buildTrialValidator(projectRoot = PROJECT_ROOT) {
+  const ajv = new Ajv({ strict: false, allErrors: true, validateFormats: false });
+  const opSchema = parseYaml(readFileSync(
+    join(projectRoot, '_meta/contracts/learning/operator_feedback_v1.schema.yaml'), 'utf-8'));
+  const trialSchema = parseYaml(readFileSync(
+    join(projectRoot, '_meta/contracts/learning/policy_trial_v1.schema.yaml'), 'utf-8'));
+  // Resolved base of the relative $ref `operator_feedback_v1.schema.yaml#`
+  // against the policy_trial.v1 $id (last path segment replaced).
+  ajv.addSchema(opSchema, 'https://liye.com/contracts/learning/operator_feedback_v1.schema.yaml');
+  return ajv.compile(trialSchema);
+}
+
+function firstError(validate) {
+  const e = validate.errors && validate.errors[0];
+  if (!e) return 'schema invalid';
+  return `${e.instancePath || '<root>'} ${e.message}`;
+}
+
+// --------------------------------------------------------------------------- //
+// Policy binding index: trace_id -> Set<policy_id> (SPEC §1.3 channel 1).
+// --------------------------------------------------------------------------- //
+
+export function buildPolicyTraceIndex(policiesDirAbs) {
+  const index = new Map();
+  if (!existsSync(policiesDirAbs)) return index;
+  for (const status of POLICY_STATUS_DIRS) {
+    const statusDir = join(policiesDirAbs, status);
+    if (!existsSync(statusDir)) continue;
+    let names;
+    try { names = readdirSync(statusDir); } catch { continue; }
+    for (const name of names) {
+      if (!name.endsWith('.yaml') && !name.endsWith('.yml')) continue;
+      let doc;
+      try { doc = parseYaml(readFileSync(join(statusDir, name), 'utf-8')); } catch { continue; }
+      if (!doc || typeof doc.policy_id !== 'string' || !Array.isArray(doc.evidence)) continue;
+      for (const ev of doc.evidence) {
+        if (ev && typeof ev.trace_id === 'string') {
+          if (!index.has(ev.trace_id)) index.set(ev.trace_id, new Set());
+          index.get(ev.trace_id).add(doc.policy_id);
+        }
+      }
+    }
+  }
+  return index;
+}
+
+// --------------------------------------------------------------------------- //
+// Verdict + provenance overlay derivation (SPEC §1.4 / §1.6).
+// --------------------------------------------------------------------------- //
+
+/**
+ * 情形2 verdict reason codes = [duplicate_conflict] + provenance overlay.
+ *   - source_dirty: from the INCOMING event field (SPEC §1.4 "incoming ... source_dirty").
+ *   - manifest_validator_failed: from the ORIGINAL stored record's provenance
+ *     (the only place manifest_validator_status exists; the raw incoming event
+ *     has no validator status, which the importer computes at ingest time).
+ * Returns { reasonCodes, provenanceReasons, provenanceDirty }.
+ */
+export function deriveVerdictReasonCodes(incomingObj, originalObj) {
+  const reasonCodes = [REASON_DUPLICATE_CONFLICT];
+  const provenanceReasons = [];
+
+  if (incomingObj && incomingObj.source_dirty === true) {
+    reasonCodes.push(REASON_SOURCE_DIRTY);
+    provenanceReasons.push('source_dirty');
+  }
+
+  const validatorStatus = originalObj && originalObj.provenance
+    ? originalObj.provenance.manifest_validator_status : undefined;
+  if (validatorStatus !== undefined && validatorStatus !== 'PASS') {
+    reasonCodes.push(REASON_MANIFEST_VALIDATOR_FAILED);
+    provenanceReasons.push(`manifest_validator_status=${validatorStatus}`);
+  }
+
+  const originalDirty = !!(originalObj && originalObj.provenance
+    && originalObj.provenance.provenance_dirty === true);
+  const provenanceDirty = provenanceReasons.length > 0 || originalDirty;
+  if (provenanceDirty && provenanceReasons.length === 0) {
+    provenanceReasons.push('original_record_provenance_dirty');
+  }
+  return { reasonCodes, provenanceReasons, provenanceDirty };
+}
+
+/**
+ * evidence_origin derivation (SPEC §1.7 / A8):
+ *   regression_replay_result -> golden_regression; else default
+ *   (production_observed; test seam may pass `synthetic`).
+ */
+export function deriveEvidenceOrigin(incomingObj, evidenceOriginDefault) {
+  if (incomingObj && incomingObj.artifact_type === 'regression_replay_result') {
+    return 'golden_regression';
+  }
+  return evidenceOriginDefault || 'production_observed';
+}
+
+// --------------------------------------------------------------------------- //
+// Sinks (live-mode only). Trials append; evidence-ledger O_EXCL append-once.
+// --------------------------------------------------------------------------- //
+
+function nowIso() { return new Date().toISOString(); } // ...Z == +00:00 offset
+
+/** Write a file with O_CREAT|O_EXCL (append-once). Returns true if written, false if it already existed. */
+function writeExclusive(filePath, data) {
+  let fd;
+  try { fd = openSync(filePath, 'wx'); }
+  catch (err) { if (err.code === 'EEXIST') return false; throw err; }
+  try { writeSync(fd, data); } finally { closeSync(fd); }
+  return true;
+}
+
+/** Serialize the evidence-ledger side-car (hand-built, mirrors 1b conflict_meta style; all values ASCII-safe). */
+function ledgerToYaml(ledger) {
+  const reasons = ledger.provenance_reasons.map((r) => `"${r}"`).join(', ');
+  return [
+    `trial_id: "${ledger.trial_id}"`,
+    `policy_id: "${ledger.policy_id}"`,
+    `canonical_record_hash: "${ledger.canonical_record_hash}"`,
+    `source_event_identity_key: "${ledger.source_event_identity_key}"`,
+    `trace_id: "${ledger.trace_id}"`,
+    `bound_via: ${ledger.bound_via}`,
+    `provenance_dirty: ${ledger.provenance_dirty ? 'true' : 'false'}`,
+    `provenance_reasons: [${reasons}]`,
+    `conflict_dir: "${ledger.conflict_dir}"`,
+    `evaluated_at: "${ledger.evaluated_at}"`,
+    '',
+  ].join('\n');
+}
+
+// --------------------------------------------------------------------------- //
+// Engine repo resolution (artifact-deref realpath base).
+// --------------------------------------------------------------------------- //
+
+function resolveEngineRepo(explicit, rootDir) {
+  if (explicit) return existsSync(explicit) ? realpathSync(explicit) : null;
+  const sibling = join(rootDir, '..', 'amazon-growth-engine');
+  return existsSync(sibling) ? realpathSync(sibling) : null;
+}
+
+// --------------------------------------------------------------------------- //
+// Idempotency: rebuild the seen trial_id set from policy_trials.jsonl (SPEC A2;
+// single SSOT, no separate cursor file -> full-re-run idempotent).
+// --------------------------------------------------------------------------- //
+
+export function buildSeenTrialIds(trialsOutAbs) {
+  const seen = new Set();
+  if (!existsSync(trialsOutAbs)) return seen;
+  for (const line of readFileSync(trialsOutAbs, 'utf-8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj;
+    try { obj = JSON.parse(trimmed); } catch { continue; }
+    if (obj && typeof obj.trial_id === 'string') seen.add(obj.trial_id);
+  }
+  return seen;
+}
+
+// --------------------------------------------------------------------------- //
+// Conflict iteration (fact_conflicts/<source_system>/<identityHex>/).
+// --------------------------------------------------------------------------- //
+
+function listConflictDirs(conflictsBaseAbs) {
+  const out = [];
+  if (!existsSync(conflictsBaseAbs)) return out;
+  let systems;
+  try { systems = readdirSync(conflictsBaseAbs, { withFileTypes: true }); } catch { return out; }
+  for (const sys of systems.sort((a, b) => (a.name < b.name ? -1 : 1))) {
+    if (!sys.isDirectory()) continue;
+    const sysDir = join(conflictsBaseAbs, sys.name);
+    let ids;
+    try { ids = readdirSync(sysDir, { withFileTypes: true }); } catch { continue; }
+    for (const id of ids.sort((a, b) => (a.name < b.name ? -1 : 1))) {
+      if (!id.isDirectory()) continue;
+      out.push({ sourceSystem: sys.name, identityHex: id.name, dir: join(sysDir, id.name) });
+    }
+  }
+  return out;
+}
+
+// --------------------------------------------------------------------------- //
+// Core: process one conflict (情形2 -> NEEDS_HUMAN trial(s)).
+// --------------------------------------------------------------------------- //
+
+function processConflict(ctx, conflictInfo) {
+  const { report } = ctx;
+  const incomingPath = join(conflictInfo.dir, 'incoming.json');
+  const originalPath = join(conflictInfo.dir, 'original.json');
+  if (!existsSync(incomingPath)) {
+    report.fail_closed += 1;
+    report.per_fail_closed.push({ reason: 'conflict missing incoming.json', conflict_dir: conflictInfo.dir });
+    return;
+  }
+  report.conflicts_scanned += 1;
+
+  const incomingText = readFileSync(incomingPath, 'utf-8');
+  let incomingAst;
+  try { incomingAst = parseCanonical(incomingText); }
+  catch (err) {
+    report.fail_closed += 1;
+    report.per_fail_closed.push({ reason: `incoming canonicalization failed: ${err.message}`, conflict_dir: conflictInfo.dir });
+    return;
+  }
+  const incomingObj = astToValue(incomingAst);
+  const traceId = typeof incomingObj.trace_id === 'string' ? incomingObj.trace_id : null;
+  // canonical_record_hash of the incoming event (1b invariant; token-preserving).
+  const canonicalRecordHash = hashCanonical(incomingAst);
+
+  let originalObj = null;
+  if (existsSync(originalPath)) {
+    try { originalObj = JSON.parse(readFileSync(originalPath, 'utf-8')); } catch { originalObj = null; }
+  }
+
+  // Binding (A6 explicit-reference-only): trace_id -> policy_id(s).
+  const policyIds = (traceId && ctx.policyIndex.has(traceId))
+    ? [...ctx.policyIndex.get(traceId)].sort()
+    : [];
+  if (policyIds.length === 0) {
+    report.unbound += 1;
+    return; // no explicit reference -> no trial (fail-closed, expected bind=0)
+  }
+  report.bound += 1;
+  report.metrics.bound_via_distribution[BOUND_VIA_CONFLICT_TRACE] += 1;
+
+  const overlay = deriveVerdictReasonCodes(incomingObj, originalObj);
+  const evidenceOrigin = deriveEvidenceOrigin(incomingObj, ctx.evidenceOriginDefault);
+  const conflictDirRel = relative(ctx.rootDir, conflictInfo.dir);
+
+  for (const policyId of policyIds) {
+    emitPolicyTrial(ctx, {
+      canonicalRecordHash,
+      policyId,
+      traceId,
+      eventIdentityKey: typeof incomingObj.event_identity_key === 'string' ? incomingObj.event_identity_key : '',
+      reasonCodes: overlay.reasonCodes,
+      provenanceReasons: overlay.provenanceReasons,
+      provenanceDirty: overlay.provenanceDirty,
+      evidenceOrigin,
+      boundVia: BOUND_VIA_CONFLICT_TRACE,
+      conflictDirRel,
+    });
+  }
+}
+
+function emitPolicyTrial(ctx, p) {
+  const { report } = ctx;
+  const trialId = computeTrialId(p.canonicalRecordHash, p.policyId);
+
+  if (ctx.seenTrialIds.has(trialId)) {
+    report.trials_skipped_idempotent += 1;
+    return;
+  }
+
+  const policyTrial = {
+    trial_id: trialId,
+    policy_id: p.policyId,
+    system_verdict: 'NEEDS_HUMAN',
+    system_verdict_reason_codes: p.reasonCodes,
+    evidence_origin: p.evidenceOrigin,
+    evaluated_at: nowIso(),
+    schema_version: SCHEMA_VERSION,
+  };
+
+  if (!ctx.validateTrial(policyTrial)) {
+    report.fail_closed += 1;
+    report.per_fail_closed.push({ trial_id: trialId, policy_id: p.policyId, reason: `trial schema-invalid: ${firstError(ctx.validateTrial)}` });
+    return; // fail-closed: never write a half-baked trial
+  }
+
+  const ledgerRelPath = join(EVIDENCE_LEDGER_DIR, `${trialId}.yaml`);
+  const ledger = {
+    trial_id: trialId,
+    policy_id: p.policyId,
+    canonical_record_hash: p.canonicalRecordHash,
+    source_event_identity_key: p.eventIdentityKey,
+    trace_id: p.traceId || '',
+    bound_via: p.boundVia,
+    provenance_dirty: p.provenanceDirty,
+    provenance_reasons: p.provenanceReasons,
+    conflict_dir: p.conflictDirRel,
+    evaluated_at: policyTrial.evaluated_at,
+  };
+
+  // Register before write so repeated identities within the same run skip
+  // (full-re-run idempotent semantics; applies to dry_run and live alike).
+  ctx.seenTrialIds.add(trialId);
+
+  report.trials_new += 1;
+  report.needs_human += 1;
+  report.metrics.verdict_distribution.NEEDS_HUMAN = (report.metrics.verdict_distribution.NEEDS_HUMAN || 0) + 1;
+  report.metrics.evidence_origin_distribution[p.evidenceOrigin] =
+    (report.metrics.evidence_origin_distribution[p.evidenceOrigin] || 0) + 1;
+  report.per_trial.push({
+    trial_id: trialId,
+    policy_id: p.policyId,
+    system_verdict: 'NEEDS_HUMAN',
+    system_verdict_reason_codes: p.reasonCodes,
+    evidence_origin: p.evidenceOrigin,
+    bound_via: p.boundVia,
+    evidence_ledger_path: ledgerRelPath,
+  });
+
+  if (ctx.mode === 'live') {
+    mkdirSync(dirname(ctx.trialsOutAbs), { recursive: true });
+    appendFileSync(ctx.trialsOutAbs, JSON.stringify(policyTrial) + '\n');
+    const ledgerDir = join(ctx.rootDir, EVIDENCE_LEDGER_DIR);
+    mkdirSync(ledgerDir, { recursive: true });
+    writeExclusive(join(ledgerDir, `${trialId}.yaml`), ledgerToYaml(ledger));
+  }
+}
+
+// --------------------------------------------------------------------------- //
+// Records scan: metrics + artifact-deref binding REHEARSAL (forward-carrying;
+// produces NO trial in 1c -- SPEC §1.2 / §1.3 channel 2 "implemented but 0 fire").
+// --------------------------------------------------------------------------- //
+
+function processRecords(ctx, recordsAbs) {
+  const { report } = ctx;
+  if (!existsSync(recordsAbs)) return;
+  const text = readFileSync(recordsAbs, 'utf-8');
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let ast;
+    try { ast = parseCanonical(trimmed); } // token-preserving (no JSON.parse->Number)
+    catch { report.records_malformed += 1; continue; }
+    report.records_scanned += 1;
+
+    const artifactTypeNode = getEntry(ast, 'artifact_type');
+    const artifactType = artifactTypeNode && artifactTypeNode.t === 'str' ? artifactTypeNode.value : null;
+    if (artifactType !== 'policy_suggestions_json') continue; // only this type drives artifact-deref
+
+    const refNode = getEntry(ast, 'raw_payload_ref');
+    const rawPayloadRef = refNode && refNode.t === 'str' ? refNode.value : null;
+    const policyId = derefPolicySuggestion(ctx, rawPayloadRef);
+    if (policyId) {
+      report.bound += 1;
+      report.metrics.bound_via_distribution[BOUND_VIA_ARTIFACT_DEREF] += 1;
+      // NOTE: artifact-deref is forward-carrying for 1d/2a; it does NOT fire a
+      // trial in 1c (the only 1c fire path is duplicate_conflict 情形2).
+    } else {
+      report.unbound += 1;
+    }
+  }
+}
+
+function derefPolicySuggestion(ctx, rawPayloadRef) {
+  const real = resolveArtifactWithinRepo(ctx.engineRepoReal, rawPayloadRef);
+  if (!real || !existsSync(real)) return null;
+  let artifact;
+  try { artifact = JSON.parse(readFileSync(real, 'utf-8')); } catch { return null; }
+  if (artifact && typeof artifact.policy_id === 'string') return artifact.policy_id;
+  return null;
+}
+
+// --------------------------------------------------------------------------- //
+// Public API
+// --------------------------------------------------------------------------- //
+
+function absUnder(rootDir, p) {
+  return p.startsWith('/') ? p : join(rootDir, p);
+}
+
+/**
+ * Evaluate policy trials from 1b importer output. In dry_run (default) NOTHING is
+ * written to disk (binding + verdict + build + validate + would-write only).
+ *
+ * @param {object} options
+ * @param {string} [options.records]    records.jsonl path (default state/memory/facts/...)
+ * @param {string} [options.conflicts]  fact_conflicts dir (default state/runtime/learning/fact_conflicts)
+ * @param {string} [options.policies]   policies dir (default state/memory/learned/policies)
+ * @param {string} [options.trialsOut]  policy_trials.jsonl out (default state/runtime/learning/...)
+ * @param {string|null} [options.since] ISO8601 convenience filter (non-correctness)
+ * @param {'dry_run'|'live'} [options.mode] default 'dry_run'
+ * @param {string|null} [options.engineRepo] AGE repo root (artifact-deref realpath); default sibling clone
+ * @param {string} [options.evidenceOriginDefault] default evidence_origin (test seam -> 'synthetic')
+ * @param {string} [options.rootDir]    liye_os root for data I/O (test seam); default PROJECT_ROOT
+ * @returns {object} EvalReport
+ */
+export function evaluatePolicyTrials(options = {}) {
+  const mode = options.mode === 'live' ? 'live' : 'dry_run';
+  const rootDir = options.rootDir ? realpathSync(options.rootDir) : PROJECT_ROOT;
+  const recordsAbs = absUnder(rootDir, options.records || DEFAULT_RECORDS);
+  const conflictsAbs = absUnder(rootDir, options.conflicts || DEFAULT_CONFLICTS);
+  const policiesAbs = absUnder(rootDir, options.policies || DEFAULT_POLICIES);
+  const trialsOutAbs = absUnder(rootDir, options.trialsOut || DEFAULT_TRIALS_OUT);
+  const windowStart = nowIso();
+
+  const ctx = {
+    mode,
+    rootDir,
+    trialsOutAbs,
+    evidenceOriginDefault: options.evidenceOriginDefault || 'production_observed',
+    engineRepoReal: resolveEngineRepo(options.engineRepo, rootDir),
+    validateTrial: buildTrialValidator(PROJECT_ROOT),
+    policyIndex: buildPolicyTraceIndex(policiesAbs),
+    seenTrialIds: buildSeenTrialIds(trialsOutAbs),
+    report: null,
+  };
+
+  const report = {
+    mode,
+    records_scanned: 0,
+    conflicts_scanned: 0,
+    records_malformed: 0,
+    bound: 0,
+    unbound: 0,
+    trials_new: 0,
+    trials_skipped_idempotent: 0,
+    needs_human: 0,
+    fail_closed: 0,
+    metrics: {
+      verdict_distribution: {},
+      evidence_origin_distribution: {},
+      bound_via_distribution: { conflict_trace_evidence: 0, artifact_deref: 0 },
+    },
+    per_trial: [],
+    per_fail_closed: [],
+    trials_out: trialsOutAbs,
+    evidence_ledger_dir: join(rootDir, EVIDENCE_LEDGER_DIR),
+    window_start: windowStart,
+    window_end: null,
+  };
+  ctx.report = report;
+
+  // 1) Conflicts = the only trial production source (情形2).
+  for (const conflictInfo of listConflictDirs(conflictsAbs)) {
+    processConflict(ctx, conflictInfo);
+  }
+  // 2) Records = metrics + artifact-deref binding rehearsal (0 trials in 1c).
+  processRecords(ctx, recordsAbs);
+
+  report.window_end = nowIso();
+  return report;
+}
+
+/** Class wrapper (whitelisted compound name) around the functional core. */
+export class PolicyTrialEvaluator {
+  constructor(options = {}) { this.options = options; }
+  run() { return evaluatePolicyTrials(this.options); }
+}
+
+// --------------------------------------------------------------------------- //
+// CLI
+// --------------------------------------------------------------------------- //
+
+const HELP = `policy_trial_evaluator.mjs - Phase 1c GHL policy-trial evaluator (dry-run-first)
+
+Usage:
+  node policy_trial_evaluator.mjs [options]
+
+Options:
+  --records <path>      records.jsonl (default state/memory/facts/fact_run_outcome_records.jsonl)
+  --conflicts <dir>     fact_conflicts dir (default state/runtime/learning/fact_conflicts)
+  --policies <dir>      learned policies dir (default state/memory/learned/policies)
+  --trials-out <path>   policy_trials.jsonl out (default state/runtime/learning/policy_trials.jsonl)
+  --since <ISO8601>     Convenience filter (non-correctness)
+  --mode <dry_run|live> Default dry_run (Phase 1c locks dry-run-first; 0 disk writes)
+  --engine-repo <dir>   Local AGE repo root (artifact-deref realpath); default sibling clone
+  --json                Print the EvalReport as JSON on stdout
+  --help                Show this help and exit 0
+
+Exit codes:
+  0  success (0 fail-closed)
+  2  >= 1 trial schema-invalid / canonicalization failure (fail-closed; nothing half-written)
+  1  unexpected error
+`;
+
+function parseArgs(argv) {
+  const opts = {
+    records: null, conflicts: null, policies: null, trialsOut: null,
+    since: null, mode: 'dry_run', engineRepo: null, json: false, help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') opts.help = true;
+    else if (a === '--json') opts.json = true;
+    else if (a === '--records') opts.records = argv[++i];
+    else if (a === '--conflicts') opts.conflicts = argv[++i];
+    else if (a === '--policies') opts.policies = argv[++i];
+    else if (a === '--trials-out') opts.trialsOut = argv[++i];
+    else if (a === '--since') opts.since = argv[++i];
+    else if (a === '--mode') opts.mode = argv[++i];
+    else if (a === '--engine-repo') opts.engineRepo = argv[++i];
+    else { process.stderr.write(`unknown argument: ${a}\n`); }
+  }
+  return opts;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) { process.stdout.write(HELP); return EXIT.SUCCESS; }
+  if (opts.mode !== 'dry_run' && opts.mode !== 'live') {
+    process.stderr.write(`invalid --mode ${opts.mode} (use dry_run|live)\n`);
+    return EXIT.UNEXPECTED;
+  }
+  let report;
+  try {
+    report = evaluatePolicyTrials(opts);
+  } catch (err) {
+    process.stderr.write(`[policy_trial_evaluator] unexpected error: ${err.stack || err.message}\n`);
+    return EXIT.UNEXPECTED;
+  }
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+  } else {
+    process.stdout.write(
+      `[policy_trial_evaluator] mode=${report.mode} conflicts=${report.conflicts_scanned} ` +
+      `records=${report.records_scanned} bound=${report.bound} unbound=${report.unbound} ` +
+      `trials_new=${report.trials_new} skip=${report.trials_skipped_idempotent} fail_closed=${report.fail_closed}\n`);
+    for (const f of report.per_fail_closed) process.stderr.write(`  fail-closed: ${f.reason || JSON.stringify(f)}\n`);
+  }
+  return report.fail_closed > 0 ? EXIT.FAIL_CLOSED : EXIT.SUCCESS;
+}
+
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === realpathSync(process.argv[1]);
+if (invokedDirectly) process.exit(main());

--- a/src/reasoning/tests/policy_trial_evaluator.test.mjs
+++ b/src/reasoning/tests/policy_trial_evaluator.test.mjs
@@ -19,6 +19,7 @@ import {
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
+import { parse as parseYaml } from 'yaml';
 
 import {
   evaluatePolicyTrials, PolicyTrialEvaluator,
@@ -472,6 +473,30 @@ test('one conflict bound to two policies fans out to two distinct trials', () =>
 // --------------------------------------------------------------------------- //
 // Module zero-reference assertion (SPEC A5 guard)
 // --------------------------------------------------------------------------- //
+
+test('evidence-ledger is injection-safe: hostile trace_id/policy_id round-trip as valid YAML', () => {
+  const root = mkRoot();
+  try {
+    // hostile values that would break a hand-built YAML if unescaped
+    const evilTrace = 'run-x"\n  injected_key: pwned\nbad: :';
+    const evilPolicy = 'P_INJECT"\n  also: bad';
+    writePolicy(root, 'candidate', evilPolicy, [evilTrace]);
+    writeConflict(root, 'amazon-growth-engine', 'idevil',
+      mkEvent({ trace_id: evilTrace }), mkRecord({ trace_id: evilTrace }));
+
+    const report = evaluatePolicyTrials({ rootDir: root, mode: 'live' });
+    assert.equal(report.trials_new, 1);
+
+    const trialId = report.per_trial[0].trial_id;
+    const ledgerText = readFileSync(join(evidenceDir(root), `${trialId}.yaml`), 'utf-8');
+    const parsed = parseYaml(ledgerText); // throws if the YAML is broken
+    assert.equal(parsed.trace_id, evilTrace, 'trace_id round-trips exactly');
+    assert.equal(parsed.policy_id, evilPolicy, 'policy_id round-trips exactly');
+    assert.equal('injected_key' in parsed, false, 'no key injected via trace_id');
+    assert.equal('also' in parsed, false, 'no key injected via policy_id');
+    assert.equal(parsed.bound_via, 'conflict_trace_evidence');
+  } finally { cleanup(root); }
+});
 
 test('evaluator module has ZERO reference to the 7 deferred reason codes + the all-clear code', () => {
   const src = readFileSync(EVALUATOR_SRC, 'utf-8');

--- a/src/reasoning/tests/policy_trial_evaluator.test.mjs
+++ b/src/reasoning/tests/policy_trial_evaluator.test.mjs
@@ -1,0 +1,486 @@
+// Phase 1c GHL policy_trial_evaluator tests (Node built-in runner: node:test).
+// Run: node --test src/reasoning/tests/policy_trial_evaluator.test.mjs
+//
+// Excluded from vitest (vitest.config.ts) because this uses node:test.
+//
+// Coverage mirrors SPEC `.planning/phase-1c/SPEC.md` §4:
+//   情形2 e2e / trial_id determinism+idempotency / provenance overlay /
+//   binding fail-closed / artifact-deref forward (incl symlink-escape defense) /
+//   evidence_origin derivation / sealed-schema validate fail-closed /
+//   token-preserving canonical_record_hash invariant / empty input /
+//   dry_run 0-write / module zero-reference assertion / uuidv5 vectors.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync,
+  readdirSync, symlinkSync,
+} from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+import {
+  evaluatePolicyTrials, PolicyTrialEvaluator,
+  uuidv5, computeTrialId, buildTrialValidator, buildPolicyTraceIndex,
+  deriveVerdictReasonCodes, deriveEvidenceOrigin,
+  NAMESPACE_GHL, NAMESPACE_GHL_PINNED, SCHEMA_VERSION, POLICY_TRIAL_V1_URI,
+} from '../policy_trial_evaluator.mjs';
+
+import {
+  parseCanonical, emitCanonical, hashCanonical, sha256Prefixed,
+} from '../../../.claude/scripts/learning/canonical_json.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EVALUATOR_SRC = join(__dirname, '..', 'policy_trial_evaluator.mjs');
+
+// --------------------------------------------------------------------------- //
+// Fixture helpers (tmp rootDir seam)
+// --------------------------------------------------------------------------- //
+
+function mkRoot() {
+  return mkdtempSync(join(tmpdir(), 'pte-'));
+}
+
+function mkEvent(overrides = {}) {
+  // Minimal raw event sidecar (the fields the evaluator reads). Canonical-ish;
+  // hashCanonical re-canonicalizes regardless.
+  return {
+    artifact_path: 'out/x.json',
+    artifact_type: 'verification_json',
+    event_identity_key: 'sha256:' + 'a'.repeat(64),
+    playbook_ref: 'pb',
+    source_commit_sha: 'b'.repeat(40),
+    source_dirty: false,
+    source_repo: 'amazon-growth-engine',
+    source_system: 'amazon-growth-engine',
+    step_id: 's1',
+    trace_id: 'run-20260530-aaaa1111',
+    ...overrides,
+  };
+}
+
+function mkRecord(overrides = {}) {
+  // A stored 24-field-ish record (original.json). Only provenance + a few fields
+  // are read by the evaluator.
+  return {
+    ...mkEvent(),
+    ingested_at: '2026-05-30T00:00:00.000Z',
+    importer_version: 'discover_new_runs@2.0.0',
+    canonical_record_hash: 'sha256:' + 'c'.repeat(64),
+    provenance: { manifest_validator_status: 'PASS', provenance_dirty: false },
+    ...overrides,
+  };
+}
+
+function writeConflict(root, sourceSystem, identityHex, incomingObj, originalObj) {
+  const dir = join(root, 'state/runtime/learning/fact_conflicts', sourceSystem, identityHex);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'incoming.json'), JSON.stringify(incomingObj));
+  if (originalObj !== undefined) {
+    writeFileSync(join(dir, 'original.json'), JSON.stringify(originalObj) + '\n');
+  }
+  return dir;
+}
+
+function writeRawConflictIncoming(root, sourceSystem, identityHex, rawText) {
+  const dir = join(root, 'state/runtime/learning/fact_conflicts', sourceSystem, identityHex);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'incoming.json'), rawText);
+  return dir;
+}
+
+function writePolicy(root, status, policyId, traceIds) {
+  const dir = join(root, 'state/memory/learned/policies', status);
+  mkdirSync(dir, { recursive: true });
+  const doc = {
+    policy_id: policyId,
+    evidence: traceIds.map((t) => ({ trace_id: t, summary: 's' })),
+  };
+  writeFileSync(join(dir, `${policyId}.yaml`), JSON.stringify(doc, null, 2));
+}
+
+function writeRecords(root, recordObjs) {
+  const p = join(root, 'state/memory/facts/fact_run_outcome_records.jsonl');
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, recordObjs.map((r) => JSON.stringify(r)).join('\n') + '\n');
+}
+
+function trialsOutPath(root) {
+  return join(root, 'state/runtime/learning/policy_trials.jsonl');
+}
+function evidenceDir(root) {
+  return join(root, 'state/runtime/learning/policy_trials_evidence');
+}
+function cleanup(root) {
+  try { rmSync(root, { recursive: true, force: true }); } catch { /* ignore */ }
+}
+
+// --------------------------------------------------------------------------- //
+// uuidv5 + namespace pin
+// --------------------------------------------------------------------------- //
+
+test('uuidv5 matches published RFC-4122 vectors', () => {
+  const NS_DNS = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+  assert.equal(uuidv5('python.org', NS_DNS), '886313e1-3b8a-5372-9b90-0c9aee199e5d');
+  assert.equal(uuidv5('example.com', NS_DNS), 'cfbff0d1-9375-5685-968c-48ce8b15ae17');
+});
+
+test('NAMESPACE_GHL equals the pinned literal (SPEC A4)', () => {
+  assert.equal(NAMESPACE_GHL, NAMESPACE_GHL_PINNED);
+  assert.equal(NAMESPACE_GHL, uuidv5(POLICY_TRIAL_V1_URI, '6ba7b811-9dad-11d1-80b4-00c04fd430c8'));
+});
+
+test('computeTrialId is deterministic and version-5 shaped', () => {
+  const h = 'sha256:' + 'd'.repeat(64);
+  const a = computeTrialId(h, 'POLICY_X');
+  const b = computeTrialId(h, 'POLICY_X');
+  assert.equal(a, b);
+  assert.notEqual(a, computeTrialId(h, 'POLICY_Y'));
+  assert.match(a, /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+});
+
+// --------------------------------------------------------------------------- //
+// canonical_record_hash invariant (token-preserving; reuse canonical_json)
+// --------------------------------------------------------------------------- //
+
+test('canonical_record_hash == sha256(canonical(incoming event)); token-preserving (no Number folding)', () => {
+  const text = JSON.stringify(mkEvent());
+  const ast = parseCanonical(text);
+  assert.equal(hashCanonical(ast), sha256Prefixed(emitCanonical(ast)));
+  // 1.0 vs 1 must NOT fold to the same hash (proves no JSON.parse->Number).
+  const a = parseCanonical('{"k":1.0}');
+  const b = parseCanonical('{"k":1}');
+  assert.notEqual(hashCanonical(a), hashCanonical(b));
+});
+
+// --------------------------------------------------------------------------- //
+// Sealed-schema validation (fail-closed)
+// --------------------------------------------------------------------------- //
+
+test('buildTrialValidator: good trial valid; extra field + missing required rejected', () => {
+  const v = buildTrialValidator();
+  const good = {
+    trial_id: '00000000-0000-5000-8000-000000000000',
+    policy_id: 'POLICY_X',
+    system_verdict: 'NEEDS_HUMAN',
+    system_verdict_reason_codes: ['duplicate_conflict'],
+    evidence_origin: 'production_observed',
+    evaluated_at: '2026-05-30T00:00:00Z',
+    schema_version: '1.0.0',
+  };
+  assert.equal(v(good), true);
+  assert.equal(v({ ...good, extra_field: 1 }), false); // additionalProperties:false
+  const missing = { ...good }; delete missing.evidence_origin;
+  assert.equal(v(missing), false);
+  // operator_feedback $ref resolves (valid sub-object accepted).
+  assert.equal(v({ ...good, operator_feedback: {
+    reviewer_id_hash: 'sha256:' + 'a'.repeat(64), verdict: 'AGREE_WITH_SYSTEM',
+    reason_codes: ['acceptable'], reviewed_at: '2026-05-30T00:00:00Z',
+  } }), true);
+});
+
+// --------------------------------------------------------------------------- //
+// Binding index
+// --------------------------------------------------------------------------- //
+
+test('buildPolicyTraceIndex maps evidence trace_id -> policy_id across status dirs', () => {
+  const root = mkRoot();
+  try {
+    writePolicy(root, 'candidate', 'POLICY_CAND', ['run-20260530-aaaa1111', 'run-20260530-bbbb2222']);
+    writePolicy(root, 'production', 'POLICY_PROD', ['trace-20260208-sample1']);
+    const idx = buildPolicyTraceIndex(join(root, 'state/memory/learned/policies'));
+    assert.deepEqual([...idx.get('run-20260530-aaaa1111')], ['POLICY_CAND']);
+    assert.deepEqual([...idx.get('trace-20260208-sample1')], ['POLICY_PROD']);
+    assert.equal(idx.has('run-does-not-exist'), false);
+  } finally { cleanup(root); }
+});
+
+// --------------------------------------------------------------------------- //
+// 情形2 end-to-end (the only trial fire path)
+// --------------------------------------------------------------------------- //
+
+test('情形2 e2e (live): bound conflict -> NEEDS_HUMAN trial + evidence-ledger back-link', () => {
+  const root = mkRoot();
+  try {
+    const traceId = 'run-20260530-aaaa1111';
+    writePolicy(root, 'candidate', 'POLICY_DUP', [traceId]);
+    const incoming = mkEvent({ trace_id: traceId, source_dirty: true });
+    const original = mkRecord({ trace_id: traceId, provenance: { manifest_validator_status: 'WARN', provenance_dirty: true } });
+    writeConflict(root, 'amazon-growth-engine', 'idhex01', incoming, original);
+
+    const report = evaluatePolicyTrials({ rootDir: root, mode: 'live' });
+    assert.equal(report.conflicts_scanned, 1);
+    assert.equal(report.bound, 1);
+    assert.equal(report.unbound, 0);
+    assert.equal(report.trials_new, 1);
+    assert.equal(report.needs_human, 1);
+    assert.equal(report.fail_closed, 0);
+    assert.equal(report.metrics.bound_via_distribution.conflict_trace_evidence, 1);
+
+    const t = report.per_trial[0];
+    assert.equal(t.policy_id, 'POLICY_DUP');
+    assert.equal(t.system_verdict, 'NEEDS_HUMAN');
+    // reason codes: duplicate_conflict + source_dirty (incoming) + manifest_validator_failed (original WARN)
+    assert.deepEqual([...t.system_verdict_reason_codes].sort(),
+      ['duplicate_conflict', 'manifest_validator_failed', 'source_dirty']);
+    assert.equal(t.bound_via, 'conflict_trace_evidence');
+
+    // trials.jsonl written + schema-valid
+    const lines = readFileSync(trialsOutPath(root), 'utf-8').trim().split('\n');
+    assert.equal(lines.length, 1);
+    const policyTrial = JSON.parse(lines[0]);
+    const v = buildTrialValidator();
+    assert.equal(v(policyTrial), true);
+    assert.equal(policyTrial.schema_version, SCHEMA_VERSION);
+
+    // evidence-ledger back-link
+    const ledgerFile = join(evidenceDir(root), `${policyTrial.trial_id}.yaml`);
+    assert.ok(existsSync(ledgerFile), 'evidence-ledger file exists');
+    const ledger = readFileSync(ledgerFile, 'utf-8');
+    assert.match(ledger, /bound_via: conflict_trace_evidence/);
+    assert.match(ledger, new RegExp(`trace_id: "${traceId}"`));
+    assert.match(ledger, /provenance_dirty: true/);
+    assert.match(ledger, /canonical_record_hash: "sha256:[0-9a-f]{64}"/);
+    assert.match(ledger, /source_dirty/);
+    assert.match(ledger, /manifest_validator_status=WARN/);
+  } finally { cleanup(root); }
+});
+
+test('idempotency: second live run skips (trials.jsonl line count unchanged)', () => {
+  const root = mkRoot();
+  try {
+    const traceId = 'run-20260530-aaaa1111';
+    writePolicy(root, 'candidate', 'POLICY_DUP', [traceId]);
+    writeConflict(root, 'amazon-growth-engine', 'idhex01',
+      mkEvent({ trace_id: traceId }), mkRecord({ trace_id: traceId }));
+
+    const r1 = evaluatePolicyTrials({ rootDir: root, mode: 'live' });
+    assert.equal(r1.trials_new, 1);
+    const after1 = readFileSync(trialsOutPath(root), 'utf-8').trim().split('\n').length;
+
+    const r2 = evaluatePolicyTrials({ rootDir: root, mode: 'live' });
+    assert.equal(r2.trials_new, 0);
+    assert.equal(r2.trials_skipped_idempotent, 1);
+    const after2 = readFileSync(trialsOutPath(root), 'utf-8').trim().split('\n').length;
+    assert.equal(after1, after2);
+  } finally { cleanup(root); }
+});
+
+test('dry_run produces trial in report but writes NOTHING to disk', () => {
+  const root = mkRoot();
+  try {
+    const traceId = 'run-20260530-aaaa1111';
+    writePolicy(root, 'candidate', 'POLICY_DUP', [traceId]);
+    writeConflict(root, 'amazon-growth-engine', 'idhex01',
+      mkEvent({ trace_id: traceId }), mkRecord({ trace_id: traceId }));
+
+    const report = evaluatePolicyTrials({ rootDir: root }); // default dry_run
+    assert.equal(report.mode, 'dry_run');
+    assert.equal(report.trials_new, 1);
+    assert.equal(existsSync(trialsOutPath(root)), false, 'no policy_trials.jsonl in dry_run');
+    assert.equal(existsSync(evidenceDir(root)), false, 'no evidence-ledger dir in dry_run');
+  } finally { cleanup(root); }
+});
+
+// --------------------------------------------------------------------------- //
+// Provenance overlay (per-clause)
+// --------------------------------------------------------------------------- //
+
+test('deriveVerdictReasonCodes: per-clause provenance overlay', () => {
+  // clean: only duplicate_conflict
+  let o = deriveVerdictReasonCodes(mkEvent({ source_dirty: false }),
+    mkRecord({ provenance: { manifest_validator_status: 'PASS', provenance_dirty: false } }));
+  assert.deepEqual(o.reasonCodes, ['duplicate_conflict']);
+  assert.equal(o.provenanceDirty, false);
+
+  // source_dirty from incoming
+  o = deriveVerdictReasonCodes(mkEvent({ source_dirty: true }),
+    mkRecord({ provenance: { manifest_validator_status: 'PASS', provenance_dirty: false } }));
+  assert.deepEqual(o.reasonCodes.sort(), ['duplicate_conflict', 'source_dirty']);
+  assert.ok(o.provenanceReasons.includes('source_dirty'));
+
+  // manifest_validator_failed from original record (FAIL != PASS)
+  o = deriveVerdictReasonCodes(mkEvent({ source_dirty: false }),
+    mkRecord({ provenance: { manifest_validator_status: 'FAIL', provenance_dirty: true } }));
+  assert.deepEqual(o.reasonCodes.sort(), ['duplicate_conflict', 'manifest_validator_failed']);
+  assert.ok(o.provenanceReasons.some((r) => r.includes('manifest_validator_status=FAIL')));
+
+  // no original.json -> only duplicate_conflict (manifest status unknown -> not appended)
+  o = deriveVerdictReasonCodes(mkEvent({ source_dirty: false }), null);
+  assert.deepEqual(o.reasonCodes, ['duplicate_conflict']);
+});
+
+// --------------------------------------------------------------------------- //
+// evidence_origin derivation
+// --------------------------------------------------------------------------- //
+
+test('deriveEvidenceOrigin: production_observed default / golden_regression / synthetic seam', () => {
+  assert.equal(deriveEvidenceOrigin(mkEvent(), undefined), 'production_observed');
+  assert.equal(deriveEvidenceOrigin(mkEvent({ artifact_type: 'regression_replay_result' }), 'synthetic'), 'golden_regression');
+  assert.equal(deriveEvidenceOrigin(mkEvent(), 'synthetic'), 'synthetic');
+});
+
+test('evidence_origin flows into trial + distribution (golden_regression via regression_replay_result)', () => {
+  const root = mkRoot();
+  try {
+    const traceId = 'run-20260530-cccc3333';
+    writePolicy(root, 'candidate', 'POLICY_REG', [traceId]);
+    writeConflict(root, 'amazon-growth-engine', 'idhexreg',
+      mkEvent({ trace_id: traceId, artifact_type: 'regression_replay_result' }),
+      mkRecord({ trace_id: traceId }));
+    const report = evaluatePolicyTrials({ rootDir: root, mode: 'live' });
+    assert.equal(report.per_trial[0].evidence_origin, 'golden_regression');
+    assert.equal(report.metrics.evidence_origin_distribution.golden_regression, 1);
+  } finally { cleanup(root); }
+});
+
+// --------------------------------------------------------------------------- //
+// Binding fail-closed (no explicit reference -> unbound, 0 trial)
+// --------------------------------------------------------------------------- //
+
+test('binding fail-closed: trace mismatch -> unbound, 0 trial', () => {
+  const root = mkRoot();
+  try {
+    writePolicy(root, 'candidate', 'POLICY_DUP', ['run-20260530-MATCHME']);
+    writeConflict(root, 'amazon-growth-engine', 'idhex01',
+      mkEvent({ trace_id: 'run-20260530-NOMATCH' }), mkRecord({ trace_id: 'run-20260530-NOMATCH' }));
+    const report = evaluatePolicyTrials({ rootDir: root, mode: 'live' });
+    assert.equal(report.conflicts_scanned, 1);
+    assert.equal(report.bound, 0);
+    assert.equal(report.unbound, 1);
+    assert.equal(report.trials_new, 0);
+    assert.equal(existsSync(trialsOutPath(root)), false);
+  } finally { cleanup(root); }
+});
+
+// --------------------------------------------------------------------------- //
+// Empty input (today's posture: bind=0 by-design)
+// --------------------------------------------------------------------------- //
+
+test('empty input: no conflicts/records -> all-zero report, no writes', () => {
+  const root = mkRoot();
+  try {
+    const report = evaluatePolicyTrials({ rootDir: root, mode: 'live' });
+    assert.equal(report.conflicts_scanned, 0);
+    assert.equal(report.records_scanned, 0);
+    assert.equal(report.bound, 0);
+    assert.equal(report.trials_new, 0);
+    assert.equal(report.fail_closed, 0);
+    assert.equal(existsSync(trialsOutPath(root)), false);
+  } finally { cleanup(root); }
+});
+
+// --------------------------------------------------------------------------- //
+// Fail-closed: malformed incoming.json (canonicalization failure -> exit 2 path)
+// --------------------------------------------------------------------------- //
+
+test('fail-closed: malformed incoming.json -> fail_closed, no trial', () => {
+  const root = mkRoot();
+  try {
+    writePolicy(root, 'candidate', 'POLICY_DUP', ['run-20260530-aaaa1111']);
+    writeRawConflictIncoming(root, 'amazon-growth-engine', 'idbad', '{ not valid json ');
+    const report = evaluatePolicyTrials({ rootDir: root, mode: 'live' });
+    assert.equal(report.fail_closed, 1);
+    assert.equal(report.trials_new, 0);
+    assert.equal(existsSync(trialsOutPath(root)), false);
+  } finally { cleanup(root); }
+});
+
+// --------------------------------------------------------------------------- //
+// Artifact-deref forward channel (implemented but 0 trial fire in 1c)
+// --------------------------------------------------------------------------- //
+
+test('artifact-deref: policy_suggestions_json record binds via deref but fires 0 trial', () => {
+  const root = mkRoot();
+  const engineRepo = mkdtempSync(join(tmpdir(), 'age-'));
+  try {
+    // synthetic artifact inside the engine repo
+    mkdirSync(join(engineRepo, 'out'), { recursive: true });
+    writeFileSync(join(engineRepo, 'out/suggestion.json'), JSON.stringify({ policy_id: 'POLICY_SUGGESTED' }));
+    writeRecords(root, [
+      mkRecord({ artifact_type: 'policy_suggestions_json', raw_payload_ref: 'out/suggestion.json' }),
+    ]);
+    const report = evaluatePolicyTrials({ rootDir: root, mode: 'live', engineRepo });
+    assert.equal(report.records_scanned, 1);
+    assert.equal(report.bound, 1);
+    assert.equal(report.metrics.bound_via_distribution.artifact_deref, 1);
+    assert.equal(report.trials_new, 0, 'artifact-deref is forward-carrying; no 1c trial');
+    assert.equal(existsSync(trialsOutPath(root)), false);
+  } finally { cleanup(root); cleanup(engineRepo); }
+});
+
+test('artifact-deref symlink-escape defense: ref resolving outside engine repo -> unbound', () => {
+  const root = mkRoot();
+  const engineRepo = mkdtempSync(join(tmpdir(), 'age-'));
+  const outside = mkdtempSync(join(tmpdir(), 'outside-'));
+  try {
+    writeFileSync(join(outside, 'secret.json'), JSON.stringify({ policy_id: 'LEAKED' }));
+    // symlink inside the repo pointing OUTSIDE
+    symlinkSync(join(outside, 'secret.json'), join(engineRepo, 'link.json'));
+    writeRecords(root, [
+      mkRecord({ artifact_type: 'policy_suggestions_json', raw_payload_ref: 'link.json' }),
+    ]);
+    const report = evaluatePolicyTrials({ rootDir: root, mode: 'live', engineRepo });
+    assert.equal(report.bound, 0, 'symlink escaping the repo must not bind');
+    assert.equal(report.unbound, 1);
+  } finally { cleanup(root); cleanup(engineRepo); cleanup(outside); }
+});
+
+test('artifact-deref path defense: ".." in raw_payload_ref -> unbound', () => {
+  const root = mkRoot();
+  const engineRepo = mkdtempSync(join(tmpdir(), 'age-'));
+  try {
+    writeRecords(root, [
+      mkRecord({ artifact_type: 'policy_suggestions_json', raw_payload_ref: '../escape.json' }),
+    ]);
+    const report = evaluatePolicyTrials({ rootDir: root, mode: 'live', engineRepo });
+    assert.equal(report.bound, 0);
+    assert.equal(report.unbound, 1);
+  } finally { cleanup(root); cleanup(engineRepo); }
+});
+
+// --------------------------------------------------------------------------- //
+// Class wrapper + multi-policy fan-out
+// --------------------------------------------------------------------------- //
+
+test('PolicyTrialEvaluator class wraps the functional core', () => {
+  const root = mkRoot();
+  try {
+    const report = new PolicyTrialEvaluator({ rootDir: root }).run();
+    assert.equal(report.mode, 'dry_run');
+    assert.equal(report.trials_new, 0);
+  } finally { cleanup(root); }
+});
+
+test('one conflict bound to two policies fans out to two distinct trials', () => {
+  const root = mkRoot();
+  try {
+    const traceId = 'run-20260530-dddd4444';
+    writePolicy(root, 'candidate', 'POLICY_A', [traceId]);
+    writePolicy(root, 'production', 'POLICY_B', [traceId]);
+    writeConflict(root, 'amazon-growth-engine', 'idmulti',
+      mkEvent({ trace_id: traceId }), mkRecord({ trace_id: traceId }));
+    const report = evaluatePolicyTrials({ rootDir: root, mode: 'live' });
+    assert.equal(report.bound, 1); // one conflict bound
+    assert.equal(report.trials_new, 2); // two policies -> two trials
+    const ids = new Set(report.per_trial.map((t) => t.trial_id));
+    assert.equal(ids.size, 2);
+  } finally { cleanup(root); }
+});
+
+// --------------------------------------------------------------------------- //
+// Module zero-reference assertion (SPEC A5 guard)
+// --------------------------------------------------------------------------- //
+
+test('evaluator module has ZERO reference to the 7 deferred reason codes + the all-clear code', () => {
+  const src = readFileSync(EVALUATOR_SRC, 'utf-8');
+  const forbidden = [
+    'golden_pack_stale', 'data_safety_unknown', 'regression_failure_severe',
+    'confidence_below_threshold', 'evidence_origin_insufficient',
+    'sample_size_insufficient', 'boundary_confidence_value', 'acceptable',
+  ];
+  for (const code of forbidden) {
+    assert.ok(!src.includes(code), `evaluator source must not reference "${code}"`);
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
       // not vitest. vitest would collect them and fail with "No test suite found".
       // Run them with: node --test .claude/scripts/learning/tests/*.test.mjs
       '.claude/scripts/learning/tests/**',
+      // Phase 1c GHL policy_trial_evaluator tests also use node:test (same reason).
+      // Run them with: node --test src/reasoning/tests/*.test.mjs
+      'src/reasoning/tests/**',
     ],
   },
 });


### PR DESCRIPTION
## Phase 1c IMPL — liye_os `policy_trial_evaluator.mjs`

Implements **Phase 1c SPEC v1.0** — `.planning/phase-1c/SPEC.md`, blob **`c6975a6aad8dfa9ba66e4c1449fc112c810a610e`** (now on `main` as squash `95c6050`). Follows Phase 1b importer (`d5a90ed`) + CI-wiring (`af0e0b4`).

### What this delivers
`src/reasoning/policy_trial_evaluator.mjs` (NEW): reads the 1b importer output (`fact_conflicts/` = the only trial source; `records.jsonl` = metrics + artifact-deref rehearsal), binds `policy_id` by **explicit reference only** (A6), renders the Pilot 1 negative-learning verdict (**A5: only `duplicate_conflict` 情形2 → `NEEDS_HUMAN` + provenance overlay**), and writes `policy_trial_v1` to `state/runtime/learning/policy_trials.jsonl` + a side-car evidence-ledger (A3). **dry-run-first** (0 disk writes by default), observability-only (Hard Gate 8), single-sided (0 AGE / 0 loamwise / 0 heartbeat / 0 schema).

### Commits
- `798d101` feat — evaluator core (binding · verdict + provenance overlay · deterministic `trial_id` · evidence-ledger · dry-run-first · sealed-schema validate)
- `b703a18` test — 22 node:test + vitest exclude
- `f3fcb9d` ci — path-filtered `node:test` workflow on node 18/20/22 (A7)
- `0aecb9d` fix — YAML-escape evidence-ledger scalars (pre-PR adversarial-review finding)

### Locked decisions honored
- **A4** `trial_id = uuidv5(NAMESPACE_GHL, canonical_record_hash + "|" + policy_id)`, no `verdict_context_tag`. `NAMESPACE_GHL` pinned literal `639e6922-8cd2-5f67-807d-f2759a14ad20` (uuidv5 self-implemented from `crypto` sha1, verified against the published `python.org`/`example.com` RFC-4122 vectors; no new dependency).
- **A6** binding = explicit-reference-only: 情形2 `trace_id` ↔ `policy.evidence[].trace_id` (fires); `artifact_type=policy_suggestions_json` deref (forward-carrying, reuses the 1b dangling-symlink defense — `resolveSymlinksAllowingMissing` reproduced **byte-identical**, since it is module-private in the frozen 1b file and cannot be exported without touching it). **Expected `bind=0` at 1c runtime — by-design** (empty data + new AGE runs carry fresh trace_ids + no policy_suggestions artifact). The resolver is exercised by fixtures, not runtime data.
- **A5** verdict scope = only `duplicate_conflict` 情形2 → `NEEDS_HUMAN` + provenance overlay (`source_dirty` from the incoming event, `manifest_validator_failed` from the original record's stored provenance). The **other 7 negative reason codes + the all-clear code have ZERO reference** in the evaluator module (grep-asserted by a test).
- **A3** provenance = evidence-ledger side-car (`policy_trials_evidence/<trial_id>.yaml`, incl. `bound_via`) reconciling the sealed `policy_trial_v1` (no back-link slot). Definitive side-car pattern, not transitional.
- **A2** idempotency watermark rebuilt from `policy_trials.jsonl` (single SSOT, no cursor file). **A8** `evidence_origin` default `production_observed` (`regression_replay_result` → `golden_regression`, test seam → `synthetic`). **A7** evaluator tests CI-wired in this PR (no follow-up).

### DoD (§3) — all met
- [x] 1 `policy_trial_evaluator.mjs` committed
- [x] 2 `--help` exit 0
- [x] 3 dry-run-first default (0 disk writes — test-verified)
- [x] 4 unit/integration tests pass (22/22 node:test)
- [x] 5 情形2 e2e (bound conflict → `NEEDS_HUMAN` trial, schema-valid, written + ledger)
- [x] 6 sealed-schema validate (extra/missing field → fail-closed)
- [x] 7 idempotency (2nd run all-skipped; line count unchanged)
- [x] 8 provenance → reason_code per-clause
- [x] 9 evidence-ledger back-link complete (`canonical_record_hash` / `trace_id` / `bound_via` / provenance)
- [x] 10 binding fail-closed + empty input (exit 0; expected bind=0)
- [x] 11 1a/1b artifacts + `records.jsonl` + schemas **0-diff** (cross-checked vs `origin/main`)
- [x] 12 pre-commit hooks pass (forbidden-name / no-bidi / blocklist / env-hygiene / guardrail) — no `--no-verify`
- [x] 13 CI green + evaluator tests CI-wired (this PR)

### Pre-PR adversarial review (5 lenses, each finding independently refuted)
1 issue family confirmed and **fixed in `0aecb9d`**: YAML injection in the evidence-ledger — `trace_id` (event schema applies no pattern) and `policy_id` (only type-checked) were interpolated raw into the hand-built YAML. Fix emits every externally sourced scalar via `JSON.stringify` (a valid YAML 1.2 double-quoted scalar); a round-trip regression test with hostile `trace_id`/`policy_id` confirms no injection. No critical/high findings remain; binding index left unchanged to avoid a dropped-binding regression.

### Hard-NO self-audit
✅ 0 AGE · ✅ 0 loamwise · ✅ 0 change to `import_facts.mjs` / `canonical_json.mjs` / any `_meta/contracts/*` schema / `records.jsonl` / `fact_conflicts/` · ✅ 0 heartbeat / `discover_new_runs` / scheduler · ✅ no `trial_history` write-back · ✅ no candidate/promotion write · ✅ no RFC8785/JCS lib (reuses `canonical_json.mjs`) · ✅ forbidden-name clean (whitelisted `PolicyTrialEvaluator`/`policy_trial`/`trial_id`) · ✅ no amend/force-push/`--no-verify`/`--admin`.

### Deviation note
- Provenance overlay reads `source_dirty` from the **incoming** event (SPEC §1.4 literal) and `manifest_validator_status` from the **original** stored record's `provenance` (the only place it exists — the raw incoming event carries no validator status). Documented in code.
- Commit footer uses `Claude Opus 4.8 (1M context)` (harness mandate).

**Do not CLI-merge** — liye_os branch protection is REVIEW_REQUIRED; merge via GitHub UI as liyecom.

Reference: SPEC v1.0 blob `c6975a6`; Phase 1b IMPL `d5a90ed` + CI-wiring `af0e0b4`; baseline `GHL-evolution-plan-v4.1.md` §3/§7.4/§7.5 + `GHL-v4.1-errata.md` B-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
