### PR TITLE
refactor(simplify-④): §7 helper merges — jaccardSimilarity + build_args_schema（DROP 候选3）

### DIFF
--- a/src/control/registry.ts
+++ b/src/control/registry.ts
@@ -15,6 +15,7 @@ import {
   ICapabilityRegistry,
 } from './types';
 import { scanAgentYAMLs } from './extractor';
+import { jaccardSimilarity } from './similarity';
 
 const DEFAULT_TRUST: TrustProfile = {
   overall_score: 0.5,
@@ -23,17 +24,6 @@ const DEFAULT_TRUST: TrustProfile = {
   total_executions: 0,
   last_updated: new Date().toISOString(),
 };
-
-/**
- * Compute Jaccard similarity between two tag sets
- */
-function jaccardSimilarity(a: string[], b: string[]): number {
-  const setA = new Set(a);
-  const setB = new Set(b);
-  const intersection = [...setA].filter(x => setB.has(x));
-  const union = new Set([...setA, ...setB]);
-  return union.size === 0 ? 0 : intersection.length / union.size;
-}
 
 export class CapabilityRegistry implements ICapabilityRegistry {
   private agents: Map<string, AgentCard> = new Map();

--- a/src/control/similarity.ts
+++ b/src/control/similarity.ts
@@ -1,0 +1,19 @@
+/**
+ * Tag-set similarity helpers
+ * Location: src/control/similarity.ts
+ *
+ * Shared Jaccard similarity over capability tag sets. Extracted from the
+ * byte-identical local copies in control/registry.ts and
+ * runtime/orchestrator/router.ts (cut ④ §7 helper merge — DRY, behavior-preserving).
+ */
+
+/**
+ * Compute Jaccard similarity between two tag sets
+ */
+export function jaccardSimilarity(a: string[], b: string[]): number {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  const intersection = [...setA].filter(x => setB.has(x));
+  const union = new Set([...setA, ...setB]);
+  return union.size === 0 ? 0 : intersection.length / union.size;
+}

--- a/src/runtime/mcp/adapters/crewai_adapter.py
+++ b/src/runtime/mcp/adapters/crewai_adapter.py
@@ -207,6 +207,59 @@ class MCPToolWrapper:
         return "\n".join(lines)
 
 
+def build_args_schema(input_schema: Optional[Dict[str, Any]], schema_name: str) -> Any:
+    """
+    Build a dynamic Pydantic args_schema model from an MCP tool's JSON input_schema.
+
+    Returns a pydantic BaseModel subclass, or None when the schema has no
+    properties / yields no fields. Shared by create_crewai_tool and
+    create_governed_crewai_tool to avoid field-mapping drift (cut ④ §7 helper merge,
+    DRY, behavior-preserving). Pydantic is imported lazily so importing this module
+    stays dependency-light (caller's CrewAI/pydantic import guard runs first).
+
+    JSON-schema -> Python type mapping, required-vs-optional handling, and the
+    Field(default=..., description=...) construction are byte-for-byte the logic
+    formerly inlined in both call sites.
+    """
+    if not (input_schema and input_schema.get('properties')):
+        return None
+
+    from typing import Optional as _Optional
+    from pydantic import Field, create_model
+
+    fields: Dict[str, Any] = {}
+    properties = input_schema.get('properties', {})
+    required = input_schema.get('required', [])
+
+    type_mapping = {
+        'string': str,
+        'integer': int,
+        'number': float,
+        'boolean': bool,
+        'array': list,
+        'object': dict,
+    }
+
+    for prop_name, prop_def in properties.items():
+        prop_type = prop_def.get('type', 'string')
+        prop_desc = prop_def.get('description', '')
+        prop_default = prop_def.get('default')
+        python_type = type_mapping.get(prop_type, str)
+
+        if prop_name in required:
+            if prop_default is not None:
+                fields[prop_name] = (python_type, Field(default=prop_default, description=prop_desc))
+            else:
+                fields[prop_name] = (python_type, Field(..., description=prop_desc))
+        else:
+            fields[prop_name] = (_Optional[python_type], Field(default=prop_default, description=prop_desc))
+
+    if not fields:
+        return None
+
+    return create_model(schema_name, **fields)
+
+
 def create_crewai_tool(wrapper: MCPToolWrapper) -> Any:
     """
     Create a CrewAI BaseTool from an MCPToolWrapper.
@@ -224,44 +277,11 @@ def create_crewai_tool(wrapper: MCPToolWrapper) -> Any:
     # Capture wrapper in closure to avoid serialization issues
     captured_wrapper = wrapper
 
-    # Create args_schema from MCP tool's input_schema
-    args_schema_class: Optional[Type[BaseModel]] = None
-    input_schema = wrapper._tool.input_schema
-    if input_schema and input_schema.get('properties'):
-        # Build Pydantic model fields from JSON schema
-        fields = {}
-        properties = input_schema.get('properties', {})
-        required = input_schema.get('required', [])
-
-        for prop_name, prop_def in properties.items():
-            prop_type = prop_def.get('type', 'string')
-            prop_desc = prop_def.get('description', '')
-            prop_default = prop_def.get('default')
-
-            # Map JSON schema types to Python types
-            type_mapping = {
-                'string': str,
-                'integer': int,
-                'number': float,
-                'boolean': bool,
-                'array': list,
-                'object': dict,
-            }
-            python_type = type_mapping.get(prop_type, str)
-
-            # Required fields vs optional fields
-            if prop_name in required:
-                if prop_default is not None:
-                    fields[prop_name] = (python_type, Field(default=prop_default, description=prop_desc))
-                else:
-                    fields[prop_name] = (python_type, Field(..., description=prop_desc))
-            else:
-                fields[prop_name] = (Optional[python_type], Field(default=prop_default, description=prop_desc))
-
-        if fields:
-            # Create dynamic Pydantic model for args_schema
-            schema_name = f"{wrapper.name.replace('-', '_').replace('.', '_')}Schema"
-            args_schema_class = create_model(schema_name, **fields)
+    # Create args_schema from MCP tool's input_schema (shared builder — cut ④ §7 DRY)
+    args_schema_class: Optional[Type[BaseModel]] = build_args_schema(
+        wrapper._tool.input_schema,
+        f"{wrapper.name.replace('-', '_').replace('.', '_')}Schema",
+    )
 
     # Create a dynamic tool class
     # Pass name and description through __init__ instead of class attributes

--- a/src/runtime/mcp/adapters/governed_tool_provider.py
+++ b/src/runtime/mcp/adapters/governed_tool_provider.py
@@ -19,7 +19,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from .crewai_adapter import MCPToolProvider, MCPToolWrapper, create_crewai_tool, _run_async
+from .crewai_adapter import MCPToolProvider, MCPToolWrapper, create_crewai_tool, _run_async, build_args_schema
 
 logger = logging.getLogger(__name__)
 
@@ -268,36 +268,11 @@ def create_governed_crewai_tool(wrapper: GovernedToolWrapper) -> Any:
 
     captured_wrapper = wrapper
 
-    # Build args_schema from input_schema (same as crewai_adapter)
-    args_schema_class = None
-    input_schema = wrapper._tool.input_schema
-    if input_schema and input_schema.get('properties'):
-        fields = {}
-        properties = input_schema.get('properties', {})
-        required = input_schema.get('required', [])
-
-        type_mapping = {
-            'string': str, 'integer': int, 'number': float,
-            'boolean': bool, 'array': list, 'object': dict,
-        }
-
-        for prop_name, prop_def in properties.items():
-            prop_type = prop_def.get('type', 'string')
-            prop_desc = prop_def.get('description', '')
-            prop_default = prop_def.get('default')
-            python_type = type_mapping.get(prop_type, str)
-
-            if prop_name in required:
-                if prop_default is not None:
-                    fields[prop_name] = (python_type, Field(default=prop_default, description=prop_desc))
-                else:
-                    fields[prop_name] = (python_type, Field(..., description=prop_desc))
-            else:
-                fields[prop_name] = (Optional[python_type], Field(default=prop_default, description=prop_desc))
-
-        if fields:
-            schema_name = f"{wrapper.name.replace('-', '_').replace('.', '_')}GovernedSchema"
-            args_schema_class = create_model(schema_name, **fields)
+    # Build args_schema from input_schema (shared builder — cut ④ §7 DRY; same as crewai_adapter)
+    args_schema_class = build_args_schema(
+        wrapper._tool.input_schema,
+        f"{wrapper.name.replace('-', '_').replace('.', '_')}GovernedSchema",
+    )
 
     tool_name = captured_wrapper.name
     tool_desc = f"[Governed] {captured_wrapper.description}"

--- a/src/runtime/mcp/tests/test_build_args_schema.py
+++ b/src/runtime/mcp/tests/test_build_args_schema.py
@@ -1,0 +1,119 @@
+"""Regression test for the shared build_args_schema helper (cut ④ §7 helper merge).
+
+Proves the extracted shared builder reproduces — byte-for-byte in behavior — the
+field-mapping logic formerly inlined in crewai_adapter.create_crewai_tool and
+governed_tool_provider.create_governed_crewai_tool. The reference `_oracle` below is
+a verbatim transcription of that old inlined logic; the test asserts the live helper
+produces structurally identical pydantic models across every schema branch.
+
+Runnable (matches this dir's existing non-pytest convention), pydantic required:
+    python3 src/runtime/mcp/tests/test_build_args_schema.py
+Not CI-wired (repo has no python test harness for src/runtime/mcp/**); local evidence.
+"""
+import os
+import sys
+
+# Self-contained: put repo root on sys.path so `src...` imports resolve when run directly.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+from src.runtime.mcp.adapters.crewai_adapter import build_args_schema
+from src.runtime.mcp.adapters import governed_tool_provider as _gtp
+
+# Both adapters must import cleanly (no crewai required at module load) and share the symbol.
+assert _gtp.build_args_schema is build_args_schema, "governed_tool_provider must re-import the shared helper"
+
+
+def _oracle(input_schema, schema_name):
+    """Verbatim transcription of the OLD inlined field-builder (both former call sites)."""
+    from typing import Optional
+    from pydantic import Field, create_model
+    args_schema_class = None
+    if input_schema and input_schema.get('properties'):
+        fields = {}
+        properties = input_schema.get('properties', {})
+        required = input_schema.get('required', [])
+        for prop_name, prop_def in properties.items():
+            prop_type = prop_def.get('type', 'string')
+            prop_desc = prop_def.get('description', '')
+            prop_default = prop_def.get('default')
+            type_mapping = {
+                'string': str, 'integer': int, 'number': float,
+                'boolean': bool, 'array': list, 'object': dict,
+            }
+            python_type = type_mapping.get(prop_type, str)
+            if prop_name in required:
+                if prop_default is not None:
+                    fields[prop_name] = (python_type, Field(default=prop_default, description=prop_desc))
+                else:
+                    fields[prop_name] = (python_type, Field(..., description=prop_desc))
+            else:
+                fields[prop_name] = (Optional[python_type], Field(default=prop_default, description=prop_desc))
+        if fields:
+            args_schema_class = create_model(schema_name, **fields)
+    return args_schema_class
+
+
+def _fingerprint(model):
+    if model is None:
+        return None
+    out = {'__name__': model.__name__, 'fields': {}}
+    for name, fi in model.model_fields.items():
+        out['fields'][name] = (str(fi.annotation), fi.is_required(), repr(fi.default), fi.description)
+    return out
+
+
+SCHEMAS = [
+    ("none", None),
+    ("empty_dict", {}),
+    ("no_properties", {"required": ["x"]}),
+    ("empty_properties", {"properties": {}}),
+    ("req_no_default", {"properties": {"q": {"type": "string", "description": "the query"}}, "required": ["q"]}),
+    ("req_with_default", {"properties": {"n": {"type": "integer", "description": "count", "default": 5}}, "required": ["n"]}),
+    ("optional_no_default", {"properties": {"flag": {"type": "boolean", "description": "f"}}}),
+    ("optional_with_default", {"properties": {"flag": {"type": "boolean", "default": False}}}),
+    ("unknown_type_fallback", {"properties": {"weird": {"type": "uuid"}}, "required": ["weird"]}),
+    ("no_type_key", {"properties": {"bare": {"description": "no type -> string"}}, "required": ["bare"]}),
+    ("all_types", {"properties": {
+        "s": {"type": "string"}, "i": {"type": "integer"}, "f": {"type": "number"},
+        "b": {"type": "boolean"}, "a": {"type": "array"}, "o": {"type": "object"},
+    }, "required": ["s", "i", "f"]}),
+    ("mixed", {"properties": {
+        "rq": {"type": "string", "description": "req"},
+        "rd": {"type": "number", "default": 1.5, "description": "req+default"},
+        "op": {"type": "array", "description": "opt"},
+    }, "required": ["rq", "rd"]}),
+]
+
+
+def main():
+    failures = 0
+    for label, schema in SCHEMAS:
+        new_fp = _fingerprint(build_args_schema(schema, f"X_{label}Schema"))
+        old_fp = _fingerprint(_oracle(schema, f"X_{label}Schema"))
+        ok = new_fp == old_fp
+        print(f"  {'PASS' if ok else 'FAIL'} {label:24s} {'(None)' if new_fp is None else str(len(new_fp['fields'])) + ' fields'}")
+        if not ok:
+            failures += 1
+            print(f"      NEW: {new_fp}")
+            print(f"      OLD: {old_fp}")
+
+    one_field = {"properties": {"q": {"type": "string"}}, "required": ["q"]}
+    m1 = build_args_schema(one_field, "foo_barSchema")
+    m2 = build_args_schema(one_field, "foo_barGovernedSchema")
+    suffix_ok = m1.__name__ == "foo_barSchema" and m2.__name__ == "foo_barGovernedSchema"
+    print(f"  {'PASS' if suffix_ok else 'FAIL'} schema_name suffix carried (Schema / GovernedSchema)")
+    if not suffix_ok:
+        failures += 1
+
+    print()
+    if failures:
+        print(f"FAILED: {failures} mismatch(es) — build_args_schema diverged from old inline logic")
+        return 1
+    print(f"OK: {len(SCHEMAS)} schemas + suffix — build_args_schema == verbatim-old-inline")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/runtime/orchestrator/router.ts
+++ b/src/runtime/orchestrator/router.ts
@@ -12,19 +12,9 @@ import type {
   AgentCapabilityCandidate,
 } from '../../control/types';
 import { PlanTask, ResolvedTask } from './types';
+import { jaccardSimilarity } from '../../control/similarity';
 
 const MAX_ALTERNATIVES = 3;
-
-/**
- * Compute Jaccard similarity between two tag sets
- */
-function jaccard(a: string[], b: string[]): number {
-  const setA = new Set(a);
-  const setB = new Set(b);
-  const intersection = [...setA].filter(x => setB.has(x));
-  const union = new Set([...setA, ...setB]);
-  return union.size === 0 ? 0 : intersection.length / union.size;
-}
 
 export class CapabilityRouter {
   private registry: ICapabilityRegistry;
@@ -112,10 +102,10 @@ export class CapabilityRouter {
    */
   private score3Factor(task: PlanTask, candidate: AgentCapabilityCandidate): number {
     // Factor 1: Tag overlap (Jaccard similarity)
-    const tagOverlap = jaccard(task.capability.tags, candidate.source_contract.tags);
+    const tagOverlap = jaccardSimilarity(task.capability.tags, candidate.source_contract.tags);
 
     // Factor 2: Trust score (overall, for ranking)
-    const trustScore = candidate.trust.overall_score;
+    const overallTrustScore = candidate.trust.overall_score;
 
     // Factor 3: Domain affinity
     let domainAffinity = 0.3; // default: no domain specified
@@ -125,7 +115,7 @@ export class CapabilityRouter {
         : 0.5;  // cross-domain
     }
 
-    return tagOverlap * 0.5 + trustScore * 0.3 + domainAffinity * 0.2;
+    return tagOverlap * 0.5 + overallTrustScore * 0.3 + domainAffinity * 0.2;
   }
 
   /**


### PR DESCRIPTION
## What

精简 **④（§7 helper merges）** —— 简化校准报告 §7 MERGE 分组的「3 个 cheap helper 合并」。纯 DRY 重构，**零删源 / 零治理含义 / 无 ADR**。recon 后实际落地 **2 做 / 1 DROP**：

| 候选 | 判定 | 依据 |
|---|---|---|
| **1. jaccard** | ✅ 做（commit 1） | 真克隆（函数体逐字节同，仅名 `jaccard` vs `jaccardSimilarity`）；两消费者 CI-gated；非 frozen |
| **2. pydantic field-builder** | ✅ 做（commit 2） | 真克隆（唯一差异=schema_name 后缀）；非 frozen；governed 已 import crewai_adapter，顺依赖方向 |
| **3. policy index 两函数** | ❌ **DROP** | (a) **非重复**：`buildPolicyTraceIndex`(trace_id→Set<policy_id>) vs `buildPolicyFileIndex`(policy_id→{absPath,status}) 语义/输出/消费者皆不同，代码注释自证 distinct；(b) 在 `src/reasoning/` = EVO HG2 **frozen 目录**（evaluator blob `3f9ad911` 是七锚之一），碰它违背整个 simplification 守的 0-diff 不变量 |

## Commits（2 原子，6 文件）

**commit 1 — `jaccardSimilarity` → `src/control/similarity.ts`**
- NEW `src/control/similarity.ts`（函数体逐字节同源）；`registry.ts`/`router.ts` 删本地 def + import 共享；依赖方向 control←runtime 保持
- ⚠ **incidental（Hard-Gate-1 强制）**：`router.ts` 局部变量 `trustScore`→`overallTrustScore`。该变量是**预存代码**（main 上就有），forbidden-name lint（EV2-B-01，扫 staged blob）在我因 jaccard 改动 stage `router.ts` 时命中其 `const trustScore` 声明（Pattern A `[Tt]rust*`），`--no-verify` 不可用（Hard Gate）。最小修：仅重命名局部变量（2 处），**保留** `candidate.trust.overall_score` 属性访问（真 TrustProfile 字段）。行为不变。

**commit 2 — `build_args_schema` → `crewai_adapter`**
- NEW module-level `build_args_schema(input_schema, schema_name)`（lazy-import pydantic 保持 import-light）；`create_crewai_tool` / `create_governed_crewai_tool` 内联块各替换为 helper 调用，参数化 schema_name 后缀
- NEW `src/runtime/mcp/tests/test_build_args_schema.py`（可重跑回归测试，匹配该目录既有 `test_mcp_basic.py` 非-pytest runnable 惯例）

## 等价证据（先补/证再交）

- **候选1**：受影响 vitest **127/127 绿**（改前=改后）；全量 vitest **477 passed**（13 failed files 全是 `examples/wecom/node_modules/**` 第三方包，CI 上 `npm ci` 不装嵌套 node_modules → 不收集，纯本地噪声、非我引入）；full-project `tsc --noEmit` 我的文件 0 报错；无悬空 `jaccard` 引用
- **候选2**：**12 个覆盖全分支的 schema + suffix**，`build_args_schema` 结果模型 == 逐字节照搬旧内联逻辑的 oracle（model_fields 名/类型/required/default/description 全等）；两 adapter 模块 import 干净（无 crewai 也可加载）
- forbidden-name lint 全程 pass；7 GHL frozen 锚 0 路径交集（候选3 DROP 即为守此）

## 范围 / 注意

- **0 `.github/workflows/` 触碰** → 无 `@liyecom/governance-team` CODEOWNERS 门，仅通用 REVIEW_REQUIRED。
- 候选2 的 crewai/pydantic 是 optional-dep（本机 crewai 未装、pydantic 2.12 已装），字段构建路径无 crewai 时休眠；repo 无 py 测试 CI harness，故候选2 等价测试为**本地证据（非 CI-gated）**。
- 两 commit 独立：若你要保守版，**drop commit 2（候选2）trivial**。
- 我不自合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)