### PR TITLE
chore(skill-factory): retire skill-forge .codex install (PR1b)

### DIFF
--- a/_meta/skill-factory/retired-skills/skill-forge.yaml
+++ b/_meta/skill-factory/retired-skills/skill-forge.yaml
@@ -1,6 +1,7 @@
 # Retired external skill — provenance record (do NOT vendor the third-party source into this repo).
-# This file is the only in-repo artifact of skill-forge after retirement; the source clone is
-# archived on the local machine OUTSIDE the repo (see archive.path below).
+# This file is the only in-repo artifact of skill-forge after retirement. skill-forge was installed
+# in TWO locations (.claude and .codex); BOTH are now removed and archived on the local machine
+# OUTSIDE the repo (see retired_locations[].archive below).
 schema: "liye-os/retired-external-skill@1"
 
 id: "skill-forge"
@@ -18,19 +19,40 @@ replaced_by:
 
 upstream:
   url: "https://github.com/WilliamSaysX/skill-forge"
-  commit: "43a27b2c6b36e4e1c4207f1ae7edfcbfa8de4f40"
+  commit: "43a27b2c6b36e4e1c4207f1ae7edfcbfa8de4f40"   # both installs share this upstream commit
   describe: "v1.0.0-13-g43a27b2"
 
-# Local, repo-EXTERNAL archive (full clone incl. .git, kept as reference implementation only).
-archive:
-  path: "~/skill-archives/skill-forge-43a27b2-20260627.tar.gz"
-  sha256: "15ccd66f1631c5d6aa6294b3636feedca2c3269820f6dfa636bdcfafbf76731a"
-  contains_git: true
-  note: "Reference implementation only — never a runtime dependency, never re-vendored into liye_os."
+# skill-forge was installed in TWO places; both removed. Each archived repo-EXTERNAL (full clone
+# incl. .git), kept as reference implementation only — never a runtime dependency, never
+# re-vendored into liye_os.
+retired_locations:
+  - install_path: "~/.claude/skills/skill-forge"
+    removed_in: "PR1 (#182, 432c198)"
+    working_tree: "clean (pristine upstream checkout)"
+    skill_md_sha256: "de0f124a76a0a994f10c26edaf60693006b1abf1494e4a223231886bf0fc0d39"
+    archive:
+      path: "~/skill-archives/skill-forge-43a27b2-20260627.tar.gz"
+      sha256: "15ccd66f1631c5d6aa6294b3636feedca2c3269820f6dfa636bdcfafbf76731a"
+      contains_git: true
+    prior_pin:
+      external_skills_lock_json: "_meta/skill-factory/external-skills.lock.json (item removed; total_locked 2 -> 1)"
+      external_skills_lock_yaml: "_meta/skill-factory/EXTERNAL_SKILLS_LOCK.yaml (entry removed; external_skills now [])"
+      last_audit: "2026-01-16"
 
-# What it was pinned as before retirement (from the now-removed lock entries).
-prior_pin:
-  external_skills_lock_json: "_meta/skill-factory/external-skills.lock.json (item removed; total_locked 2 -> 1)"
-  external_skills_lock_yaml: "_meta/skill-factory/EXTERNAL_SKILLS_LOCK.yaml (entry removed; external_skills now [])"
-  prior_skill_md_sha256: "de0f124a76a0a994f10c26edaf60693006b1abf1494e4a223231886bf0fc0d39"
-  last_audit: "2026-01-16"
+  - install_path: "~/.codex/skills/skill-forge"
+    removed_in: "PR1b (this change)"
+    working_tree: >
+      DIRTY — 8 tracked files modified (incl. SKILL.md, scripts/fetch_source.py, references/*) plus
+      1 untracked references/GOVERNANCE_POINTERS.md. These were local governance-integration edits
+      (pointers to _meta/governance/SKILL_CONSTITUTION_v0.1.md + _meta/policies/DEFAULT_SKILL_POLICY.md),
+      preserved verbatim in the archive as the conceptual seed for tools/source-intake/.
+    skill_md_sha256: "044cca3f8c14b7dadc41b53584159312ee6046a624defa3c0abfd181403fcb47"
+    archive:
+      path: "~/skill-archives/skill-forge-codex-43a27b2-dirty-20260627.tar.gz"
+      sha256: "d0137e80a5a338780cf0196d74f1c1dff84f9ee409f7f4ad2fb83a2e177e7ca0"
+      contains_git: true
+      preserves_dirty_tree: true
+    prior_pin:
+      note: >
+        NOT tracked in external-skills.lock (Codex-side install; the lock only ever covered the
+        .claude install). This is why PR1 missed it — surfaced by the #183 review.


### PR DESCRIPTION
## PR1b — 退役 skill-forge 的 .codex 安装（PR1 漏网）

PR1（#182）只删了 `~/.claude/skills/skill-forge`。**#183 复审发现第二处活跃安装** `~/.codex/skills/skill-forge`（Codex 侧），同 upstream commit `43a27b2`，但**工作树 dirty**：

- 8 个 tracked 文件改动（含 `SKILL.md`、`scripts/fetch_source.py`、`references/*`）+ 1 个 untracked `references/GOVERNANCE_POINTERS.md`
- `SKILL.md` sha256 `044cca3f...` ≠ `.claude` 版的 `de0f124a...`
- **从未进 `external-skills.lock`**（lock 只覆盖 `.claude` 那份）→ 这正是 PR1 漏掉它的原因

### 本 PR 做了什么
1. **归档 dirty clone 到 repo 外**（全树含 .git + 工作改动 + untracked，保留本地治理集成改动作为 `tools/source-intake/` 的概念种子）：
   - `~/skill-archives/skill-forge-codex-43a27b2-dirty-20260627.tar.gz`
   - sha256 `d0137e80a5a338780cf0196d74f1c1dff84f9ee409f7f4ad2fb83a2e177e7ca0`
   - 删除前已验证：可解压 + SKILL.md hash 精确匹配 + dirty 态完整（git status 9 项）
2. **删除活跃目录** `~/.codex/skills/skill-forge`（兄弟目录完好，单一显式路径 rm）
3. **重构 retired manifest 为 `retired_locations[]`**，诚实记录两处安装（.claude clean / .codex dirty）各自的 SKILL.md hash + 归档。

### 边界 / 验证
- **in-repo 改动 = 仅 manifest**（`_meta/skill-factory/retired-skills/skill-forge.yaml`），**无第三方源码 vendor**
- YAML parse 通过（2 retired_locations）
- pre-commit 全门过
- 两份 skill-forge 安装现已全清，**技术退役完成**

> 关联：#182（PR1 retire）/ #183（source-intake SPEC v1.1）。本 PR 独立于 #183，不阻塞、不混合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
