### PR TITLE
feat(github-scout): Phase 0 + 0.1 — read-only, license-gated GitHub prior-art scout

### DIFF
--- a/.claude/skills/github-scout.md
+++ b/.claude/skills/github-scout.md
@@ -1,0 +1,52 @@
+# GitHub Prior-Art Scout
+
+Advisory skill for checking **prior art on GitHub** before building a new capability.
+Invokes the read-only Hands tool `tools/github-scout/scout.py` and interprets its
+report under LiYe governance.
+
+> ⚠️ **Discoverability**: this is a flat, **manually-loaded** advisory doc (like
+> `liye-agent.md`). It is NOT auto-discovered — `.claude/skills/index.yaml` sweeps
+> `Skills/` (capital) only. Load it on demand.
+>
+> ⚠️ **Authority**: the method and the license rules are NOT defined here. They live
+> in the L1 methodology (SKILL_CONSTITUTION §3 — no reverse dependency). This file
+> only tells Claude *when* and *how* to invoke, and points to L1.
+
+## When to Use
+
+- The user floats a new capability/idea and asks "has someone built this?" / "should
+  we fork or reimplement?" / "search GitHub for prior art."
+- Before a harvest-ADR / Reference Declaration, to assemble candidates.
+
+## Read First (L1 — the actual method, the SSOT)
+
+- `docs/methodology/01_Research_Intelligence/github-scout/skill_definition.md` — identity, the license-gated inspect method, the 4-leaf taxonomy, governance hooks.
+- `docs/methodology/01_Research_Intelligence/github-scout/license_policy.yaml` — the machine-readable tier → ceiling → recommendation SSOT.
+- `_meta/adr/ADR-GitHub-Prior-Art-Scout.md` — the authorizing ADR and invariants I1–I3.
+
+## How to Invoke
+
+```bash
+# from repo root — unauthenticated public read by default
+python3 tools/github-scout/scout.py report --idea "the idea in one sentence" --json
+```
+
+- Phrase the idea with **2–3 strong nouns** (GitHub search ANDs terms).
+- Read the report's `notices` first (weak query / empty recall are flagged).
+- `report` is the only Phase 0 subcommand; others exit 3.
+
+## How to Read the Result (do not over-claim)
+
+- The report is **advisory**. Never present it as a decision.
+- `needs-human-review` means **the human decides** — scout never concludes semantic
+  behavior-fit. Surface the candidate, its license tier, and the sub_reason; ask.
+- `skip` on `unknown` / `strong_copyleft` is **fail-closed and correct** — do not
+  propose reading or vendoring that source.
+- Always relay the `recall_notice` and that transitive licenses are unscanned.
+
+## Hard Boundaries (never do these on the user's behalf from a scout result)
+
+- No fork / clone / vendor / PR / Codebase-Registry write — surface, don't act.
+- Any reuse outcome goes through the harvest-ADR / Reference Declaration ceremony
+  (SYSTEMS.md Fork 纪律). A `reference-only` result = a read-only reference satellite,
+  not a runtime dependency.

--- a/_meta/adr/ADR-GitHub-Prior-Art-Scout.md
+++ b/_meta/adr/ADR-GitHub-Prior-Art-Scout.md
@@ -1,0 +1,142 @@
+---
+artifact_scope: meta
+artifact_name: GitHub-Prior-Art-Scout
+artifact_role: contract
+target_layer: 0
+is_bghs_doctrine: no
+---
+
+# ADR — GitHub Prior-Art Scout（github-scout, Phase 0）
+
+**Status**: Accepted
+**Date**: 2026-06-26
+**Accepted-Date**: 2026-06-26
+**Phase**: 0
+**Decision Makers**: LiYe
+**SSOT**: `_meta/adr/ADR-GitHub-Prior-Art-Scout.md`
+
+> Meta Declaration per ADR-Architecture-Doctrine-BGHS-Separation.md §3 is the YAML
+> frontmatter above (`artifact_role: contract` pins machine-enforceable invariants;
+> `is_bghs_doctrine: no` — this authorizes a tool, it is not itself BGHS doctrine).
+
+---
+
+## 1. Context
+
+When a new capability idea appears in LiYe Systems, we want to check **prior art on
+GitHub** before building — to decide whether to reference-only, clean-room
+reimplement, route to human review, or skip — *without* tripping any of the
+governance rails (Fork 纪律, clean-room, license isolation, harvest-ADR ceremony).
+
+There was no governed connector for this. `gh` exists locally and the ambient
+keyring token carries the `repo` (write) scope, so any naïve "just call the API"
+approach risks (a) leaking write capability and (b) reading copyleft source before a
+license decision. This ADR authorizes a **read-only, advisory** scout and pins the
+invariants that keep it safe.
+
+This is the **blocking-first authorizing credential** for Phase 0: it is merged
+before the implementation is considered governed.
+
+## 2. Decision
+
+Build **github-scout** as a three-layer capability:
+
+| Layer | Location | Role |
+|-------|----------|------|
+| **L1 Methodology** | `docs/methodology/01_Research_Intelligence/github-scout/` | knowledge + the `license_policy.yaml` machine-readable SSOT |
+| **Hands tool** | `tools/github-scout/scout.py` (+ `declaration.yaml`) | read-only CLI that *consumes* L1 and calls the GitHub API |
+| **L3 Instruction** | `.claude/skills/github-scout.md` | flat advisory doc constraining how Claude invokes it |
+
+The L1 and L3 placements live **inside** the frozen Skill three-layer constitution
+(`docs/architecture/SKILL_CONSTITUTION.md` §1). The Hands tool sits **outside** that
+spine (see §4). Phase 0 ships the `report` subcommand only.
+
+## 3. Model-independent invariants (enforced by scout.py + test_scout.py)
+
+1. **I1 — zero external mutating side-effect.** No fork / clone / vendor / PR /
+   network write. Only local, gitignored `traces/` are written.
+2. **I2 — read-only by construction.** Default sends **no** `Authorization` header
+   (unauthenticated public read). A token is attached only when explicitly supplied
+   **and** asserted via the `X-OAuth-Scopes` response header. Phase 0 requires a
+   **NO-SCOPE** token: any classic scope at all (including read-only `read:org`) ⇒
+   fail-closed; a fine-grained "Public repositories (read-only)" token reports empty
+   scopes and passes (its fine-grained permissions are not exposed via this header and
+   rely on the operator provisioning it read-only). **No live write probe is ever
+   issued** (an expected-403 write probe would itself be a write request).
+3. **I3 — sequential inspect state machine.** Per candidate: fetch the authoritative
+   license **first** → resolve tier → fetch README/tree **only if** the tier's
+   inspect ceiling permits. A missing LICENSE file (HTTP 404) ⇒ `confidence=no_license`;
+   any other fetch failure (5xx / timeout / NOASSERTION / "other") ⇒
+   `confidence=fetch_failed`. **Both** resolve to `tier=unknown` ⇒ metadata only.
+4. **License policy is an L1 SSOT, not code.** The mapping *license tier → inspect
+   ceiling → allowed recommendation* is defined once in
+   `docs/methodology/01_Research_Intelligence/github-scout/license_policy.yaml` and
+   loaded at runtime. scout.py **must not** hardcode tiers or ceilings
+   (SKILL_CONSTITUTION §3, no reverse dependency). `test_scout.py` loads the live
+   SSOT and fails on any drift.
+5. **Fail-closed default.** Unresolved / unrecognized / fetch-failed license ⇒
+   `unknown` ⇒ metadata only ⇒ recommendation `skip`. Source is never inspected
+   under an unresolved license.
+
+## 4. Why the Hands tool is OUTSIDE the Skill three-layer spine
+
+`SKILL_CONSTITUTION.md` §2 freezes the authority chain
+`docs/methodology (L1) → src/skill (L2) → .claude/skills (L3)`. scout.py is **not**
+an L2 Executable Skill (nothing dispatches it at runtime; it is a "runs-and-exits"
+CLI). It is **BGHS-Hands infrastructure**, justified by the **Project** constitution
+`docs/CONSTITUTION.md §2.1` ("Reusable infra tooling") and the existing `tools/`
+house style (e.g. `notion-sync`, `trace_guard.sh`, none of which live in `src/skill/`).
+
+> **Honest correction (recorded for the audit trail):** an earlier draft mis-cited
+> "SKILL_CONSTITUTION §2.1" as authorizing `tools/` and inserted scout.py into the
+> frozen §2 chain. That phrase is in the *Project* constitution, not the Skill
+> constitution, which has no §2.1/tools/Hands clause. scout.py is therefore framed
+> as a downstream **consumer** of the L1 SSOT, **not** a node in the frozen chain.
+
+Adding leaf entries under existing `docs/methodology/.../`, `tools/`, and
+`.claude/skills/` directories does **not** violate
+`ADR-Architecture-Doctrine-BGHS-Separation.md §5` (which forbids creating
+concern-named directories `brain/governance/hands/session` and a BGHS runtime layer).
+
+## 5. Credentials (ADR-Credential-Mediation P1-f)
+
+- `declaration.yaml` declares both the Doctrine single-URI `credential_path:
+  cred://liye-os/github-scout-readonly` (retained) and the P1-f `credential_bindings[]`
+  (purpose / broker_required / optional).
+- Phase 0 runs **unauthenticated**. The read-only token is **optional**, supplied via
+  env, used only for rate-limit headroom, and asserted read-only (I2). scout.py never
+  reads the token value into code or logs beyond the passive scope assertion. Full
+  `EnvCredentialBroker` wiring is deferred to Phase 1 (`future_split_direction`).
+
+## 6. Scope
+
+**In (Phase 0):** this ADR; the L1 `skill_definition.md` + `license_policy.yaml` +
+`README` (with `methods.md`/`evolution_log.md` stubbed); `scout.py` (`report` only) +
+`declaration.yaml` + tests; the flat L3 `github-scout.md`; manual validation on real
+ideas producing traces.
+
+**Out (Phase 1+):** `ghbudget` bucketed budget; **transitive** license scan;
+`emit-reference` + tracked draft (manual promote); richer eval; `derive`/`search`/
+`inspect` subcommands; a typed JSON schema (no `validate-contracts.mjs` validator is
+added in Phase 0 — the gate stays byte-unchanged at **Passed: 21**); promotion to an
+L2 `src/skill/` only if a runtime needs to dispatch scouting; an
+`Extensions/mcp-servers/` server only if a non-Claude consumer requires it.
+
+## 7. Notes on related decisions (recorded, not load-bearing)
+
+- **L3 discoverability is honest.** `.claude/skills/github-scout.md` is a flat,
+  manually-loaded advisory doc (like `liye-agent.md`). The skill registry
+  (`.claude/skills/index.yaml`) sweeps `Skills/` (capital, `sfc_sweep`) only, so this
+  file is a deliberate registry-orphan, **not** auto-discovered. Making it
+  discoverable (the official `skill-creator` → `Skills/` SFC package) is intentionally
+  **not** done here — that is a separate, heavier packaging decision.
+- The recommendation taxonomy has 4 leaves (`reference-only` / `reimplement` /
+  `needs-human-review` / `skip`); `vendor`/`fork-as-dependency` survive only as a
+  `needs-human-review` sub-reason, satisfying Fork 纪律.
+
+## 8. Consequences
+
+Prior-art recon becomes a one-command, fail-closed, advisory step that respects every
+governance rail. The cost is that github-scout is conservative by design (it routes
+permissive matches to human review rather than auto-recommending reuse) and, in Phase
+0, is rate-limited (unauthenticated) and does not scan transitive licenses.

