### PR TITLE
feat(band-b): manifest-reality clock continuity detection — surface gaps/resets, never backfill (#191)

### DIFF
--- a/.github/workflows/manifest-reality-clock-tests.yml
+++ b/.github/workflows/manifest-reality-clock-tests.yml
@@ -1,0 +1,38 @@
+# Manifest Reality Clock Continuity Tests
+#
+# Dedicated Python test gate for the manifest-reality 30-day clock runner.
+# The suite is self-contained, stdlib-only, and has ZERO cross-repo / network
+# dependency; it uses synthetic temp ledgers only. This PR keeps
+# clock_eligible_day and the main exit-code contract unchanged.
+
+name: Manifest Reality Clock Tests
+
+on:
+  pull_request:
+    paths:
+      - '_meta/contracts/scripts/manifest_reality_clock.py'
+      - '_meta/contracts/scripts/test_manifest_reality_clock.py'
+      - '_meta/contracts/scripts/manifest_reality_clock_README.md'
+      - '.github/workflows/manifest-reality-clock-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - '_meta/contracts/scripts/manifest_reality_clock.py'
+      - '_meta/contracts/scripts/test_manifest_reality_clock.py'
+      - '_meta/contracts/scripts/manifest_reality_clock_README.md'
+      - '.github/workflows/manifest-reality-clock-tests.yml'
+
+jobs:
+  python-tests:
+    name: unittest (manifest_reality_clock)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run manifest reality clock unittest
+        run: python3 _meta/contracts/scripts/test_manifest_reality_clock.py

--- a/_meta/contracts/scripts/manifest_reality_clock.py
+++ b/_meta/contracts/scripts/manifest_reality_clock.py
@@ -28,7 +28,7 @@ import hashlib
 import json
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]            # liye_os/
@@ -101,6 +101,91 @@ def _git_path_dirty(repo: Path, path: Path) -> object:
         return bool([ln for ln in proc.stdout.splitlines() if ln.strip()])
     except Exception:
         return None
+
+
+def _day_eligibility(entries: list) -> dict:
+    """Collapse ledger entries to {utc_date(str): day_is_eligible(bool)}, fail-closed:
+    a day is eligible iff it has >=1 entry AND every entry that day has
+    clock_eligible_day is True. Tolerates entries missing the field (-> not eligible).
+    """
+    by_day: dict = {}
+    for e in entries:
+        d = e.get("utc_date")
+        if not isinstance(d, str):
+            continue
+        ok = e.get("clock_eligible_day") is True
+        by_day[d] = ok if d not in by_day else (by_day[d] and ok)
+    return by_day
+
+
+def analyze_continuity(prior_entries: list, today_entry: dict) -> dict:
+    """PURE continuity analysis. Given the entries already in the ledger plus the
+    entry about to be appended, compute streak/gap metadata. NEVER fabricates days.
+
+    Returns a dict (the value for today_entry['continuity']):
+      prev_entry_utc_date : str|None  last distinct ledger date strictly before today
+      gap_days            : [str]     calendar dates strictly between prev and today
+      continuity_break    : bool      len(gap_days) > 0
+      streak_reset        : bool      prior history exists AND yesterday was not a clean eligible day
+      current_streak_len  : int       consecutive eligible UTC days ending today (0 if today ineligible)
+      streak_start_utc_date : str|None first day of that streak
+    """
+    today_s = today_entry.get("utc_date")
+    today_d = date.fromisoformat(today_s)
+    today_ok = today_entry.get("clock_eligible_day") is True
+
+    day_ok = _day_eligibility(list(prior_entries) + [today_entry])
+
+    prior_dates = sorted({e.get("utc_date") for e in prior_entries
+                          if isinstance(e.get("utc_date"), str)
+                          and date.fromisoformat(e["utc_date"]) < today_d})
+    prev = prior_dates[-1] if prior_dates else None
+
+    gap_days = []
+    if prev is not None:
+        d = date.fromisoformat(prev) + timedelta(days=1)
+        while d < today_d:
+            gap_days.append(d.isoformat())
+            d += timedelta(days=1)
+
+    # streak: walk back day-by-day from today while each day is a clean eligible day
+    streak = 0
+    if today_ok:
+        d = today_d
+        while day_ok.get(d.isoformat()) is True:
+            streak += 1
+            d -= timedelta(days=1)
+    streak_start = (today_d - timedelta(days=streak - 1)).isoformat() if streak > 0 else None
+
+    yesterday = (today_d - timedelta(days=1)).isoformat()
+    streak_reset = (prev is not None) and (day_ok.get(yesterday) is not True)
+
+    return {
+        "prev_entry_utc_date": prev,
+        "gap_days": gap_days,
+        "continuity_break": len(gap_days) > 0,
+        "streak_reset": streak_reset,
+        "current_streak_len": streak,
+        "streak_start_utc_date": streak_start,
+    }
+
+
+def read_ledger(ledger: Path) -> list:
+    """Read existing JSONL ledger entries (tolerant: skip blank/malformed lines).
+    Returns [] if the file does not exist.
+    """
+    if not ledger.exists():
+        return []
+    out = []
+    for ln in ledger.read_text(encoding="utf-8").splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            continue
+    return out
 
 
 def _expected_manifest_hash() -> object:
