### PR TITLE
fix(source-intake): transport-level failures → fail-closed IntakeFatal (#187)

### DIFF
--- a/tools/source-intake/source_intake.py
+++ b/tools/source-intake/source_intake.py
@@ -213,7 +213,15 @@ class GitHubReadOnlyClient:
             headers["X-GitHub-Api-Version"] = "2022-11-28"
         if self.token:                       # I2: header attached only when token present
             headers["Authorization"] = "Bearer " + self.token   # mirrors scout.py read-only auth
-        status, hdrs, body = self.transport.get(full, headers)
+        try:
+            status, hdrs, body = self.transport.get(full, headers)
+        except IntakeFatal:
+            raise
+        except (urllib.error.URLError, OSError) as e:
+            raise IntakeFatal(
+                "GitHub transport failure for %s: %s: %s. Network/TLS transport "
+                "condition, not a code error; fail-closed." % (full, type(e).__name__, e)
+            ) from e
         self.call_log.append({"kind": kind, "url": full, "status": status})
         if status == 403 and hdrs.get("x-ratelimit-remaining") == "0":
             raise IntakeFatal("GitHub rate limit exhausted (read budget). Stop; retry later "

--- a/tools/source-intake/test_source_intake.py
+++ b/tools/source-intake/test_source_intake.py
@@ -14,6 +14,7 @@ import io
 import json
 import tarfile
 import unittest
+import urllib.error
 from pathlib import Path
 
 import source_intake
@@ -408,6 +409,49 @@ class N10UnstableTarball(unittest.TestCase):
         tx = FakeTransport(unstable_tarball=True)
         with self.assertRaises(IntakeFatal):
             _intake(tx, make_request())
+
+
+# --------------------------------------------------------------------------- #
+# Transport failures - network/TLS faults must convert to IntakeFatal
+# --------------------------------------------------------------------------- #
+class RaisingTransport:
+    def __init__(self, error):
+        self.error = error
+
+    def get(self, url, headers):
+        raise self.error
+
+
+class RecordingSink:
+    def __init__(self):
+        self.calls = []
+
+    def write(self, path, body):
+        self.calls.append((path, body))
+
+
+class TransportFailClosed(unittest.TestCase):
+    def test_urlerror_transport_failure_fails_closed_without_staging_write(self):
+        sink = RecordingSink()
+        client = GitHubReadOnlyClient(
+            transport=RaisingTransport(urllib.error.URLError("simulated handshake timeout")),
+            token=None,
+        )
+        with self.assertRaises(IntakeFatal):
+            run_intake(make_request(), client, POLICY, staging_root=EXTERNAL_STAGING,
+                       sink=sink, now_utc="2026-06-27T12:00:05Z")
+        self.assertEqual(sink.calls, [])
+
+    def test_timeout_transport_failure_fails_closed_without_staging_write(self):
+        sink = RecordingSink()
+        client = GitHubReadOnlyClient(
+            transport=RaisingTransport(TimeoutError("simulated timeout")),
+            token=None,
+        )
+        with self.assertRaises(IntakeFatal):
+            run_intake(make_request(), client, POLICY, staging_root=EXTERNAL_STAGING,
+                       sink=sink, now_utc="2026-06-27T12:00:05Z")
+        self.assertEqual(sink.calls, [])
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #187.

## What
Convert **transport-level** network failures in `source-intake` into the project's fail-closed contract (`IntakeFatal` → `FAIL-CLOSED:` on stderr → **exit 2**), instead of a raw Python traceback with exit 1.

## Mechanism
`GitHubReadOnlyClient._get` is the single chokepoint through which every injected transport flows, but only HTTP-*status* errors were handled (`HttpTransport.get` catches `HTTPError` and returns the status for 403/404 branching). A bare `urllib.error.URLError` / `socket.timeout` / `ssl.SSLError` / `OSError` (e.g. a TLS handshake timeout) was **uncaught** — it unwound through `run_intake` → `cmd_intake`, bypassing `main()`'s `except IntakeFatal`, producing a traceback + exit 1.

This was observed in production during the first real reference-pack pilot: the N10 re-download hit `urllib.error.URLError: <urlopen error _ssl.c:1011: The handshake operation timed out>` → traceback, exit 1.

## Fix (surgical — ~8 lines, one location)
Wrap **only** the `self.transport.get(...)` call in `_get` with:
- `except IntakeFatal: raise` (re-raise unchanged — no double-wrap)
- `except (urllib.error.URLError, OSError)` → `raise IntakeFatal(...)` with a clear "network/TLS transport condition, not a code error; fail-closed" message naming the URL + underlying exception.

`(urllib.error.URLError, OSError)` covers `URLError`, `socket.timeout`/`TimeoutError`, `ssl.SSLError`, and connection `OSError`s. `HTTPError` continues to be handled by `HttpTransport.get` as a status return — **403 / 404 / rate-limit / no_license / fetch_failed paths are unchanged**. No new imports.

## Tests
New `TransportFailClosed` class in `test_source_intake.py`:
- transport raising `urllib.error.URLError` → asserts `IntakeFatal` **and** the recording `StagingSink` was never called (no staging write);
- transport raising `TimeoutError` (an `OSError` subclass) → same.

`python3 tools/source-intake/test_source_intake.py` → **42 passed** (40 pre-existing + 2 new).

## Adversarial review (independent of the implementer)
Beyond the unit suite, an independent CLI-boundary fault injection (monkeypatching the default `HttpTransport.get` and calling `main(["intake", …])`) confirmed, for **both** `URLError` and `TimeoutError`:

| acceptance criterion | result |
|---|---|
| CLI exit code | **2** |
| no exception escapes `main()` | ✅ |
| stderr begins `FAIL-CLOSED:` | ✅ |
| **no** Python `Traceback` | ✅ |
| no manifest written (`--out`) | ✅ |
| no staging write | ✅ (unit: `sink.calls == []`) |

i.e. the exact production repro (URLError → traceback → exit 1) now yields FAIL-CLOSED → exit 2.

## Scope / hygiene
- Touches **only** `tools/source-intake/source_intake.py` (+9/−1) and `tools/source-intake/test_source_intake.py` (+44).
- 0-diff on `github-scout` (`scout.py` / `license_policy.yaml`) and `sfc_ci_gate.mjs`.
- Pre-commit hooks ran and passed (forbidden-name lint, env-hygiene, blocklist, guardrail) — **not** bypassed.
- Branch cut from `main` after #186 (SPEC v1.2) landed. Sibling design issue #188 (audit-taxonomy) is **not** in this PR.

> Not merged by me — awaiting your review/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
