### PR TITLE
GHL learning-fact taxonomy: generic `write_outcome` artifact_type (CBU write/execution receipts)

### DIFF
--- a/.claude/scripts/learning/tests/import_facts_write_outcome.test.mjs
+++ b/.claude/scripts/learning/tests/import_facts_write_outcome.test.mjs
@@ -1,0 +1,98 @@
+/**
+ * artifact_type: write_outcome — positive + negative coverage via the REAL importer path.
+ * Doctrine: _meta/adr/ADR-Learning-Fact-Artifact-Type-Taxonomy.md (2026-06-14).
+ *
+ * Operator non-negotiable DoD: prove a write_outcome event with
+ * raw_payload_summary.action_kind + string-encoded budget fields passes ALL THREE
+ * importer validation stages end-to-end —
+ *   S1  event schema     (import_facts.mjs:402)
+ *   S1b numeric-not-string (import_facts.mjs:411 — Pilot 1 string-encode-all)
+ *   S2  record schema    (import_facts.mjs:489)
+ * via importFacts() (NOT a re-compiled ajv), so it tracks the importer's own validators.
+ *
+ * The positive test is also the SPLIT-FAILURE SENTINEL: if the record-schema enum
+ * copy (fact_run_outcome_record_v1) is NOT widened in lockstep with the event schema,
+ * importFacts rejects at record-validate (rejects=1, new_records=0) and this test fails —
+ * catching exactly the "event passed, record copy didn't" hazard.
+ *
+ * The synthetic sidecar is DERIVED from the real golden_sidecar.json (a true AGE
+ * emit_fact.py output) and resealed (identity then content), so it remains internally
+ * consistent through the importer's recompute gates S4/S5.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { importFacts, computeIdentityKey } from '../import_facts.mjs';
+import { makeStringNode, makeObjectNode } from '../canonical_json.mjs';
+import {
+  goldenAst, withField, reseal, emit, numNode,
+  identityHex, tmpEngineRepo, tmpRoot, writeRegistry, placeSidecar, countLines,
+} from './_helpers.mjs';
+
+/** Derive a self-consistent write_outcome event AST from the golden sidecar. */
+function buildWriteOutcomeAst({ nativeBudget = false, traceId = 'wo-default' } = {}) {
+  let ast = goldenAst();
+  ast = withField(ast, 'artifact_type', makeStringNode('write_outcome'));
+  // distinct trace_id per test → distinct event_identity_key (trace_id ∈ the 8-key identity set;
+  // raw_payload_summary is NOT, so without this the 3 cases would collide on one identity).
+  ast = withField(ast, 'trace_id', makeStringNode(traceId));
+  // kind lives in the summary (NOT a per-kind artifact_type value); budgets string-encoded (S1b).
+  const prevBudget = nativeBudget ? numNode(25) : makeStringNode('25.00');
+  const summary = makeObjectNode([
+    ['action_kind', makeStringNode('CAMPAIGN_BUDGET_UPDATE')],
+    ['previous_daily_budget', prevBudget],
+    ['proposed_daily_budget', makeStringNode('30.00')],
+    ['proposed_spend_delta', makeStringNode('5.00')],
+    ['currency', makeStringNode('USD')],
+  ]);
+  ast = withField(ast, 'raw_payload_summary', summary);
+  // artifact_type + summary changed → reseal identity (8-key) then content (incl. identity).
+  return reseal(ast, { identity: true, content: true });
+}
+
+function setup(opts) {
+  const ast = buildWriteOutcomeAst(opts);
+  const identity = computeIdentityKey(ast);
+  const eng = tmpEngineRepo();
+  placeSidecar(eng, '2026-06-14', identityHex(identity) + '.json', emit(ast));
+  const root = tmpRoot();
+  const reg = writeRegistry(root);
+  const recordsOut = join(root, 'records.jsonl');
+  return {
+    ast, identity, recordsOut,
+    common: { source: 'amazon-growth-engine', engineRepo: eng, rootDir: root, recordsOut, registryPath: reg },
+  };
+}
+
+test('write_outcome positive: event(S1) + S1b string-budgets + record(S2) all pass via real importer', () => {
+  const { common, recordsOut, identity } = setup({ traceId: 'wo-positive' });
+  const r = importFacts({ ...common, mode: 'live' });
+  assert.equal(r.rejects, 0, `unexpected rejects: ${JSON.stringify(r.per_reject)}`);
+  assert.equal(r.new_records, 1);
+  assert.equal(countLines(recordsOut), 1);
+  const rec = JSON.parse(readFileSync(recordsOut, 'utf-8').trim());
+  assert.equal(rec.artifact_type, 'write_outcome');
+  assert.equal(rec.raw_payload_summary.action_kind, 'CAMPAIGN_BUDGET_UPDATE');
+  assert.equal(rec.raw_payload_summary.previous_daily_budget, '25.00'); // string-encoded survives
+  assert.equal(rec.schema_version, '1.0.0');                            // additive: const unchanged
+  assert.equal(rec.event_identity_key, identity);
+});
+
+test('write_outcome negative control: native-number budget → S1b NUMERIC_NOT_STRING reject', () => {
+  const { common, recordsOut } = setup({ nativeBudget: true, traceId: 'wo-negative' });
+  const r = importFacts({ ...common, mode: 'live' });
+  assert.equal(r.new_records, 0);
+  assert.equal(r.rejects, 1);
+  assert.equal(r.per_reject[0].reason, 'NUMERIC_NOT_STRING');
+  assert.equal(countLines(recordsOut), 0);
+});
+
+test('write_outcome dry_run: NEW counted, ZERO disk writes', () => {
+  const { common, recordsOut } = setup({ traceId: 'wo-dryrun' });
+  const r = importFacts({ ...common, mode: 'dry_run' });
+  assert.equal(r.new_records, 1);
+  assert.equal(r.rejects, 0);
+  assert.equal(existsSync(recordsOut), false, 'dry_run MUST NOT write records.jsonl');
+});