--- a/docs/methodology/01_Research_Intelligence/README.md
+++ b/docs/methodology/01_Research_Intelligence/README.md
@@ -14,6 +14,7 @@ Skills in this domain enable agents to:
 
 | Skill | Description | Status |
 |-------|-------------|--------|
+| [`github-scout`](./github-scout/) | Read-only, license-gated GitHub prior-art recon (advisory; Hands tool at `tools/github-scout/`) | Active (Phase 0) |
 | `web-research` | Systematic web search and information extraction | Planned |
 | `academic-search` | Academic database queries (PubMed, Scholar, etc.) | Planned |
 | `source-verification` | Credibility assessment and fact-checking | Planned |

--- a/docs/methodology/01_Research_Intelligence/github-scout/README.md
+++ b/docs/methodology/01_Research_Intelligence/github-scout/README.md
@@ -1,0 +1,34 @@
+# github-scout — L1 Methodology
+
+The **knowledge layer (Brain)** for GitHub prior-art reconnaissance. This directory
+defines *what* the scout knows and *how* it should reason; the executable tool lives
+separately at `tools/github-scout/` (Hands) and the Claude-facing instruction at
+`.claude/skills/github-scout.md` (L3).
+
+> Authorized by `_meta/adr/ADR-GitHub-Prior-Art-Scout.md` (blocking-first, Phase 0).
+
+## Contents
+
+| File | Role | Status |
+|------|------|--------|
+| `skill_definition.md` | the methodology: identity, license-gated inspect method, taxonomy, governance | Full |
+| `license_policy.yaml` | **machine-readable SSOT**: license tier → inspect ceiling → allowed recommendation | Full · loaded at runtime by `scout.py` |
+| `methods.md` | detailed procedures / playbooks | Stub (Phase 0 — filled as practice accrues) |
+| `evolution_log.md` | learning log | Stub (no history yet) |
+| `templates/report_output.example.json` | example of the advisory report shape | Reference |
+
+## The one thing to know
+
+`license_policy.yaml` is the **single source of truth** for the safety-critical
+mapping. The prose in `skill_definition.md` is *about* it; `scout.py` *loads* it and
+never hardcodes tiers; `test_scout.py` loads it live and fails on drift. Edit the
+policy here — never in code (SKILL_CONSTITUTION §3, no reverse dependency).
+
+## How it's used
+
+```bash
+python3 tools/github-scout/scout.py report --idea "your idea in a sentence"
+```
+
+Output is **advisory only**. Any reuse outcome enters the harvest-ADR / Reference
+Declaration ceremony (SYSTEMS.md Fork 纪律).

--- a/docs/methodology/01_Research_Intelligence/github-scout/evolution_log.md
+++ b/docs/methodology/01_Research_Intelligence/github-scout/evolution_log.md
@@ -1,0 +1,12 @@
+# github-scout — Evolution Log
+
+> **Stub (Phase 0).** No operating history yet. Append dated entries as the scout's
+> heuristics (query derivation, relevance signals, recommendation defaults) change.
+> Safety invariants (I1–I3, fail-closed) are **not** heuristics and change only via an
+> ADR amendment, not a log entry.
+
+| Date | Change | Driver |
+|------|--------|--------|
+| 2026-06-26 | Phase 0 created (report subcommand; license-gated state machine; 4-leaf taxonomy). | ADR-GitHub-Prior-Art-Scout |
+| 2026-06-26 | Default derived-term cap set to 3 (GitHub search ANDs terms; >3 collapses recall). | first live runs |
+| 2026-06-26 | I2 scope-gate **bug** fixed: a non-200 auth probe now fails closed. The impl was fail-OPEN (5xx / abuse-403 probes were accepted, so a write-scoped token could be falsely attested read-only and still attached). This corrects the impl to honor the already-stated I2 — it does **not** change the invariant, so no ADR amendment. Found by adversarial red-team (GHS-01). | adversarial review |

--- a/docs/methodology/01_Research_Intelligence/github-scout/license_policy.yaml
+++ b/docs/methodology/01_Research_Intelligence/github-scout/license_policy.yaml
@@ -1,0 +1,104 @@
+# license_policy.yaml — github-scout machine-readable SSOT
+# ===========================================================================
+# AUTHORITY (SKILL_CONSTITUTION §3 / plan H-2):
+#   This file is the SINGLE machine-readable source of truth for the mapping
+#       license tier -> inspect ceiling -> allowed recommendations.
+#   tools/github-scout/scout.py MUST load this at runtime and MUST NOT hardcode
+#   tier membership, ceilings, or allowed recommendations. skill_definition.md
+#   is prose ABOUT this file. The authorizing ADR pins this mapping as a
+#   model_independent_invariant.
+#
+# FAIL-CLOSED CONTRACT:
+#   Any SPDX id not listed under a tier below resolves to tier `unknown`.
+#   A missing LICENSE file (HTTP 404) resolves to `unknown` with confidence
+#   `no_license`; any OTHER license-fetch failure (5xx / timeout / NOASSERTION /
+#   "other") resolves to `unknown` with confidence `fetch_failed`. (scout.py keeps
+#   the two confidences distinct so trace stats are not polluted; both gate identically.)
+#   `unknown` permits metadata only and the single recommendation `skip`.
+# ===========================================================================
+policy_version: "1.0.0"
+
+# Inspect ceilings: name -> ordered list of permitted fetch stages.
+# scout.py's sequential state machine never fetches a stage absent from the
+# resolved tier's ceiling (plan H-3). `metadata` is always free (it comes from
+# the single search call); `license` is the authoritative gate fetch.
+inspect_ceilings:
+  metadata_only:                  [metadata]
+  metadata_license:               [metadata, license]
+  metadata_license_readme_tree:   [metadata, license, readme, tree]
+
+# The 4-leaf recommendation taxonomy (plan §4). No fork / vendor-as-kit leaf
+# (Fork 纪律): vendor candidacy survives only as a needs-human-review sub_reason.
+recommendation_leaves:
+  - reference-only
+  - reimplement
+  - needs-human-review
+  - skip
+
+# Sub-reason enum carried by a needs-human-review recommendation (plan §4).
+needs_human_review_sub_reasons:
+  - vendor-as-kit-candidate
+  - behavior-fit-unclear
+  - license-isolation
+  - transitive-unscanned
+
+# Tier table. SPDX ids are compared lowercased. Membership here is exhaustive
+# only for the common cases; ANYTHING unlisted is fail-closed to `unknown`.
+tiers:
+  permissive:
+    spdx: [mit, mit-0, bsd-2-clause, bsd-3-clause, bsd-3-clause-clear, isc, 0bsd,
+           cc0-1.0, unlicense, zlib, bsl-1.0, ncsa, postgresql, python-2.0, wtfpl]
+    inspect_ceiling: metadata_license_readme_tree
+    allowed_recommendations: [reference-only, reimplement, needs-human-review]
+    default_recommendation: needs-human-review
+    default_sub_reason: behavior-fit-unclear
+    obligations: []
+    notes: "Permissive: attribution-only. scout still defaults to human review
+            because semantic behavior-fit is not machine-decidable here."
+
+  permissive_with_obligations:
+    spdx: [apache-2.0, ecl-2.0]
+    inspect_ceiling: metadata_license_readme_tree
+    allowed_recommendations: [reference-only, reimplement, needs-human-review]
+    default_recommendation: needs-human-review
+    default_sub_reason: behavior-fit-unclear
+    obligations: [preserve-notice, patent-grant-and-termination]
+    notes: "Apache-2.0 family: preserve NOTICE; carries an explicit patent grant
+            with a termination clause. Flag obligations before any reuse."
+
+  weak_copyleft:
+    spdx: [mpl-2.0, lgpl-2.1, lgpl-2.1-only, lgpl-2.1-or-later, lgpl-3.0,
+           lgpl-3.0-only, lgpl-3.0-or-later, epl-1.0, epl-2.0, cddl-1.0,
+           ms-pl, eupl-1.1, eupl-1.2, osl-3.0]
+    inspect_ceiling: metadata_license_readme_tree
+    allowed_recommendations: [reimplement, needs-human-review, skip]
+    default_recommendation: needs-human-review
+    default_sub_reason: license-isolation
+    obligations: [file-or-link-level-isolation-required]
+    notes: "Weak copyleft: reuse demands verified file/link isolation in our
+            stack. No vendor-as-dependency without isolation review."
+
+  strong_copyleft:
+    spdx: [gpl-2.0, gpl-2.0-only, gpl-2.0-or-later, gpl-3.0, gpl-3.0-only,
+           gpl-3.0-or-later, agpl-3.0, agpl-3.0-only, agpl-3.0-or-later,
+           sspl-1.0, osl-3.0-or-later]
+    inspect_ceiling: metadata_license
+    allowed_recommendations: [skip, reimplement]
+    default_recommendation: skip
+    default_sub_reason: null
+    obligations: [copyleft-veto, clean-room-reimplement-from-public-docs-only]
+    notes: "Strong copyleft: veto on vendor/fork-as-dependency. The only non-skip
+            path is a clean-room reimplement from PUBLIC docs (never the source),
+            which requires a human decision + harvest-ADR. Source is NOT fetched
+            beyond metadata + LICENSE."
+
+  unknown:
+    spdx: []   # the fail-closed bucket; license fetch_failed also lands here
+    inspect_ceiling: metadata_only
+    allowed_recommendations: [skip]
+    default_recommendation: skip
+    default_sub_reason: null
+    obligations: [fail-closed]
+    notes: "No license file / unrecognized SPDX / NOASSERTION / fetch_failed =>
+            metadata only, idea-only. Never inspect source under an unresolved
+            license."