@@ -199,7 +284,20 @@ def main() -> int:
     args = ap.parse_args()
 
     entry = run_once(args.engine_repo.resolve(), args.manifest_path.resolve())
+    prior = read_ledger(args.ledger)
+    entry["continuity"] = analyze_continuity(prior, entry)
     print(json.dumps(entry, indent=2, ensure_ascii=False))
+
+    cont = entry["continuity"]
+    if cont["continuity_break"] or cont["streak_reset"]:
+        print(
+            "ALARM: clock continuity break — prev=%s missing=%s streak_reset=%s "
+            "current_streak_len=%s streak_start=%s. NO backfill (fail-closed); "
+            "consecutive-day count restarts." % (
+                cont["prev_entry_utc_date"], cont["gap_days"], cont["streak_reset"],
+                cont["current_streak_len"], cont["streak_start_utc_date"]),
+            file=sys.stderr,
+        )
 
     if args.append:
         append_entry(args.ledger, entry)

--- a/_meta/contracts/scripts/manifest_reality_clock_README.md
+++ b/_meta/contracts/scripts/manifest_reality_clock_README.md
@@ -28,6 +28,24 @@ scheduler's non-zero exit never loses the record.
 Gate-open evidence = **30 consecutive UTC-day PASS**. Any missing day OR any
 non-PASS entry resets the count (fail-closed). One run per UTC day.
 
+Each entry now includes a `continuity` block:
+
+- `prev_entry_utc_date` — last distinct ledger date strictly before today, or
+  `null` for genesis.
+- `gap_days` — UTC dates strictly between the previous ledger date and today.
+- `continuity_break` — `true` when `gap_days` is non-empty.
+- `streak_reset` — `true` when prior history exists and yesterday was not a
+  clean eligible day, either because it is missing or because it has a non-PASS
+  entry.
+- `current_streak_len` — consecutive eligible UTC days ending today, or `0` if
+  today is not eligible.
+- `streak_start_utc_date` — first UTC date in the current streak, or `null`.
+
+If `continuity_break` or `streak_reset` is true, the runner also emits a loud
+stderr `ALARM` line. On wake, the runner records only TODAY and never backfills
+a past day's PASS; a gap is surfaced in the field and alarm, never silently
+healed.
+
 ## Executor options
 
 | Option | Pros | Cons | When |

