### PR TITLE
docs(evo-d): ADR D-11 checkpoint 收口 — 勾 EVO-D PR merged + 回填 anchor

### DIFF
--- a/_meta/adr/ADR-Learning-Stack-Generations.md
+++ b/_meta/adr/ADR-Learning-Stack-Generations.md
@@ -151,7 +151,7 @@ Layer 0（liye_os 内部）；不触 loamwise / domain engines / 产品线。eng
 - [x] `validate_adr_bghs.mjs` 通过
 - [ ] Operator Accept + 双 cooling（Accept ✓ **2026-06-12** + draft cooling ✓；**post-Accept cooling 起算中** = Accept commit 实际时间 +24h，最早 2026-06-13 同北京时间后才考虑 merge #165 + 回填 anchor）
 - [x] EVO-C PR merged（R-2 + R-3a 全项落地，Hard Gates 1-4 实证）— #169 squash `ff271ec`（2026-06-14）
-- [ ] EVO-D PR merged（R-4：drift_monitor 物理拆分，D-11 授权，HG1-4 实证）— *本 PR 合并后由 operator 勾选*
+- [x] EVO-D PR merged（R-4：drift_monitor 物理拆分，D-11 授权，HG1-4 实证）— #179 squash `0f4d1e7`（2026-06-27）
 - [ ] R-3b 移交 GHL 2b/2c ceremony
 
 ## Appendix A: Audit Chain


### PR DESCRIPTION
## What

EVO-D IMPL（PR #179）已 squash-merge 进 `main`（`0f4d1e7`，2026-06-27）。按 ADR-008 **§D-11 增补**里「*本 PR 合并后由 operator 勾选*」的指示，做 **R-4 治理证据链的最后收口**：翻 Adoption Checkpoint `- [ ] EVO-D PR merged` → `[x]`，回填 `#179 squash 0f4d1e7（2026-06-27）`。

镜像同段 EVO-C 行（`#169 squash ff271ec`）的 anchor 回填惯例——指针锚到 squash SHA 而非 merge-commit/branch。

## Changes (1 file, 1+/1−)

| File | Change |
|---|---|
| `_meta/adr/ADR-Learning-Stack-Generations.md` | Adoption Checkpoints **单行**（L154）：`[ ]`→`[x]` + 回填 `#179 squash 0f4d1e7（2026-06-27）` |

## 范围 / 安全

- **0 代码 / 0 schema / 0 `.github/workflows/` 触碰** → 不触发 `@liyecom/governance-team` CODEOWNERS 门（与 #178/#179 不同，这是纯 docs follow-up）。
- `validate_adr_bghs.mjs` **14/14 valid**。
- Decision Log D-01..D-11 字节不变；仅动 Adoption Checkpoints 勾选位（live 段，承 D-10/D-11 就地纠正先例）。
- diff 精确一行（`git diff --stat` = `1 file changed, 1 insertion(+), 1 deletion(-)`）。

收口后 R-4（drift_monitor 物理拆分）整条证据链闭合。我不自合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)