--- a/docs/methodology/01_Research_Intelligence/github-scout/methods.md
+++ b/docs/methodology/01_Research_Intelligence/github-scout/methods.md
@@ -1,0 +1,21 @@
+# github-scout — Methods (Playbook)
+
+> **Stub (Phase 0).** Detailed procedures accrue here as the scout is used on real
+> ideas. The authoritative method (the license-gated inspect state machine) is in
+> [`skill_definition.md`](./skill_definition.md) §03; the machine-readable rules are
+> in [`license_policy.yaml`](./license_policy.yaml). This file holds the *operator
+> playbook* on top of those.
+
+## Phase 0 quick playbook
+
+1. Phrase the idea in **one sentence** with 2–3 strong nouns (GitHub search ANDs terms).
+2. Run `report`; read `notices` first (weak query / empty recall are flagged loudly).
+3. Treat every `needs-human-review` as **your** decision — scout never concludes fit.
+4. For `strong_copyleft` / `unknown`: stop at metadata. Source is not (and must not be) read.
+5. Before acting on any candidate: open the harvest-ADR / Reference Declaration ceremony.
+
+## To be filled (Phase 1)
+
+- Query-broadening recipes (topic:/language: qualifiers, two-word slices).
+- Transitive-license triage once the scanner exists.
+- Worked examples per recommendation leaf.

--- a/docs/methodology/01_Research_Intelligence/github-scout/skill_definition.md
+++ b/docs/methodology/01_Research_Intelligence/github-scout/skill_definition.md
@@ -1,0 +1,120 @@
+# 🔭 GitHub Prior-Art Scout Skill
+
+**Version**: 1.0
+**Created**: 2026-06-26
+**Last Updated**: 2026-06-26
+**Status**: Active (Phase 0)
+**Layer**: L1 Methodology (Brain) · consumed by `tools/github-scout/` (Hands) + `.claude/skills/github-scout.md` (L3)
+
+---
+
+## 🔹01. Skill Identity（技能身份）
+
+**Skill Name**: GitHub Prior-Art Scout / GitHub 先验技术侦察
+
+**Core Mission**:
+在动手构建一个新能力之前，对 GitHub 上的既有开源实现做**只读、合规、可审计**的侦察，
+把"是否已有人实现过这个想法、能否复用、以何种纪律复用"这个判断，从凭感觉拍脑袋
+变成一条 fail-closed 的、有许可证门禁的、把结论交还给人的流程。
+
+**Capability Domain**: Research Intelligence（先验技术 / 竞品 / 开源生态侦察）
+
+**What it is NOT**: 它**不做决定**。它产出一份 advisory 报告。任何复用结论都要走
+harvest-ADR / Reference Declaration 仪式（SYSTEMS.md Fork 纪律）。它也不是 runtime
+依赖、不 fork、不 clone、不 vendor、不开 PR。
+
+**Target Scenarios**:
+- 新能力立项前的"是否重复造轮子"检查
+- 评估某个想法的开源成熟度与许可证可复用性
+- 为 harvest-ADR / Reference Declaration 准备候选清单
+
+---
+
+## 🔹02. Capability Model（能力模型）
+
+| 维度 | 内容 |
+|------|------|
+| **输入** | 一句话想法（idea sentence） |
+| **派生** | 词法抽取检索词（去停用词，取最强 3 个；GitHub search 默认 AND） |
+| **搜索** | 一次只读 repo 搜索（按 stars 排序，cap N） |
+| **侦察** | 对每个候选按 §03 的**许可证门状态机**做分级 inspect |
+| **打分** | 仅用词法/元数据信号的相关性（M-4：禁止呈现唯一信号是描述子串匹配的候选） |
+| **输出** | 每候选一个 4 叶建议 + 强制 `recall_notice` + `hard_non_goals` |
+
+**核心原则**：召回优先、精度其次（先把候选找全，再用许可证门 + 人审过滤）；
+对**许可证**与**写权限**绝对保守（fail-closed）。
+
+---
+
+## 🔹03. The License-Gated Inspect Method（核心方法：许可证门状态机）
+
+这是本技能的方法论内核，也是 clean-room 纪律的真实闸门。
+
+> **SSOT**：`license tier → inspect 上限 → 允许建议` 的权威映射定义在本目录的
+> [`license_policy.yaml`](./license_policy.yaml)。本文是**关于**它的散文；
+> `tools/github-scout/scout.py` **运行时加载**它、绝不复刻。两者漂移即测试失败。
+
+**严格时序（不可乱序）**：
+
+1. 只取 **metadata + 权威许可证**（`/repos/{repo}/license` 的 SPDX，不是搜索结果里的 hint）。
+2. **评 tier**（按 `license_policy.yaml`）。
+3. **仅当** tier 的 inspect 上限允许，才取 README / tree 形状；否则**立即停**。
+
+**Fail-closed**：无 LICENSE 文件（404）⇒ `confidence = no_license`；任何其它取用失败
+（5xx / NOASSERTION / "other" / timeout）⇒ `confidence = fetch_failed`；**两者都** ⇒
+`tier = unknown` ⇒ 仅 metadata。**绝不**在许可证未决时读源码。
+
+**许可证档 × inspect 上限**（权威在 `license_policy.yaml`；下表为非权威示例）：
+
+| 许可证档 | inspect 上限 | 默认建议 |
+|---|---|---|
+| permissive（MIT/BSD/ISC…） | metadata + LICENSE + README + tree 形状 | needs-human-review |
+| permissive + obligations（Apache-2.0） | 同上 + 标 NOTICE / 专利义务 | needs-human-review |
+| weak copyleft（MPL/LGPL…） | 同上 + 标隔离风险 | needs-human-review（sub: license-isolation） |
+| strong copyleft（GPL/AGPL/SSPL） | **metadata + LICENSE only** | skip（唯一非 skip 路径 = clean-room 重写） |
+| unknown / fetch_failed | **metadata only** | skip |
+
+---
+
+## 🔹04. Recommendation Taxonomy（建议分类，4 叶）
+
+`reference-only` / `reimplement` / `needs-human-review` / `skip`。
+
+- **砍掉** `fork` / `vendor-as-kit` 叶（满足 Fork 纪律）；vendor 候选性只作为
+  `needs-human-review` 的 **sub_reason** 存活：
+  `vendor-as-kit-candidate | behavior-fit-unclear | license-isolation | transitive-unscanned`。
+- **保守默认**：在允许 `needs-human-review` 的档，默认就给 `needs-human-review`
+  ——因为**语义能力契合不可机器判定**，必须交还给人；scout 永不自动得出"去复用"。
+- 每个候选都带 `caveats`（至少 `transitive-unscanned`，因为 Phase 0 不扫传递依赖）。
+
+---
+
+## 🔹05. What Claude Must Be Able to Do（能力边界 / 诚实表达）
+
+- 明确区分"许可证允许" vs "行为契合" vs "值得复用"——前者机器可判，后两者交人。
+- 对空/弱召回**大声报**（派生词 < 2、零候选都要在 `notices` 里显式说）。
+- 永远复述 `recall_notice`：这是 advisory，不是决定。
+- 知识边界：Phase 0 不扫传递许可证、不做供应链信任评估、未认证时有 rate 限。
+
+---
+
+## 🔹06. Governance Integration（治理接线）
+
+- **Fork 纪律（SYSTEMS.md）**：任何复用结论 → harvest-ADR / Reference Declaration
+  仪式；`reference-only` = 只读 reference satellite，不是 runtime 依赖。
+- **Clean-room**：strong copyleft 只允许从**公开文档**重写（源码不被 fetch，I3 保证）。
+- **Reference Declaration（BGHS-ADR §4）**：scout 的 `reference-only` 输出可直接喂给
+  `artifact_scope: reference`（`source_kind: fork|concept`）声明。
+
+---
+
+## 🔹07. Relationship to Hands & L3（与执行层的关系）
+
+| 层 | 件 | 职责 |
+|---|---|---|
+| **L1（本档）** | `skill_definition.md` + `license_policy.yaml` + `methods.md` | 方法论 SSOT |
+| **Hands** | `tools/github-scout/scout.py` + `declaration.yaml` | 执行；运行时加载本层 |
+| **L3** | `.claude/skills/github-scout.md` | 约束 Claude 何时/如何调用，只引用本层 |
+
+权威自上而下：方法论只在 L1 定义；Hands 与 L3 只加载/引用，绝不各自重定义
+（SKILL_CONSTITUTION §3）。