--- a/_meta/contracts/scripts/test_manifest_reality_clock.py
+++ b/_meta/contracts/scripts/test_manifest_reality_clock.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Self-contained tests for manifest_reality_clock continuity hardening."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "manifest_reality_clock",
+    Path(__file__).resolve().parent / "manifest_reality_clock.py",
+)
+clk = importlib.util.module_from_spec(_SPEC)
+sys.modules["manifest_reality_clock"] = clk
+_SPEC.loader.exec_module(clk)
+
+
+def E(day: str, ok: bool = True) -> dict:
+    return {"utc_date": day, "clock_eligible_day": ok}
+
+
+class ManifestRealityClockContinuityTests(unittest.TestCase):
+    def test_consecutive_days_keep_streak(self):
+        cont = clk.analyze_continuity(
+            [E("2026-06-26"), E("2026-06-27")],
+            E("2026-06-28"),
+        )
+
+        self.assertFalse(cont["continuity_break"])
+        self.assertFalse(cont["streak_reset"])
+        self.assertEqual(cont["gap_days"], [])
+        self.assertEqual(cont["current_streak_len"], 3)
+        self.assertEqual(cont["streak_start_utc_date"], "2026-06-26")
+        self.assertEqual(cont["prev_entry_utc_date"], "2026-06-27")
+
+    def test_2026_06_28_gap_repro_resets_to_today_only(self):
+        cont = clk.analyze_continuity(
+            [E("2026-06-22"), E("2026-06-23")],
+            E("2026-06-28"),
+        )
+
+        self.assertTrue(cont["continuity_break"])
+        self.assertTrue(cont["streak_reset"])
+        self.assertEqual(
+            cont["gap_days"],
+            ["2026-06-24", "2026-06-25", "2026-06-26", "2026-06-27"],
+        )
+        self.assertEqual(cont["current_streak_len"], 1)
+        self.assertEqual(cont["streak_start_utc_date"], "2026-06-28")
+        self.assertEqual(cont["prev_entry_utc_date"], "2026-06-23")
+
+    def test_prior_day_fail_resets_without_calendar_gap(self):
+        cont = clk.analyze_continuity(
+            [E("2026-06-27", ok=False)],
+            E("2026-06-28"),
+        )
+
+        self.assertEqual(cont["gap_days"], [])
+        self.assertFalse(cont["continuity_break"])
+        self.assertTrue(cont["streak_reset"])
+        self.assertEqual(cont["current_streak_len"], 1)
+
+    def test_genesis_has_no_reset(self):
+        cont = clk.analyze_continuity([], E("2026-06-28"))
+
+        self.assertIsNone(cont["prev_entry_utc_date"])
+        self.assertEqual(cont["gap_days"], [])
+        self.assertFalse(cont["continuity_break"])
+        self.assertFalse(cont["streak_reset"])
+        self.assertEqual(cont["current_streak_len"], 1)
+        self.assertEqual(cont["streak_start_utc_date"], "2026-06-28")
+
+    def test_today_ineligible_has_zero_current_streak(self):
+        cont = clk.analyze_continuity(
+            [E("2026-06-27")],
+            E("2026-06-28", ok=False),
+        )
+
+        self.assertEqual(cont["current_streak_len"], 0)
+        self.assertIsNone(cont["streak_start_utc_date"])
+
+    def test_multi_day_clean_streak(self):
+        cont = clk.analyze_continuity(
+            [
+                E("2026-06-24"),
+                E("2026-06-25"),
+                E("2026-06-26"),
+                E("2026-06-27"),
+            ],
+            E("2026-06-28"),
+        )
+
+        self.assertFalse(cont["continuity_break"])
+        self.assertFalse(cont["streak_reset"])
+        self.assertEqual(cont["current_streak_len"], 5)
+        self.assertEqual(cont["streak_start_utc_date"], "2026-06-24")
+
+    def test_duplicate_day_is_fail_closed(self):
+        cont = clk.analyze_continuity(
+            [E("2026-06-27", ok=True), E("2026-06-27", ok=False)],
+            E("2026-06-28"),
+        )
+
+        self.assertTrue(cont["streak_reset"])
+        self.assertEqual(cont["current_streak_len"], 1)
+
+    def test_append_records_gap_metadata_without_backfill_lines(self):
+        with tempfile.TemporaryDirectory() as td:
+            ledger = Path(td) / "ledger.jsonl"
+            ledger.write_text(json.dumps(E("2026-06-23")) + "\n", encoding="utf-8")
+            entry = E("2026-06-28")
+
+            entry["continuity"] = clk.analyze_continuity(clk.read_ledger(ledger), entry)
+            clk.append_entry(ledger, entry)
+
+            lines = ledger.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(len(lines), 2)
+            appended = json.loads(lines[-1])
+            self.assertEqual(
+                appended["continuity"]["gap_days"],
+                ["2026-06-24", "2026-06-25", "2026-06-26", "2026-06-27"],
+            )
+
+    def test_read_ledger_skips_blank_and_malformed_lines(self):
+        with tempfile.TemporaryDirectory() as td:
+            ledger = Path(td) / "ledger.jsonl"
+            valid = E("2026-06-28")
+            ledger.write_text(
+                "\nnot json\n" + json.dumps(valid) + "\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(clk.read_ledger(ledger), [valid])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the runner-hardening design from #191 (第二刀). **Detection-only — no backfill, no launchd change, no gate/activation change.**

## Problem
The Band B 30-day clock **reset silently** on 2026-06-28: a 4-day gap (UTC 6/24–6/27) cleared the consecutive-PASS streak because launchd `StartCalendarInterval` does not fire while the Mac is asleep (and catches up only once on wake). The runner had no gap detection, so the reset was only discoverable by eyeballing the JSONL. Per the authoritative rule (`manifest_reality_clock_README.md:28-29`): 30 *consecutive* UTC-day PASS; any missing day OR non-PASS resets (fail-closed).

## What this adds
- **`analyze_continuity(prior_entries, today_entry)`** — a **pure** function emitting a per-entry `continuity` block: `prev_entry_utc_date`, `gap_days`, `continuity_break`, `streak_reset`, `current_streak_len`, `streak_start_utc_date`. `streak_reset` mirrors the README rule exactly: with prior history, a non-clean *yesterday* (missing day **or** non-PASS entry) restarts the streak.
- **`read_ledger()`** — tolerant JSONL reader (skips blank/malformed lines).
- **`main()`** wires continuity into the entry and, on break/reset, emits a loud stderr **`ALARM`** line.
- **README** documents the `continuity` block + ALARM + the no-backfill principle.
- **Dedicated CI workflow** (`manifest-reality-clock-tests.yml`, Python 3.12, paths-triggered, self-contained — mirrors the learning-track per-runner-workflow norm).

## LOCKED invariants preserved (verified)
- `clock_eligible_day` stays a **pure** function of `(validator PASS, exit 0)` — untouched.
- `main()` **exit code unchanged** (`0 if today eligible else 1`); continuity is surfaced via the entry field + ALARM, **not** by overloading exit code (keeps the scheduler contract intact).
- **No backfill (fail-closed):** on wake the runner records only TODAY; `gap_days` are recorded as metadata, **never** materialized as past-day entries. The `test_append_records_gap_metadata_without_backfill_lines` test is load-bearing (append to a gapped temp ledger ⇒ file gains **exactly one** line).
- **launchd / plist untouched** — integrity is enforced by the ledger rule + runner detection, not by assuming launchd never misses (per #191's design).

## Live behavior (the actual reset event)
```
6-28 (after 6-22,6-23):  streak_reset=true  gap_days=[06-24..06-27]  current_streak_len=1  streak_start=2026-06-28
6-29 (gap-free):         streak_reset=false gap_days=[]              current_streak_len=2  streak_start=2026-06-28
```
i.e. the silent 6-28 reset would now fire an ALARM + a machine-readable `continuity` record; a subsequent gap-free run correctly continues the streak.

## Tests
NEW self-contained `unittest` (9 cases): consecutive streak, the 6-28 gap repro, prior-day-FAIL reset (no calendar gap), genesis, today-ineligible, multi-day clean streak, duplicate-day fail-closed, the no-backfill append invariant, and `read_ledger` tolerance. All pure / temp-ledger — **zero** validator/git/network/real-ledger dependency.

`python3 _meta/contracts/scripts/test_manifest_reality_clock.py` → **9 passed**.

## Scope / hygiene
- Touches **exactly** 4 files (runner +continuity, NEW test, README, NEW workflow). +295/−1.
- **Does NOT touch or commit** the uncommitted 2026-06-28 ledger line — that decision stays on #191 (operator ruling: don't fold it into other work).
- Implemented by codex (codex-rescue) against a locked self-contained PLAN; **adversarially reviewed independently** — diff read, scope-checked (no tracked-file leakage; unrelated untracked `governed-work-loop` scaffolding present in the worktree from a concurrent process was explicitly excluded), suite re-run, the 6-28 reset reproduced live, forbidden-name lint clean (not bypassed).
- Branch cut from `main` (`dac71a4`).

**Refs #191** (does not close it — #191 also tracks the reset acknowledgement + the dirty-line commit decision). Not merged by me — awaiting your review/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