--- a/.github/workflows/learning-importer-tests.yml
+++ b/.github/workflows/learning-importer-tests.yml
@@ -3,7 +3,7 @@
 # Dedicated test gate for the liye_os fact importer (Phase 1b):
 #   .claude/scripts/learning/import_facts.mjs   — fact importer (dual-hash decision tree)
 #   .claude/scripts/learning/canonical_json.mjs — token-preserving JSON canonicalizer
-#   .claude/scripts/learning/tests/*.test.mjs   — 55 node:test (incl. golden.test.mjs)
+#   .claude/scripts/learning/tests/*.test.mjs   — 58 node:test (incl. golden.test.mjs + write_outcome)
 #
 # Why a dedicated workflow: these suites use the Node built-in runner (node:test),
 # which the root `npm test` (vitest) deliberately EXCLUDES — vitest.config.ts
@@ -66,5 +66,5 @@ jobs:
       - name: Install dependencies (ajv + yaml for import_facts.mjs)
         run: npm ci
 
-      - name: Run importer node:test (55 tests, incl. golden.test.mjs byte-equality)
+      - name: Run importer node:test (58 tests, incl. golden.test.mjs byte-equality)
         run: node --test .claude/scripts/learning/tests/*.test.mjs

--- a/_meta/adr/ADR-Learning-Fact-Artifact-Type-Taxonomy.md
+++ b/_meta/adr/ADR-Learning-Fact-Artifact-Type-Taxonomy.md
@@ -1,0 +1,86 @@
+---
+artifact_scope: meta
+artifact_name: Learning-Fact-Artifact-Type-Taxonomy
+artifact_role: contract
+target_layer: 0
+is_bghs_doctrine: no
+---
+
+# ADR — Learning Fact `artifact_type` 分类边界：通用 `write_outcome` 类（CBU write/execution receipts）
+
+> 文件名采非数字前缀（`ADR-Learning-Fact-Artifact-Type-Taxonomy.md`）以进入 CI-wired BGHS frontmatter gate（`adr-bghs-gate.yml`）的有效扫描域。
+
+**Status**: Accepted
+**Date**: 2026-06-14
+**Accepted-Date**: 2026-06-14
+**Decision Makers**: LiYe
+**SSOT**: 本文件（artifact_type 分类教条）；schema SSOT = `_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml`（canonical）；AGE 端为 byte-pinned vendored copy
+**References**:
+- N-1（Normative）: `_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml` —— `artifact_type` enum（实测落点：本 PR 前为 4 值 `verification_json / policy_suggestions_json / step_evaluation_instance / regression_replay_result`）；`event_identity_key` description 实证 `artifact_type` ∈ 8-key identity 原像；`event_content_hash` 排除集 = `[emitted_at, raw_payload_summary.metric_formatting_hint]`（**`raw_payload_summary.action_kind` 进 content hash，不进排除集**）
+- N-2（Normative）: `_meta/contracts/learning/fact_run_outcome_record_v1.schema.yaml` —— `artifact_type` 为**展开副本（非 $ref）**；文件头 line-15 维护契约「本文件 event 字段必须与 event_v1 保持同步」 → enum 拓宽**必须双改**，否则 importer record-validate（`import_facts.mjs:489`）拒
+- N-3（Normative）: `.claude/scripts/learning/import_facts.mjs` —— `buildValidators()`（:141，ajv `strict:false, validateFormats:false`，匹配 Python jsonschema 默认）双 schema compile；三关 S1 event-validate（:402）/ S1b NUMERIC_NOT_STRING（:411，`raw_payload_summary` 内任意 native number 即拒，Pilot 1 string-encode-all）/ record-validate（:489）
+- N-4（Normative）: `src/reasoning/policy_trial_evaluator.mjs` —— `artifact_type` 仅两处 handling 且均**无 unknown-value throw/allowlist**：`deriveEvidenceOrigin`（:302）`regression_replay_result`→`golden_regression`，**else→default `production_observed`**（write_outcome 落此）；records-scan（:558）仅 `policy_suggestions_json` 驱动 artifact-deref，余者 `continue`（write_outcome 无 deref）
+- N-5（Normative）: `_meta/contracts/scripts/validate-contracts.mjs:511-536` —— schema 校验逐项 `logPass` over `schemaFiles[]`（显式 16-entry 数组）。**21 是全局 Summary pass 计数**（= 2 SSOT-ish + 16 schemas + 1 formula instance + 2 policy instances），非数组长度。本决策**编辑既有数组成员的 enum 值、不新增数组 entry** → schema-pass 计数与全局总数皆**零变化（守 21）**；`validateContractSchemas` 仅 parse YAML + 查 `$schema/$id/required` 在场，不做 instance 校验
+- S-1（Supporting）: 2026-06-14 CBU fact artifact_type micro-discuss（`wf_0b114a29`，critic verdict ISSUES_FOUND：`generic_is_lossless=true` / `would_break_importer=false`，3 minor 已 fold 入本 ADR）；先行 AGE #403 activation-readiness audit v2（`wf_526da5e9`，`BLOCKED_BY_KNOWN_SEAM`）确立两门模型 —— 承重事实以本 ADR 逐项 file:line 实测为准，非以 workflow 自证
+**Commit anchor**: 对齐 ADR-GHL 教条「the post-squash merge commit becomes the durable anchor; no pre-squash SHA is normative」。**Accept≠merge**：Accept 时 anchor=pending（承载本 ADR 的 liye_os schema/ADR PR 仍 open，frontmatter 不预编 SHA）；PR squash-merge 后回填 post-squash merge SHA 为 durable anchor（docs-only follow-up）。
+
+---
+
+## Context
+
+GHL A 主线已 build-complete，撞 activation 墙：唯一缺口是「首条 APPLIED production CBU fact 进 learning 流」（见 AGE #403 / audit v2 两门模型 —— Door1 APPLIED 物理写代码完整、Door2 fact-into-stream seam 缺）。在动任何 AGE wiring 之前，必须先把「write/execution receipt 映射成 fact」后那条 fact 的**输出形状**钉死，否则后续所有 CBU wiring 会各自发明 artifact_type，污染 8-key identity 空间。
+
+`artifact_type` 是 `event_identity_key = sha256(source_system + source_repo + trace_id + artifact_type + artifact_path + playbook_ref + step_id + source_commit_sha)` 的 **8 个 locked 输入之一**（N-1）。因此「为每种写动作（CBU / keyword-bid / …）铸 per-kind artifact_type 值」会 fork identity 空间，且复活已被否决的「CBU 专属 enum」反模式。
+
+## Decision
+
+新增**一个通用 enum 值** `write_outcome`，作为「write/execution receipt → fact」类（与现有 eval/inference/replay 同级，非 CBU 专属，可被未来任意 receipt→fact 写路径复用）：
+
+1. `fact_run_outcome_event_v1.artifact_type.enum` **+`write_outcome`**（canonical SSOT, N-1）。
+2. 具体动作种类 → `raw_payload_summary.action_kind`（free-string，**复用 AGE execution 侧词表**如 `CAMPAIGN_BUDGET_UPDATE` / `SP_KEYWORD_BID_UPDATE`，**不在 fact schema 内铸第 4 份枚举副本**）。
+3. `schema_version` **维持 const `"1.0.0"`** —— enum 拓宽是 JSON-Schema 加性、向后兼容（既有 4 值 fact 仍 valid，identity/content-hash 算术不变），无须真 bump；本微 ADR 即满足 producer 自施的「schema 改动需 ADR」policy。
+4. `artifact_type.description` doctrine 从「Restricted to AGE evaluation/inference/replay artifacts」扩成「+ execution/write outcomes」。治理决策（PROMOTED/DEMOTED/lifecycle/trust_matrix）**仍走 `governance_event_v1`**（不混入 write_outcome）。
+
+### 决策成立的关键机制（lossless 证明）
+
+`event_content_hash` 排除集仅 `[emitted_at, raw_payload_summary.metric_formatting_hint]`（N-1）。`raw_payload_summary.action_kind` **不在排除集 → 进 content fingerprint**。故：
+- **identity** 由通用 `write_outcome` + 其余 7 key 唯一化（不因 kind 细分而 fork）；
+- **content** 由 `action_kind` 保真 → 不同写动作产不同 content hash → D-13 duplicate-vs-conflict 判定正确，**信息零丢失**。
+
+二者正交：通用值收敛 identity，`action_kind` 在 content 层保真。这是「generic + summary-discriminator」相对「per-kind enum」的唯一无损形态。
+
+## Cross-repo edit sequence（load-bearing；enum 在 3 份 hand-synced 副本，非 $ref）
+
+副本清单（共 3 份：liye_os 全仓 grep `regression_replay_result` 实测 **2 处枚举副本（event+record）**，第 3 处为 AGE 跨仓 vendored copy；**无隐藏第 4 份 allowlist/TS-union/python-validator/count-assertion**——6-lens 红队 HIDDEN-COPY 实证）：
+1. liye_os canonical event schema（N-1）—— 本 PR 改。
+2. liye_os record schema（N-2，**最易漏**：漏改则 event 过、record-validate `:489` 拒 = split failure）—— 本 PR 改。
+3. AGE vendored copy（`DO-NOT-EDIT` pin）—— **后续 AGE follow-up PR** verbatim re-vendor。
+
+**序**（forward fail-closed）：先 liye_os (1)+(2) merge → AGE follow-up PR re-vendor (3) + bump freshness（`test_vendor_schema_freshness` 钉 canonical-body sha256 + source-commit 字符串在场；header `Upstream blob (SHA-1)` 行为文档性、非 CI 强制）+ 删 `emit_fact.py` 死常量 `_ARTIFACT_TYPES`（defined-never-referenced，留着会变假权威）。**先改 AGE 会破 freshness 测试**。`write_outcome` 值必须双仓 merge 在前，才 wire cbu_producer emit（否则 `fact_rejects/`）。
+
+- contracts gate **守 21**（enum-only 编辑、不增 `schemaFiles[]` entry，N-5 → 无合法 gate 增长、无 carve-out）。
+- 触发 CI：liye_os `contracts-gate.yml` + `learning-importer-tests.yml` + `adr-bghs-gate.yml`；AGE `test_vendor_schema_freshness`（hash 重算前红）。
+- 零行为改动、门仍关、零 fact 发射、frozen anchor（`golden_sidecar.json` + hash 函数）零触碰。
+
+## Non-negotiable DoD（operator-mandated）
+
+liye_os PR **不得只改 enum**。必须含一个**正向 fixture/test**，经**真 importer 路径**（非重写 ajv）证明 `artifact_type: write_outcome` + `raw_payload_summary.action_kind` + **string-encoded budget fields** 同时通过 ① event schema（S1）② S1b numeric-not-string ③ record schema（S2）。实现：从真 `golden_sidecar.json` 派生自洽 write_outcome sidecar（`reseal` 重算 identity+content），`importFacts({mode:'live'})` 断言 `new_records=1 / rejects=0`。**若漏改 record enum，此测在 record-validate 直接 `rejects=1 / new_records=0` → 红 = split-failure 哨兵**。配负向控制：native-number budget → `rejects=1` `NUMERIC_NOT_STRING`（实证 S1b 仍生效 + string-encode 是 Phase-1b wiring 的硬前提）。
+
+## Forks（已裁）
+
+- **Q1 命名** = `write_outcome`（`governed_*` 会与 governance 双流混淆；`execution_*` 冗长）。
+- **Q2 action_kind** = free-string 复用 execution 词表（不铸第 4 份枚举）。
+- **Q3 evaluator 分支** = 不加；`write_outcome` 静默落 default `production_observed`（N-4 实证不抛、不丢 fact）。待真有 evidence 语义需求再开。
+- **Q4 死常量** = AGE re-vendor PR 顺手删 `_ARTIFACT_TYPES`。
+
+## Downstream（本 ADR 之外）
+
+- **AGE follow-up PR**（步骤 2）：verbatim re-vendor event schema + bump freshness + 删死常量；**不接 live wiring**。
+- **AGE Phase 1b SPEC**（步骤 3，两仓 merge 后起）：cbu_producer caller + `_receipt_summary`/`_RECEIPT_SUMMARY_FIELDS` 扩 `action_kind`（值取自 `_CBU_KIND`，**非**「复用现成 action_kind」—— 那个在 `_cbu_preflight_report`，不同物）。**消歧**：本 ADR 改的是 `fact.artifact_type`，**不碰**同模块已发货的 `cbu_producer.inputs_artifact_type`（`INPUTS_ARTIFACT_TYPE='marketplace_growth_cap_audit'`，execution input-provenance tag，同名不同物）。raw_payload_summary 数值须 string-encode 才过 S1b。
+
+## Rejected alternatives
+
+1. **per-kind artifact_type 值**（`campaign_budget_update_outcome` 等）—— fork 8-key identity 空间，复活 CBU 专属 enum 反模式。**否决**。
+2. **新 schema_version bump 到 1.1.0** —— enum 拓宽是加性、无破坏；bump 制造无谓 migration。**否决**。
+3. **新增独立 write_outcome schema 文件** —— 会令 contracts gate 21→22（需 carve-out）+ 复制 19 字段，违背「最小、最便宜」。**否决**。
+4. **kind 放 top-level 新字段（非 raw_payload_summary）** —— 改 20-field top-level 形状 = 破坏性、动 required/identity。**否决**；summary 是无损落点。

--- a/_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml
+++ b/_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml
@@ -99,9 +99,15 @@ properties:
       - policy_suggestions_json
       - step_evaluation_instance
       - regression_replay_result
+      - write_outcome
     description: |
-      Engine artifact category. Restricted to AGE evaluation/inference/replay artifacts.
+      Engine artifact category. Covers AGE evaluation / inference / replay artifacts AND
+      execution/write outcomes. write_outcome = a write/execution receipt mapped into a fact
+      (e.g. an APPLIED CAMPAIGN_BUDGET_UPDATE). The concrete action kind lives in
+      raw_payload_summary.action_kind — NOT a per-kind artifact_type value: artifact_type is one of the
+      8 locked event_identity_key inputs, so minting per-kind values would fork identity space.
       Governance decisions (PROMOTED / DEMOTED / lifecycle / trust_matrix) use governance_event_v1 (per N-2 B-04).
+      Taxonomy doctrine + rationale: _meta/adr/ADR-Learning-Fact-Artifact-Type-Taxonomy.md
 
   artifact_path:
     type: string

--- a/_meta/contracts/learning/fact_run_outcome_record_v1.schema.yaml
+++ b/_meta/contracts/learning/fact_run_outcome_record_v1.schema.yaml
@@ -103,11 +103,14 @@ properties:
 
   artifact_type:
     type: string
+    # Kept in sync with fact_run_outcome_event_v1.schema.yaml (per the line-15 maintenance contract).
+    # write_outcome added per _meta/adr/ADR-Learning-Fact-Artifact-Type-Taxonomy.md (2026-06-14).
     enum:
       - verification_json
       - policy_suggestions_json
       - step_evaluation_instance
       - regression_replay_result
+      - write_outcome
 
   artifact_path:
     type: string


### PR DESCRIPTION
## What

Adds **one generic enum value `write_outcome`** to the learning-fact `artifact_type` taxonomy — the durable output shape for AGE write/execution receipts mapped into facts (e.g. an APPLIED `CAMPAIGN_BUDGET_UPDATE`). This nails the fact shape **before** any AGE CBU wiring, so future write-outcome wiring can't each invent its own `artifact_type` and fork identity space.

Doctrine: `_meta/adr/ADR-Learning-Fact-Artifact-Type-Taxonomy.md` (NEW, durable, BGHS-valid).

## Key mechanism (why generic + summary-discriminator, not per-kind enum)

`artifact_type` is one of the **8 locked `event_identity_key` inputs** → minting per-kind values (`campaign_budget_update_outcome`, …) would fork identity space (and revive the rejected CBU-specific enum). Instead:

- the concrete action kind lives in **`raw_payload_summary.action_kind`** (free-string, reuses AGE execution vocabulary like `CAMPAIGN_BUDGET_UPDATE`);
- `raw_payload_summary` is **not** in the `event_content_hash` exclusion set (`[emitted_at, raw_payload_summary.metric_formatting_hint]` only) → `action_kind` participates in the content fingerprint → **lossless** (D-13 duplicate-vs-conflict stays correct);
- identity converges on the generic value; content preserves the kind. Orthogonal.

## Changes

| File | Change |
|------|--------|
| `fact_run_outcome_event_v1.schema.yaml` (canonical SSOT) | enum `+write_outcome` + description doctrine extended |
| `fact_run_outcome_record_v1.schema.yaml` | enum `+write_outcome` (hand-synced expanded copy, **not** `$ref`) + sync comment |
| `ADR-Learning-Fact-Artifact-Type-Taxonomy.md` | NEW durable taxonomy ADR |
| `import_facts_write_outcome.test.mjs` | NEW positive + negative + dry_run test |
| `learning-importer-tests.yml` | comment-only: test count 55→58 |

`schema_version` stays **const `"1.0.0"`** — enum widening is additive / backward-compatible (every prior-valid fact stays valid), no version bump.

## Operator non-negotiable DoD — met

The PR does **not** only change the enum. The new test proves, via the **real `importFacts()` path** (not a re-compiled ajv), that `write_outcome` + `action_kind` + **string-encoded budget fields** pass all three importer stages:

- **S1** event-schema validate (`import_facts.mjs:402`)
- **S1b** numeric-not-string (`:411` — string budgets pass; native-number budget → `NUMERIC_NOT_STRING`, asserted by the negative control)
- **S2** record-schema validate (`:489`)

The positive test is also a **split-failure sentinel**: empirically verified that removing `write_outcome` from the record enum alone makes it fail with `record_schema_error: /artifact_type must be equal to one of the allowed values` (event S1 passes, record S2 rejects) — catching exactly the "event passed, record copy didn't" hazard.

## Verification (local)

- `node --test .claude/scripts/learning/tests/*.test.mjs` → **58/58** (incl. 3 new + `golden.test.mjs` 6/6 cross-language byte-equality, frozen anchor untouched)
- `node _meta/contracts/scripts/validate-contracts.mjs` → **Passed: 21 / Warnings: 0 / Errors: 0** (gate stays 21 — enum-only edit, no new `schemaFiles[]` entry, **no carve-out**)
- `node .claude/scripts/validate_adr_bghs.mjs` → 12 ADRs valid
- `src/reasoning/tests/policy_trial_evaluator.test.mjs` → 22/22 (`write_outcome` defaults to `production_observed`, no throw)

## Adversarial review

6-lens red-team (`wf_2c841fac`, ~547k tok): **0 HIGH / 0 MED / 2 LOW**, both folded —
1. per-test distinct identity (the 3 cases shared one `event_identity_key` because identity excludes `raw_payload_summary`; now each carries a distinct `trace_id`);
2. ADR phrasing precision (gate-21 = global pass count not array length; copy count = 2 in-repo + 1 cross-repo AGE).
Lenses confirmed: gate-21 preserved, no hidden 4th enum copy/allowlist, strict additivity, sentinel validity, downstream consumer safety, ADR fidelity.

## Out of scope (follow-ups)

- **AGE PR** (next, liye_os-first / forward fail-closed): verbatim re-vendor the event schema + bump `test_vendor_schema_freshness` + delete the dead `emit_fact._ARTIFACT_TYPES` constant. **No live wiring.**
- **AGE Phase 1b SPEC** (after both merge): `cbu_producer` caller + `_receipt_summary`/`_RECEIPT_SUMMARY_FIELDS` extension for `action_kind`.

No live wiring here; emit door stays closed; **zero production fact emitted**.

---

Merge: requires `liyecom` web squash (loudmirror cannot self-merge). Commit anchor in the ADR is `pending` until post-squash backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