--- a/docs/methodology/01_Research_Intelligence/github-scout/templates/report_output.example.json
+++ b/docs/methodology/01_Research_Intelligence/github-scout/templates/report_output.example.json
@@ -1,0 +1,91 @@
+{
+  "_comment": "Illustrative github-scout report (Phase 0). Real output is produced by tools/github-scout/scout.py and written to its gitignored traces/. Two candidates below show both gate branches: a permissive license (README/tree fetched -> needs-human-review) and an unresolved license (metadata only -> skip).",
+  "schema": "github-scout/report",
+  "phase": 0,
+  "generated_at_utc": "2026-06-26T14:02:33Z",
+  "recall_notice": "ADVISORY ONLY — heuristic prior-art recon, NOT a decision. Per SYSTEMS.md Fork 纪律: any reuse outcome enters the harvest-ADR / Reference Declaration ceremony; a 'reference-only' result = a read-only reference satellite, never a runtime dependency. RED/unknown licenses are fail-closed. Transitive licenses and supply-chain trust are NOT scanned here (Phase 1).",
+  "hard_non_goals": [
+    "no-fork", "no-clone", "no-vendor", "no-PR", "no-network-write",
+    "no-Codebase-Registry-write", "no-production-contract", "not-a-runtime-dependency",
+    "stars-are-not-sole-ranking", "no-automatic-behavior-fit-conclusion"
+  ],
+  "auth_mode": "unauthenticated",
+  "token_scopes": [],
+  "policy_version": "1.0.0",
+  "idea": "amazon advertising bid automation",
+  "derived_query": "amazon advertising bid",
+  "notices": [],
+  "candidate_count": 2,
+  "candidates": [
+    {
+      "metadata": {
+        "repo": "example-org/permissive-repo",
+        "stars": 20,
+        "pushed_at": "2026-06-08",
+        "description": "an MIT-licensed example whose license PERMITS README + tree inspection",
+        "url": "https://github.com/example-org/permissive-repo"
+      },
+      "license": {
+        "spdx": "mit",
+        "tier": "permissive",
+        "confidence": "ok",
+        "inspect_ceiling": "metadata_license_readme_tree"
+      },
+      "inspected": {
+        "readme_excerpt": "# Example README (first ~240 chars, whitespace-collapsed) ...",
+        "tree_shape": ["LICENSE", "README.md", "src", "requirements.txt"],
+        "stages_permitted": ["metadata", "license", "readme", "tree"]
+      },
+      "relevance": {
+        "matched_terms": ["amazon", "advertising", "bid"],
+        "signal": "name_or_topic",
+        "low_confidence": false
+      },
+      "recommendation": "needs-human-review",
+      "sub_reason": "behavior-fit-unclear",
+      "allowed_recommendations": ["reference-only", "reimplement", "needs-human-review"],
+      "caveats": ["transitive-unscanned"],
+      "obligations": [],
+      "policy_note": "Permissive: attribution-only. scout still defaults to human review because semantic behavior-fit is not machine-decidable here.",
+      "low_confidence": false
+    },
+    {
+      "metadata": {
+        "repo": "example-org/no-license-repo",
+        "stars": 1,
+        "pushed_at": "2026-02-06",
+        "description": "no LICENSE file -> tier=unknown -> source is NOT inspected (fail-closed)",
+        "url": "https://github.com/example-org/no-license-repo"
+      },
+      "license": {
+        "spdx": null,
+        "tier": "unknown",
+        "confidence": "no_license",
+        "inspect_ceiling": "metadata_only"
+      },
+      "inspected": {
+        "readme_excerpt": null,
+        "tree_shape": null,
+        "stages_permitted": ["metadata"]
+      },
+      "relevance": {
+        "matched_terms": ["amazon", "advertising", "bid"],
+        "signal": "name_or_topic",
+        "low_confidence": false
+      },
+      "recommendation": "skip",
+      "sub_reason": null,
+      "allowed_recommendations": ["skip"],
+      "caveats": ["transitive-unscanned"],
+      "obligations": ["fail-closed"],
+      "policy_note": "No license file / unrecognized SPDX / NOASSERTION / fetch_failed => metadata only, idea-only. Never inspect source under an unresolved license.",
+      "low_confidence": false
+    }
+  ],
+  "network_call_summary": {
+    "search": 1,
+    "license": 2,
+    "readme": 1,
+    "tree": 1
+  }
+}

--- a/tools/github-scout/.gitignore
+++ b/tools/github-scout/.gitignore
@@ -1,0 +1,10 @@
+# github-scout local artifacts — generated, NOT source (plan correction #4).
+# The repo-root /traces and data/traces rules do NOT cover this subtree, so it is
+# ignored here explicitly. scout.py creates traces/ at runtime.
+#
+#   traces/  = advisory run outputs (gitignored; never auto-tracked)
+#   drafts/  = Phase-1 reference drafts (gitignored; manual promote via `git add -f`)
+traces/
+drafts/
+__pycache__/
+*.pyc

--- a/tools/github-scout/README.md
+++ b/tools/github-scout/README.md
@@ -1,0 +1,80 @@
+# github-scout (Hands tool)
+
+Read-only, advisory GitHub **prior-art reconnaissance**. Given an idea, it searches
+GitHub, gates each candidate by its authoritative license, and emits a conservative
+recommendation — so a new capability can be checked against existing open source
+*before* building, under LiYe governance (Fork 纪律, clean-room, harvest-ADR).
+
+> **This tool decides nothing.** It produces an advisory report. Any reuse outcome
+> goes through the harvest-ADR / Reference Declaration ceremony (SYSTEMS.md).
+
+## Where this sits (architecture)
+
+`github-scout` is a **three-layer** capability:
+
+| Layer | Location | Role |
+|-------|----------|------|
+| **L1 Methodology** (Brain) | `docs/methodology/01_Research_Intelligence/github-scout/` | the human knowledge + the `license_policy.yaml` SSOT |
+| **Hands tool** (this dir) | `tools/github-scout/` | the executable CLI that *consumes* L1 and talks to the GitHub API |
+| **L3 Instruction** | `.claude/skills/github-scout.md` | flat advisory doc that tells Claude how/when to invoke this |
+
+This tool is **BGHS-Hands infrastructure and sits OUTSIDE the Skill three-layer spine**
+(it is not an L2 Executable Skill). It never originates policy — the license
+tier → inspect ceiling → allowed recommendation mapping is loaded at runtime from the
+L1 SSOT. See `declaration.yaml` and `ADR-GitHub-Prior-Art-Scout.md`.
+
+## Usage (Phase 0: `report` only)
+
+```bash
+# from repo root — runs UNAUTHENTICATED (public read, 60/hr) by default
+python3 tools/github-scout/scout.py report \
+  --idea "deduplicate jsonl records by canonical content hash" \
+  --out traces/dedup.json          # trace path is relative to this tool dir
+
+python3 tools/github-scout/scout.py report --idea "..." --json   # full JSON to stdout
+python3 tools/github-scout/scout.py report --idea "..." --limit 5 # cap candidates
+```
+
+Other subcommands (`derive` / `search` / `inspect` / `emit-reference`) are reserved
+for Phase 1 and exit with code 3.
+
+### Optional read-only token (rate-limit headroom)
+
+Default is unauthenticated. To raise the limit to 5000/hr, supply a **read-only**
+token via the env var named by `--token-env` (default `GITHUB_SCOUT_READONLY_TOKEN`):
+
+```bash
+GITHUB_SCOUT_READONLY_TOKEN=<fine-grained read-only PAT> python3 tools/github-scout/scout.py report --idea "..."
+```
+
+scout.py asserts the token via the `X-OAuth-Scopes` response header. Phase 0 requires
+a **NO-SCOPE** token: **any classic scope at all (including read-only `read:org`) ⇒
+fail-closed** (no live write probe is issued). A fine-grained "Public repositories
+(read-only)" token reports empty scopes and passes. Your ambient `gh` keyring token is
+intentionally never used (it carries `repo` + `gist` write scopes).
+
+## Safety invariants (enforced + tested)
+
+- **I1** zero external mutating side-effect — no fork/clone/vendor/PR/write; only local gitignored `traces/`.
+- **I2** read-only by construction — no Authorization header unless an explicitly-asserted read-only token is given.
+- **I3** sequential inspect — authoritative license first; README/tree only if the tier ceiling permits; any fetch failure ⇒ `unknown` ⇒ metadata only.
+
+```bash
+python3 tools/github-scout/test_scout.py     # 23 offline tests (no network; requires pyyaml)
+```
+
+`test_scout.py` loads the live L1 `license_policy.yaml`, so it fails if scout.py and
+the SSOT ever drift (H-2), and asserts at the network-call layer that RED/unknown
+repos get **zero** README/tree fetches (H-3).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `scout.py` | the CLI (report subcommand) |
+| `test_scout.py` | offline test suite (unittest, no deps beyond pyyaml) |
+| `declaration.yaml` | BGHS Component Declaration (primary_concern: Hands) |
+| `traces/` | run outputs — **gitignored**, advisory |
+| `drafts/` | Phase-1 reference drafts — **gitignored**, manual promote |
+
+Requires: Python 3.9+ and `pyyaml`.

--- a/tools/github-scout/declaration.yaml
+++ b/tools/github-scout/declaration.yaml
@@ -1,0 +1,60 @@
+# Component Declaration — github-scout (Hands tool)
+# Schema: ADR-Architecture-Doctrine-BGHS-Separation.md §2 (Component Declaration).
+# NOTE: this is the FIRST tool-level Component Declaration in the portfolio
+# (notion-sync etc. predate the BGHS doctrine and carry none). Established here
+# per the ADR §2 form; not copied from an existing tool precedent.
+artifact_scope: component
+component_name: github-scout
+layer: 0                      # liye_os Layer-0 reusable infra tooling
+
+# BGHS: this tool interacts with an external API and the local filesystem.
+# Its METHODOLOGY (Brain) lives in L1 docs/methodology/...; the tool only executes.
+primary_concern: Hands
+secondary_concern: Session   # emits advisory traces (session-adjacent run records)
+
+model_contingent_items:
+  - "query derivation from an idea sentence (lexical heuristic; tuned over time)"
+  - "relevance scoring signals (lexical/metadata only)"
+  - "default recommendation copy / wording"
+
+model_independent_invariants:
+  - "I1 zero external mutating side-effect: no fork/clone/vendor/PR/network write; only local gitignored traces"
+  - "I2 read-only by construction: default sends no Authorization header; a token is attached only if asserted via X-OAuth-Scopes; Phase 0 requires a NO-SCOPE token (any classic scope incl. read:org => fail-closed); no live write probe"
+  - "I3 sequential inspect: authoritative license fetched FIRST, README/tree only if the tier ceiling permits"
+  - "license tier -> inspect ceiling -> allowed recommendation is sourced from the L1 license_policy.yaml SSOT at runtime; never hardcoded in scout.py"
+  - "unresolved/unrecognized/fetch-failed license => unknown tier => metadata only => skip (fail-closed)"
+
+# Session-adjacent output (advisory traces), not an authoritative session event stream.
+session_source_of_truth: null
+session_adjacent_output: "tools/github-scout/traces/*.json (gitignored, advisory)"
+
+# Doctrine single-URI pointer (retained per ADR-Credential-Mediation; NOT overridden).
+credential_path: cred://liye-os/github-scout-readonly
+
+# P1-f multi-binding form. Phase 0 runs UNAUTHENTICATED by default; this binding is
+# the OPTIONAL read-only token that, when supplied, raises the rate limit. scout.py
+# never reads the value into code/logs beyond a passive X-OAuth-Scopes assertion.
+credential_bindings:
+  - reference: cred://liye-os/github-scout-readonly
+    purpose: "read-only discovery of public GitHub repos, metadata, and license (rate-limit headroom only)"
+    broker_required: false        # Phase 0: env var; full EnvCredentialBroker wiring deferred
+    optional: true                # absent => unauthenticated public read (60/hr) with a loud notice
+    env_var_phase0: GITHUB_SCOUT_READONLY_TOKEN
+    required_scope: "fine-grained 'Public repositories (read-only)' OR classic token with NO scopes"
+    scope_assertion_caveat: "X-OAuth-Scopes only reflects CLASSIC scopes; a fine-grained token's permissions are not exposed via this header, so a fine-grained binding relies on the operator provisioning it read-only"
+
+wake_resume_entrypoint: null
+
+explicit_non_goals:
+  - "does not fork, clone, vendor, or open PRs"
+  - "does not write the Codebase Registry or any production contract/schema"
+  - "is not a runtime dependency; candidates it surfaces are never auto-imported"
+  - "does not conclude semantic behavior-fit automatically (routes to needs-human-review)"
+  - "does not scan transitive/dependency licenses (Phase 1)"
+  - "does not rank by stars alone"
+
+future_split_direction: >
+  If a runtime/Agent ever needs to dispatch scouting programmatically, promote the
+  dispatch surface to an L2 Executable Skill under src/skill/ (the methodology stays
+  in L1). Wire credential_bindings through a real EnvCredentialBroker instance, and
+  add the ghbudget bucketed-budget + transitive license scan, in Phase 1.

--- a/tools/github-scout/scout.py
+++ b/tools/github-scout/scout.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""scout.py — github-scout Hands CLI. Phase 0: `report` only. READ-ONLY, advisory.
+
+BGHS classification: primary_concern = Hands (see declaration.yaml). This tool sits
+OUTSIDE the Skill three-layer spine (it is BGHS-Hands infrastructure, not an L2
+Executable Skill); it CONSUMES the L1 methodology SSOT and never originates policy.
+
+Authority chain (plan §1 / SKILL_CONSTITUTION §3):
+    docs/methodology/01_Research_Intelligence/github-scout/license_policy.yaml  (L1 SSOT)
+        -> scout.py loads it at runtime; tiers/ceilings are NEVER hardcoded here.
+
+Model-independent invariants (pinned by ADR-GitHub-Prior-Art-Scout):
+  I1  Zero external mutating side-effect. No fork/clone/vendor/PR/network write.
+      Only local, gitignored traces/ may be written.
+  I2  Read-only by construction. Default sends NO Authorization header
+      (unauthenticated public read). A token is attached ONLY when explicitly
+      provided AND asserted via the X-OAuth-Scopes response header on a successful
+      (HTTP 200) probe; Phase 0 requires a NO-SCOPE token, so any classic scope
+      (incl. read:org) OR an inconclusive (non-200) probe => fail-closed. No live
+      write probe is ever issued.
+  I3  Sequential inspect state machine. Per candidate: fetch authoritative
+      license FIRST -> resolve tier -> fetch README/tree ONLY IF the tier ceiling
+      permits. A missing LICENSE (404) => confidence='no_license'; any other fetch
+      failure (5xx/timeout/NOASSERTION/'other') => confidence='fetch_failed'; both
+      => tier=unknown, ceiling=metadata_only.
+
+Usage:
+    python3 tools/github-scout/scout.py report --idea "an idea in a sentence" [--out traces/run.json]
+        [--limit N] [--json] [--policy PATH] [--token-env VAR]
+Other subcommands (derive/search/inspect/emit-reference) are reserved for Phase 1.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+# NOTE: PyYAML is imported lazily inside LicensePolicy.load() so that --help and the
+# reserved subcommands work with zero third-party deps; only `report` needs it.
+
+API_ROOT = "https://api.github.com"
+USER_AGENT = "liye-github-scout/0.1 (read-only; advisory)"
+# Phase 0 requires a NO-SCOPE token. A public prior-art scout needs zero scopes for
+# public reads, so ANY non-empty classic scope (including read:org) => fail-closed
+# (I2). Fine-grained tokens report an EMPTY X-OAuth-Scopes header, so a fine-grained
+# "Public repositories (read-only)" token also passes; note that fine-grained perms
+# are NOT exposed via this header and rely on the operator provisioning it read-only.
+
+
+class ScoutFatal(Exception):
+    """Raised on any fail-closed condition; aborts the run cleanly."""
+
+
+# --------------------------------------------------------------------------- #
+# Transport (single network chokepoint; injectable for H-3 network-layer tests)
+# --------------------------------------------------------------------------- #
+class HttpTransport:
+    """Default transport over urllib. Returns (status, headers_dict, body_bytes)."""
+
+    def get(self, url: str, headers: dict) -> tuple[int, dict, bytes]:
+        req = urllib.request.Request(url, headers=headers, method="GET")
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                return resp.status, {k.lower(): v for k, v in resp.headers.items()}, resp.read()
+        except urllib.error.HTTPError as e:
+            body = e.read() if hasattr(e, "read") else b""
+            return e.code, {k.lower(): v for k, v in (e.headers or {}).items()}, body
+
+
+class GitHubClient:
+    """Read-only GitHub REST client. Every request flows through _get(), which
+    records an entry into call_log — that log is the network-layer evidence for I3."""
+
+    def __init__(self, transport=None, token: str | None = None):
+        self.transport = transport or HttpTransport()
+        self.token = token
+        self.call_log: list[dict] = []      # [{kind, repo, path, status}]
+        self.auth_mode = "unauthenticated"
+        self.token_scopes: list[str] = []
+
+    def _get(self, path: str, kind: str, repo: str | None = None) -> tuple[int, dict, object]:
+        url = path if path.startswith("http") else API_ROOT + path
+        headers = {"Accept": "application/vnd.github+json",
+                   "User-Agent": USER_AGENT,
+                   "X-GitHub-Api-Version": "2022-11-28"}
+        if self.token:                       # I2: header attached only when token present
+            headers["Authorization"] = "Bearer " + self.token
+        status, hdrs, body = self.transport.get(url, headers)
+        self.call_log.append({"kind": kind, "repo": repo, "path": path, "status": status})
+        if status == 403 and hdrs.get("x-ratelimit-remaining") == "0":
+            raise ScoutFatal("GitHub rate limit exhausted (read budget). Stop; retry later "
+                             "or supply a read-only token to raise the limit.")
+        parsed: object = None
+        if body:
+            try:
+                parsed = json.loads(body)
+            except (ValueError, UnicodeDecodeError):
+                parsed = None
+        return status, hdrs, parsed
+
+    # --- I2: read-only assertion (passive header read; NO live write probe) ---
+    def assert_readonly_or_die(self) -> None:
+        if not self.token:
+            self.auth_mode = "unauthenticated"     # read-only by construction
+            return
+        status, hdrs, _ = self._get("/rate_limit", kind="auth_probe")  # benign read
+        if status != 200:
+            # GHS-01 fail-closed: without an authoritative 200 we cannot trust the
+            # ABSENCE of scopes (error responses carry no X-OAuth-Scopes header), so we
+            # must NOT proceed with — or attach — the token (I2). 401 = invalid/expired;
+            # 5xx / abuse-403 = inconclusive. Either way, refuse rather than fail open.
+            raise ScoutFatal(
+                "read-only assertion inconclusive: token auth-probe returned HTTP %s; "
+                "refusing to use the token (fail-closed, I2). Run unauthenticated, or "
+                "supply a verifiable NO-SCOPE token." % status)
+        raw = hdrs.get("x-oauth-scopes", "")
+        scopes = [s.strip() for s in raw.split(",") if s.strip()]
+        self.token_scopes = scopes
+        if scopes:   # ANY classic scope (incl. read:org) is too broad for a public scout
+            raise ScoutFatal(
+                "supplied token carries scope(s) %s — Phase 0 requires a NO-SCOPE token "
+                "(fail-closed, I2). Use a classic token with NO scopes, or a fine-grained "
+                "'Public repositories (read-only)' token." % scopes)
+        self.auth_mode = "authenticated-readonly"
+
+    # --- metadata (one search call covers all candidates) ---
+    def search_repos(self, query: str, limit: int) -> list[dict]:
+        q = urllib.parse.urlencode(
+            {"q": query, "sort": "stars", "order": "desc", "per_page": str(limit)})
+        status, _, parsed = self._get("/search/repositories?" + q, kind="search")
+        if status == 422:
+            raise ScoutFatal("search query rejected by GitHub (422): %r" % query)
+        if status != 200 or not isinstance(parsed, dict):
+            raise ScoutFatal("search failed (HTTP %s)." % status)
+        return parsed.get("items", []) or []
+
+    # --- authoritative license: the GATE fetch (I3 step 1) ---
+    def authoritative_license(self, repo: str) -> tuple[str | None, str]:
+        """Returns (spdx_lower_or_None, confidence) where confidence in
+        {'ok', 'no_license', 'fetch_failed'}."""
+        try:
+            status, _, parsed = self._get("/repos/%s/license" % repo, kind="license", repo=repo)
+        except ScoutFatal:
+            raise
+        except Exception:
+            return None, "fetch_failed"
+        if status == 404:
+            return None, "no_license"
+        if status != 200 or not isinstance(parsed, dict):
+            return None, "fetch_failed"
+        spdx = ((parsed.get("license") or {}).get("spdx_id") or "").strip()
+        if not spdx or spdx.upper() in {"NOASSERTION", "OTHER"}:
+            return None, "fetch_failed"   # unrecognized => fail-closed bucket
+        return spdx.lower(), "ok"
+
+    # --- gated fetches (I3 step 3; only called when ceiling permits) ---
+    def readme_excerpt(self, repo: str, limit_chars: int = 240) -> str | None:
+        status, _, parsed = self._get("/repos/%s/readme" % repo, kind="readme", repo=repo)
+        if status != 200 or not isinstance(parsed, dict):
+            return None
+        try:
+            text = base64.b64decode(parsed.get("content", "")).decode("utf-8", "replace")
+        except Exception:
+            return None
+        return re.sub(r"\s+", " ", text).strip()[:limit_chars] or None
+
+    def tree_shape(self, repo: str, limit: int = 25) -> list[str] | None:
+        status, _, parsed = self._get("/repos/%s/contents" % repo, kind="tree", repo=repo)
+        if status != 200 or not isinstance(parsed, list):
+            return None
+        return [e.get("name", "") for e in parsed[:limit] if isinstance(e, dict)]
+
+
+# --------------------------------------------------------------------------- #
+# License policy (loaded from the L1 SSOT; never hardcoded here)
+# --------------------------------------------------------------------------- #
+class LicensePolicy:
+    def __init__(self, doc: dict):
+        self.doc = doc
+        self.tiers = doc["tiers"]
+        self.ceilings = doc["inspect_ceilings"]
+        self.leaves = set(doc["recommendation_leaves"])
+        self._spdx_index = {}
+        for tier_name, tier in self.tiers.items():
+            for spdx in (tier.get("spdx") or []):
+                self._spdx_index[spdx.lower()] = tier_name
+        self._validate()
+
+    def _validate(self) -> None:
+        if "unknown" not in self.tiers:
+            raise ScoutFatal("policy missing required fail-closed tier 'unknown'.")
+        for name, tier in self.tiers.items():
+            if tier["inspect_ceiling"] not in self.ceilings:
+                raise ScoutFatal("tier %s references unknown ceiling %s" % (name, tier["inspect_ceiling"]))
+            allowed = set(tier["allowed_recommendations"])
+            if not allowed <= self.leaves:
+                raise ScoutFatal("tier %s allows non-leaf recommendation(s)" % name)
+            if tier["default_recommendation"] not in allowed:
+                raise ScoutFatal("tier %s default_recommendation not in its allowed set" % name)
+
+    @classmethod
+    def load(cls, path: Path) -> "LicensePolicy":
+        if not path.exists():
+            raise ScoutFatal("license policy SSOT not found at %s" % path)
+        try:
+            import yaml
+        except ImportError:
+            raise ScoutFatal("PyYAML is required to load the license policy SSOT. "
+                             "Install it: `python3 -m pip install pyyaml` (or `uv add pyyaml`).")
+        return cls(yaml.safe_load(path.read_text(encoding="utf-8")))
+
+    def tier_for(self, spdx_lower: str | None) -> str:
+        if not spdx_lower:
+            return "unknown"
+        return self._spdx_index.get(spdx_lower, "unknown")
+
+    def ceiling_stages(self, tier_name: str) -> list[str]:
+        return list(self.ceilings[self.tiers[tier_name]["inspect_ceiling"]])
+
+    def tier(self, tier_name: str) -> dict:
+        return self.tiers[tier_name]
+
+
+# --------------------------------------------------------------------------- #
+# Lexical helpers (relevance/query are metadata-only signals; M-4)
+# --------------------------------------------------------------------------- #
+_STOP = set(("a an the of for to and or with in on into via using build make create "
+             "system that this your our new idea app tool service platform engine "
+             "based simple framework library project").split())
+
+
+def derive_query(idea: str) -> str:
+    """Lexical term extraction. Returns '' when no meaningful term survives the
+    stopword filter — callers must treat that as a loud derivation failure (M-4),
+    not silently fall back to the raw idea as a strong query."""
+    words = [w for w in re.findall(r"[a-z0-9+#]+", idea.lower())
+             if w not in _STOP and len(w) > 2]
+    # GitHub search ANDs terms; >3 terms collapses recall to near-zero. Keep the 3
+    # strongest (input order) — a recall/precision default, tunable in Phase 1.
+    return " ".join(words[:3])
+
+
+def lexical_relevance(query: str, item: dict) -> dict:
+    terms = set(query.lower().split())
+    name = (item.get("name") or "").lower()
+    desc = (item.get("description") or "").lower()
+    topics = " ".join(item.get("topics") or []).lower()
+    in_name = {t for t in terms if t in name or t in topics}
+    in_desc = {t for t in terms if t in desc}
+    matched = in_name | in_desc
+    # M-4: a candidate whose ONLY signal is a description-substring match is weak.
+    desc_only = bool(matched) and not in_name
+    return {
+        "matched_terms": sorted(matched),
+        "signal": "name_or_topic" if in_name else ("description_only" if in_desc else "none"),
+        "low_confidence": (not matched) or desc_only,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Report (the only Phase 0 deliverable)
+# --------------------------------------------------------------------------- #
+RECALL_NOTICE = (
+    "ADVISORY ONLY — heuristic prior-art recon, NOT a decision. Per SYSTEMS.md Fork "
+    "纪律: any reuse outcome enters the harvest-ADR / Reference Declaration ceremony; "
+    "a 'reference-only' result = a read-only reference satellite, never a runtime "
+    "dependency. RED/unknown licenses are fail-closed. Transitive licenses and "
+    "supply-chain trust are NOT scanned here (Phase 1)."
+)
+HARD_NON_GOALS = [
+    "no-fork", "no-clone", "no-vendor", "no-PR", "no-network-write",
+    "no-Codebase-Registry-write", "no-production-contract", "not-a-runtime-dependency",
+    "stars-are-not-sole-ranking", "no-automatic-behavior-fit-conclusion",
+]
+
+
+def recommend(policy: LicensePolicy, tier_name: str, relevance: dict) -> dict:
+    tier = policy.tier(tier_name)
+    leaf = tier["default_recommendation"]
+    sub = tier.get("default_sub_reason")
+    caveats = ["transitive-unscanned"]      # Phase 0 never scans transitive deps
+    if relevance["low_confidence"] and leaf == "needs-human-review":
+        caveats.append("relevance-low-confidence")
+    return {
+        "recommendation": leaf,
+        "sub_reason": sub if leaf == "needs-human-review" else None,
+        "allowed_recommendations": tier["allowed_recommendations"],
+        "caveats": caveats,
+        "obligations": tier.get("obligations") or [],
+        "policy_note": tier.get("notes", "").strip(),
+    }
+
+
+def inspect_candidate(client: GitHubClient, policy: LicensePolicy, item: dict, query: str) -> dict:
+    repo = item.get("full_name", "")
+    metadata = {
+        "repo": repo,
+        "stars": item.get("stargazers_count", 0),
+        "pushed_at": (item.get("pushed_at") or "")[:10],
+        "description": item.get("description") or "",
+        "url": item.get("html_url") or ("https://github.com/" + repo),
+    }
+    # I3 step 1 — authoritative license FIRST (the gate)
+    spdx, confidence = client.authoritative_license(repo)
+    tier_name = policy.tier_for(spdx) if confidence == "ok" else "unknown"
+    stages = policy.ceiling_stages(tier_name)
+    license_block = {
+        "spdx": spdx, "tier": tier_name, "confidence": confidence,
+        "inspect_ceiling": policy.tier(tier_name)["inspect_ceiling"],
+    }
+    # I3 step 3 — gated fetches, ONLY if the ceiling permits
+    readme = client.readme_excerpt(repo) if "readme" in stages else None
+    tree = client.tree_shape(repo) if "tree" in stages else None
+    relevance = lexical_relevance(query, item)
+    return {
+        "metadata": metadata,
+        "license": license_block,
+        "inspected": {"readme_excerpt": readme, "tree_shape": tree,
+                      "stages_permitted": stages},
+        "relevance": relevance,
+        **recommend(policy, tier_name, relevance),
+        "low_confidence": relevance["low_confidence"],
+    }
+
+
+def build_report(idea: str, limit: int, policy: LicensePolicy,
+                 client: GitHubClient) -> dict:
+    client.assert_readonly_or_die()            # I2
+    terms = derive_query(idea)
+    query = terms or idea.strip()              # fall back to raw idea for the search...
+    query_weak = len(terms.split()) < 2        # ...but weakness is judged on derived terms
+    candidates = client.search_repos(query, limit)
+    inspected = [inspect_candidate(client, policy, it, query) for it in candidates]
+    notices = []
+    if query_weak:
+        notices.append("derived query is weak (<2 terms) — broaden the idea or add "
+                       "topic:/language: qualifiers manually (model-contingent risk).")
+    if not candidates:
+        notices.append("no candidates for query %r — broaden terms." % query)
+    return {
+        "schema": "github-scout/report",
+        "phase": 0,
+        "generated_at_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "recall_notice": RECALL_NOTICE,
+        "hard_non_goals": HARD_NON_GOALS,
+        "auth_mode": client.auth_mode,
+        "token_scopes": client.token_scopes,
+        "policy_version": policy.doc.get("policy_version"),
+        "idea": idea,
+        "derived_query": query,
+        "notices": notices,
+        "candidate_count": len(inspected),
+        "candidates": inspected,
+        "network_call_summary": _call_summary(client.call_log),
+    }
+
+
+def _call_summary(call_log: list[dict]) -> dict:
+    out: dict[str, int] = {}
+    for c in call_log:
+        out[c["kind"]] = out.get(c["kind"], 0) + 1
+    return out
+
+
+def _hash_idea(idea: str) -> str:
+    return hashlib.sha256(idea.encode("utf-8")).hexdigest()[:12]
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _default_policy_path() -> Path:
+    root = Path(__file__).resolve().parents[2]   # tools/github-scout/scout.py -> repo root
+    return root / "docs/methodology/01_Research_Intelligence/github-scout/license_policy.yaml"
+
+
+def _traces_root() -> Path:
+    return (Path(__file__).resolve().parent / "traces").resolve()
+
+
+def _safe_trace_path(out_arg: str) -> Path:
+    """Confine --out STRICTLY to tools/github-scout/traces/ (invariant I1). Reject
+    absolute paths and any '..' escape; the only writable surface is traces/."""
+    traces_root = _traces_root()
+    p = Path(out_arg)
+    if p.is_absolute():
+        raise ScoutFatal("--out must be relative to traces/; absolute path rejected (I1): %s" % out_arg)
+    parts = [x for x in p.parts if x not in ("", ".")]
+    if parts and parts[0] == "traces":           # tolerate 'traces/run.json' or bare 'run.json'
+        parts = parts[1:]
+    if not parts:
+        raise ScoutFatal("--out must name a file under traces/ (got empty/dir): %s" % out_arg)
+    resolved_path = (traces_root / Path(*parts)).resolve()
+    if resolved_path == traces_root or traces_root not in resolved_path.parents:
+        raise ScoutFatal("--out escapes traces/ ('..'/absolute rejected, I1): %s" % out_arg)
+    return resolved_path
+
+
+def _print_human(report: dict) -> None:
+    print("== github-scout report (Phase 0, advisory) ==")
+    print("idea   :", report["idea"])
+    print("query  :", report["derived_query"], "  | auth:", report["auth_mode"])
+    for n in report["notices"]:
+        print("notice :", n)
+    print("-" * 78)
+    for i, c in enumerate(report["candidates"], 1):
+        m, lic = c["metadata"], c["license"]
+        flag = " [low-confidence]" if c["low_confidence"] else ""
+        print("%2d %-38s %6s★  %-12s %-16s %s%s" % (
+            i, m["repo"][:38], m["stars"], lic["spdx"] or "none",
+            lic["tier"], c["recommendation"], flag))
+        if c["sub_reason"]:
+            print("     sub_reason:", c["sub_reason"], "| caveats:", ",".join(c["caveats"]))
+    print("-" * 78)
+    print("calls  :", report["network_call_summary"])
+    print(report["recall_notice"])
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    if not args.idea or not args.idea.strip():
+        sys.stderr.write("ERROR: --idea is required and must be non-empty\n")
+        return 2
+    out = _safe_trace_path(args.out) if args.out else None   # I1: validate BEFORE any network
+    policy = LicensePolicy.load(Path(args.policy) if args.policy else _default_policy_path())
+    token = os.environ.get(args.token_env) if args.token_env else None
+    client = GitHubClient(token=token)
+    report = build_report(args.idea, args.limit, policy, client)
+    if out:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+        sys.stderr.write("trace written: %s\n" % out)
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        _print_human(report)
+    return 0
+
+
+def _reserved(args: argparse.Namespace) -> int:
+    sys.stderr.write("'%s' is reserved for Phase 1 and not implemented.\n" % args.cmd)
+    return 3
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="scout.py", description="github-scout (Phase 0: report only)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    r = sub.add_parser("report", help="idea -> ranked, license-gated prior-art report")
+    r.add_argument("--idea", required=True, help="the idea, in a sentence")
+    r.add_argument("--out", default=None,
+                   help="trace filename, confined to traces/ (I1; absolute/'..' rejected)")
+    r.add_argument("--limit", type=int, default=8, help="max search candidates (default 8)")
+    r.add_argument("--json", action="store_true", help="print full JSON to stdout")
+    r.add_argument("--policy", default=None, help="override license_policy.yaml path")
+    r.add_argument("--token-env", default="GITHUB_SCOUT_READONLY_TOKEN",
+                   help="env var holding a READ-ONLY token (asserted; default unauthenticated)")
+    r.set_defaults(func=cmd_report)
+
+    for name in ("derive", "search", "inspect", "emit-reference"):
+        sp = sub.add_parser(name, help="(Phase 1, reserved)")
+        sp.set_defaults(func=_reserved)
+
+    args = p.parse_args(argv)
+    try:
+        return args.func(args)
+    except ScoutFatal as e:
+        sys.stderr.write("FAIL-CLOSED: %s\n" % e)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/github-scout/test_scout.py
+++ b/tools/github-scout/test_scout.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""test_scout.py — offline tests for github-scout (no network; FakeTransport).
+
+Covers the plan's safety invariants:
+  H-2  scout's effective inspect ceiling per tier == the L1 license_policy.yaml SSOT
+       (loaded live, so the test fails if scout.py and the SSOT ever drift).
+  H-3  network-layer state machine: a RED (strong_copyleft) / unknown / fetch_failed
+       repo yields ZERO readme/tree GETs; a permissive repo yields exactly one each.
+  fail-closed  license 404 / 500 / NOASSERTION => tier=unknown => metadata_only.
+  I2   write-scoped token => fail-closed; read-only token => ok; no token => unauthenticated.
+
+Run:  python3 tools/github-scout/test_scout.py       (exit 0 = all green; Python 3.9+)
+"""
+from __future__ import annotations    # PEP 604 'str | None' annotations on Python 3.9
+
+import base64
+import json
+import unittest
+from pathlib import Path
+
+import scout
+from scout import (GitHubClient, LicensePolicy, ScoutFatal, build_report,
+                   inspect_candidate, _default_policy_path, _safe_trace_path, _traces_root)
+
+POLICY = LicensePolicy.load(_default_policy_path())
+
+
+def _resp(status, body=None, headers=None):
+    raw = json.dumps(body).encode() if body is not None else b""
+    return status, {k.lower(): v for k, v in (headers or {}).items()}, raw
+
+
+class FakeTransport:
+    """Records nothing itself; GitHubClient.call_log is the network-layer evidence.
+    Serves canned responses keyed by URL substring."""
+
+    def __init__(self, repos: dict, scopes: str | None = None, license_status=None,
+                 probe_status: int = 200):
+        self.repos = repos                 # full_name -> {spdx, readme, tree}
+        self.scopes = scopes               # X-OAuth-Scopes value for /rate_limit probe
+        self.license_status = license_status or {}   # full_name -> forced HTTP status
+        self.probe_status = probe_status   # forced status for the auth /rate_limit probe
+        self.requests: list = []           # wire log: (url, auth_header_or_None)
+
+    def get(self, url: str, headers: dict):
+        self.requests.append((url, headers.get("Authorization")))
+        if "/rate_limit" in url:
+            if self.probe_status != 200:   # error responses carry no X-OAuth-Scopes header
+                return _resp(self.probe_status, {"message": "err"})
+            return _resp(200, {"ok": True}, {"X-OAuth-Scopes": self.scopes or ""})
+        if "/search/repositories" in url:
+            items = [{"full_name": fn, "name": fn.split("/")[-1],
+                      "stargazers_count": r.get("stars", 100),
+                      "description": r.get("description", ""),
+                      "pushed_at": "2026-01-01T00:00:00Z",
+                      "topics": r.get("topics", []),
+                      "html_url": "https://github.com/" + fn}
+                     for fn, r in self.repos.items()]
+            return _resp(200, {"items": items})
+        for fn, r in self.repos.items():
+            if ("/repos/%s/license" % fn) in url:
+                forced = self.license_status.get(fn)
+                if forced and forced != 200:
+                    return _resp(forced, {} if forced != 404 else {"message": "Not Found"})
+                spdx = r.get("spdx")
+                if spdx is None:
+                    return _resp(404, {"message": "Not Found"})
+                return _resp(200, {"license": {"spdx_id": spdx}})
+            if ("/repos/%s/readme" % fn) in url:
+                content = base64.b64encode((r.get("readme", "readme")).encode()).decode()
+                return _resp(200, {"content": content})
+            if ("/repos/%s/contents" % fn) in url:
+                return _resp(200, [{"name": n, "type": "file"} for n in r.get("tree", ["src"])])
+        return _resp(404, {"message": "Not Found"})
+
+
+def _kinds(client, repo):
+    return [c["kind"] for c in client.call_log if c["repo"] == repo]
+
+
+class PolicyShape(unittest.TestCase):
+    def test_unknown_tier_is_fail_closed(self):
+        self.assertEqual(POLICY.tier_for(None), "unknown")
+        self.assertEqual(POLICY.tier_for("totally-made-up-9.9"), "unknown")
+        self.assertEqual(POLICY.ceiling_stages("unknown"), ["metadata"])
+        self.assertEqual(POLICY.tier("unknown")["allowed_recommendations"], ["skip"])
+
+    def test_every_default_is_within_allowed(self):
+        for name, t in POLICY.tiers.items():
+            self.assertIn(t["default_recommendation"], t["allowed_recommendations"], name)
+
+
+class CeilingMatchesSSOT(unittest.TestCase):
+    """H-2 + H-3: drive a real candidate through inspect and assert the fetches
+    performed match exactly the SSOT-declared ceiling for its resolved tier."""
+
+    SAMPLES = {
+        "permissive": "mit",
+        "permissive_with_obligations": "apache-2.0",
+        "weak_copyleft": "mpl-2.0",
+        "strong_copyleft": "gpl-3.0",
+    }
+
+    def _run(self, repo, spdx=None, license_status=None):
+        repos = {repo: {"spdx": spdx, "readme": "hi", "tree": ["a", "b"]}}
+        client = GitHubClient(transport=FakeTransport(
+            repos, license_status={repo: license_status} if license_status else None))
+        item = {"full_name": repo, "name": repo.split("/")[-1], "description": "x",
+                "stargazers_count": 9, "topics": []}
+        return inspect_candidate(client, POLICY, item, "x"), client
+
+    def test_each_tier_fetches_exactly_its_ceiling(self):
+        for tier, spdx in self.SAMPLES.items():
+            res, client = self._run("o/%s" % tier, spdx=spdx)
+            self.assertEqual(res["license"]["tier"], tier)
+            ssot_stages = POLICY.ceiling_stages(tier)
+            kinds = _kinds(client, "o/%s" % tier)
+            self.assertIn("license", kinds, tier)            # gate always fetched
+            self.assertEqual("readme" in kinds, "readme" in ssot_stages, tier)
+            self.assertEqual("tree" in kinds, "tree" in ssot_stages, tier)
+            # effective ceiling label == SSOT declaration
+            self.assertEqual(res["license"]["inspect_ceiling"],
+                             POLICY.tier(tier)["inspect_ceiling"], tier)
+
+    def test_strong_copyleft_never_touches_source(self):
+        res, client = self._run("o/gpl", spdx="agpl-3.0")
+        self.assertEqual(res["license"]["tier"], "strong_copyleft")
+        self.assertNotIn("readme", _kinds(client, "o/gpl"))
+        self.assertNotIn("tree", _kinds(client, "o/gpl"))
+        self.assertEqual(res["recommendation"], "skip")
+
+    def test_no_license_is_metadata_only(self):
+        res, client = self._run("o/nolic", spdx=None)         # 404
+        self.assertEqual(res["license"]["tier"], "unknown")
+        self.assertEqual(res["license"]["confidence"], "no_license")
+        self.assertEqual(_kinds(client, "o/nolic"), ["license"])
+
+    def test_license_fetch_failure_is_fail_closed(self):
+        res, client = self._run("o/boom", spdx="mit", license_status=500)
+        self.assertEqual(res["license"]["tier"], "unknown")   # MIT ignored on fetch fail
+        self.assertEqual(res["license"]["confidence"], "fetch_failed")
+        self.assertNotIn("readme", _kinds(client, "o/boom"))
+
+    def test_noassertion_is_fail_closed(self):
+        res, client = self._run("o/noa", spdx="NOASSERTION")
+        self.assertEqual(res["license"]["tier"], "unknown")
+        self.assertEqual(res["license"]["confidence"], "fetch_failed")
+
+
+class ReadOnlyAssertion(unittest.TestCase):
+    def test_no_token_is_unauthenticated(self):
+        c = GitHubClient(transport=FakeTransport({}))
+        c.assert_readonly_or_die()
+        self.assertEqual(c.auth_mode, "unauthenticated")
+
+    def test_write_scope_token_fails_closed(self):
+        c = GitHubClient(transport=FakeTransport({}, scopes="gist, read:org, repo"), token="x")
+        with self.assertRaises(ScoutFatal):
+            c.assert_readonly_or_die()
+
+    def test_read_org_scope_fails_closed(self):
+        # tightened (Phase 0.1): ANY classic scope, incl. read-only read:org, fails closed
+        c = GitHubClient(transport=FakeTransport({}, scopes="read:org"), token="x")
+        with self.assertRaises(ScoutFatal):
+            c.assert_readonly_or_die()
+
+    def test_empty_scope_finegrained_token_passes(self):
+        c = GitHubClient(transport=FakeTransport({}, scopes=""), token="x")
+        c.assert_readonly_or_die()
+        self.assertEqual(c.auth_mode, "authenticated-readonly")
+
+    def test_probe_5xx_fails_closed_and_does_not_attest_readonly(self):
+        # GHS-01: an inconclusive (non-200) probe must NOT fail open. A write-scoped
+        # token whose probe errors out must be refused, never falsely attested.
+        tx = FakeTransport({}, scopes="repo", probe_status=500)
+        c = GitHubClient(transport=tx, token="ghp_writescoped")
+        with self.assertRaises(ScoutFatal):
+            c.assert_readonly_or_die()
+        self.assertNotEqual(c.auth_mode, "authenticated-readonly")
+
+    def test_probe_401_fails_closed(self):       # GHS-02 coverage
+        c = GitHubClient(transport=FakeTransport({}, probe_status=401), token="x")
+        with self.assertRaises(ScoutFatal):
+            c.assert_readonly_or_die()
+
+    def test_probe_abuse_403_fails_closed(self):  # GHS-02 coverage (remaining != 0)
+        c = GitHubClient(transport=FakeTransport({}, probe_status=403), token="x")
+        with self.assertRaises(ScoutFatal):
+            c.assert_readonly_or_die()
+
+    def test_inconclusive_probe_does_not_attach_token_to_reads(self):
+        # GHS-01: after a fail-closed probe, no candidate read is ever issued with the token.
+        tx = FakeTransport({"o/x": {"spdx": "mit"}}, scopes="repo", probe_status=500)
+        c = GitHubClient(transport=tx, token="ghp_writescoped")
+        with self.assertRaises(ScoutFatal):
+            build_report("a cache idea here", 4, POLICY, c)
+        # only the probe was attempted; no /repos read carried the token
+        self.assertTrue(all("/repos/" not in url for url, _ in tx.requests))
+
+
+class ReportShape(unittest.TestCase):
+    def test_report_has_mandatory_governance_fields(self):
+        repos = {"o/good": {"spdx": "mit", "readme": "r", "tree": ["s"], "description": "good cache"},
+                 "o/bad": {"spdx": "gpl-3.0", "description": "thing"}}
+        client = GitHubClient(transport=FakeTransport(repos))
+        rep = build_report("a good cache idea", 8, POLICY, client)
+        self.assertIn("recall_notice", rep)
+        self.assertTrue(rep["recall_notice"])
+        self.assertIn("hard_non_goals", rep)
+        self.assertEqual(rep["auth_mode"], "unauthenticated")
+        self.assertEqual(rep["candidate_count"], 2)
+        # low_confidence present per candidate (M-4)
+        for c in rep["candidates"]:
+            self.assertIn("low_confidence", c)
+
+    def test_zero_term_query_flagged(self):
+        client = GitHubClient(transport=FakeTransport({}))
+        rep = build_report("the a of", 8, POLICY, client)   # all stopwords
+        self.assertTrue(any("weak" in n for n in rep["notices"]))
+
+
+class TracePathConfinement(unittest.TestCase):
+    """I1: --out may only write under tools/github-scout/traces/ (Blocker 1)."""
+
+    def test_bare_filename_lands_in_traces(self):
+        p = _safe_trace_path("run.json")
+        self.assertEqual(p.parent, _traces_root())
+        self.assertEqual(p.name, "run.json")
+
+    def test_traces_prefixed_filename_ok(self):
+        self.assertEqual(_safe_trace_path("traces/run.json").parent, _traces_root())
+
+    def test_subdir_under_traces_ok(self):
+        p = _safe_trace_path("sub/run.json")
+        self.assertIn(_traces_root(), p.parents)
+
+    def test_absolute_path_rejected(self):
+        with self.assertRaises(ScoutFatal):
+            _safe_trace_path("/tmp/evil.json")
+
+    def test_parent_escape_rejected(self):
+        for evil in ("../README.md", "../../etc/passwd", "traces/../../README.md", "a/../../b"):
+            with self.assertRaises(ScoutFatal, msg=evil):
+                _safe_trace_path(evil)
+
+    def test_empty_or_dir_rejected(self):
+        for bad in ("", ".", "traces/", "traces"):
+            with self.assertRaises(ScoutFatal, msg=repr(bad)):
+                _safe_trace_path(bad)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Phase 0 + 0.1 of **github-scout** — a governed, read-only, license-gated GitHub prior-art reconnaissance capability. Given an idea sentence, it searches GitHub, gates each candidate by its **authoritative** license, and emits a conservative advisory recommendation, so a new capability can be checked against existing open source *before* building, under LiYe Fork 纪律 / clean-room / harvest-ADR.

**It decides nothing.** Output is advisory; any reuse outcome goes through the harvest-ADR / Reference Declaration ceremony.

## Shape (three layers + Hands tool)

| Layer | Path | Role |
|-------|------|------|
| L1 Methodology (Brain) | `docs/methodology/01_Research_Intelligence/github-scout/` | prose + machine-readable `license_policy.yaml` SSOT |
| Hands tool | `tools/github-scout/scout.py` | CLI (`report` only); **consumes** the SSOT at runtime; sits OUTSIDE the frozen Skill three-layer spine (BGHS-Hands infra) |
| L3 Instruction | `.claude/skills/github-scout.md` | flat, manual-load; references L1 |

Authorized blocking-first by `_meta/adr/ADR-GitHub-Prior-Art-Scout.md`.

## Safety invariants (enforced + tested)

- **I1** zero external mutating side-effect — no fork/clone/vendor/PR/network write; only local **gitignored** `traces/`, and `--out` is confined to `traces/` (absolute / `..` rejected, validated before any network call).
- **I2** read-only by construction — no `Authorization` header by default; a token is attached only if it asserts as **NO-SCOPE** via `X-OAuth-Scopes`; any classic scope (incl. `read:org`) **or** a non-200/inconclusive auth probe ⇒ **fail-closed**. No live write probe.
- **I3** sequential, license-first inspect — `404 ⇒ no_license`, other fetch failure ⇒ `fetch_failed`, either unresolved ⇒ `tier = unknown ⇒ metadata only`. README/tree fetched only if the tier ceiling permits.

## Phase 0.1 review folds

Operator review (2 blockers + 2 mids) and an adversarial red-team:

- **Blocker 1** — `--out` path-escape closed (`_safe_trace_path`, live-verified a sentinel escape is rejected).
- **Blocker 2** — reproducibility: stdlib-only + Python 3.9 compat (lazy `pyyaml` import, `from __future__ import annotations`).
- **Mid 3** — scope width tightened to NO-SCOPE.
- **Mid 4** — `404 ⇒ no_license` reconciled across code / ADR / `license_policy.yaml` / L1 prose.
- **GHS-01 (red-team must-fix)** — the scope gate was **fail-OPEN** on a non-200 auth probe (5xx / abuse-403 accepted ⇒ a write-scoped token could be falsely attested read-only **and still attached**). Now fails closed; 4 targeted tests added. Logged in `evolution_log.md` as an impl-vs-I2 bug fix (not an invariant change).

## Verification

- **23** offline tests pass on Python **3.9.6** and **3.13** *with PyYAML installed* (the suite loads the L1 SSOT, so without pyyaml it errors at import — an environment gap, not a logic failure). Run: `python3 tools/github-scout/test_scout.py`.
- `validate-contracts` **unchanged — Passed: 21** (no schema added).
- Tests load the live `license_policy.yaml`, so scout.py↔SSOT **drift fails the suite** (H-2), and assert at the network-call layer that RED/unknown repos get **zero** README/tree fetches (H-3).

## Deliberately NOT in scope (deferred to Phase 1)

MCP · JSON schema · L2 runtime skill · auto-fork/clone · `ghbudget` · transitive license scan · `emit-reference`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
