### PR TITLE
chore(dev-env): add bin/install-hooks.sh — liye_os git-hook installer (PR-3)

### DIFF
--- a/bin/install-hooks.sh
+++ b/bin/install-hooks.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# install-hooks.sh — One-time setup for LiYe OS local git hooks.
+#
+# Run this once after cloning liye_os. It points git at the tracked hook
+# directory via git's native core.hooksPath (no third-party framework):
+#
+#     git config core.hooksPath .claude/.githooks
+#
+# Before this script, the only way to enable the hooks was to type that
+# command by hand — this mirrors amazon-growth-engine's ./bin/install-hooks.sh
+# so the same muscle memory works across both repos.
+#
+# These hooks are LOCAL GUARDRAILS, not enforcement:
+#   - Bypassable with `git commit --no-verify` (so NOT a security boundary).
+#   - Real enforcement lives in CI / server-side checks.
+#   - Their job is to catch accidental scope drift / secret leaks BEFORE a
+#     push, not to defend against an intentional bypass.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOKS_PATH=".claude/.githooks"
+
+cd "$REPO_ROOT"
+
+if [ ! -f "$HOOKS_PATH/pre-commit" ]; then
+  echo "❌ $HOOKS_PATH/pre-commit not found under $REPO_ROOT" >&2
+  echo "   Are you running this from a liye_os clone? Aborting." >&2
+  exit 1
+fi
+
+# Use git's native core.hooksPath (idempotent — safe to re-run).
+git config core.hooksPath "$HOOKS_PATH"
+
+# Ensure the hook is executable.
+chmod +x "$HOOKS_PATH/pre-commit"
+
+cat <<'EOF'
+✓ Git hooks installed via core.hooksPath = .claude/.githooks
+
+  Active hook:
+    - pre-commit: guardrail (CLAUDE.md / Pack size limits) + blocks for
+      .DS_Store / >10MB files / data files / venv / .env* files, a staged
+      secret-pattern scan (env / keys), the env-hygiene gate
+      (.claude/scripts/env_hygiene_gate.mjs), and the forbidden-name lint
+      (tools/lint_forbidden_names.sh).
+
+  ⚠ IMPORTANT: this is a LOCAL guardrail only.
+    - Bypassable with `git commit --no-verify` — NOT a security boundary.
+    - It does NOT replace code review or CI.
+
+  To verify install:
+    git config core.hooksPath        # -> .claude/.githooks
+
+  To uninstall:
+    git config --unset core.hooksPath
+EOF

--- a/bin/install-hooks.sh
+++ b/bin/install-hooks.sh
@@ -40,7 +40,8 @@ cat <<'EOF'
 
   Active hook:
     - pre-commit: guardrail (CLAUDE.md / Pack size limits) + blocks for
-      .DS_Store / >10MB files / data files / venv / .env* files, a staged
+      .DS_Store / >10MB files / data files / venv / .env / .env.local /
+      .env.production files, a staged
       secret-pattern scan (env / keys), the env-hygiene gate
       (.claude/scripts/env_hygiene_gate.mjs), and the forbidden-name lint
       (tools/lint_forbidden_names.sh).


### PR DESCRIPTION
## What

Adds `bin/install-hooks.sh` to liye_os — a one-command installer for the local git hooks. Before this, enabling the hooks meant typing `git config core.hooksPath .claude/.githooks` by hand. This mirrors amazon-growth-engine's `./bin/install-hooks.sh` so the same setup works across both repos (cross-repo muscle memory for onboarding).

PR-3 of the iconexpert onboarding track (PR-0 #195 merged; PR-1 AGE#544, PR-2 AGE#546 merged).

## The installer

- Sets `core.hooksPath` → tracked `.claude/.githooks` via git's native mechanism (no third-party framework). Idempotent — safe to re-run.
- `chmod +x` the `pre-commit` hook (liye_os's only hook; no commit-msg here, unlike AGE).
- Prints exactly what the hook does — guardrail (CLAUDE.md / Pack size limits), blocks for `.DS_Store` / >10MB / data / venv / `.env*`, staged secret-pattern scan, env-hygiene gate, forbidden-name lint — and states plainly it is a **LOCAL guardrail**: bypassable with `--no-verify`, **not** a security boundary, does not replace review/CI.
- Guards: aborts with a clear message if `.claude/.githooks/pre-commit` is missing (wrong cwd).

## Scope / non-changes

- **Purely additive** — one new file, no existing file touched.
- **No onboarding-doc change.** The Day-1 SOP's `./bin/install-hooks.sh` (ICONEXPERT_ONBOARDING §2, line 35) is the **AGE clone's** installer; per §3 iconexpert does not touch liye_os on Day-1, so no SOP rewiring is needed.
- House style: `#!/usr/bin/env bash` + `set -euo pipefail` (matches `.claude/.githooks/pre-commit`).

## Verification (local)

- `bash -n` clean; run from the worktree → exit 0, sets/reaffirms `.claude/.githooks`, executable bit preserved (mode 100755).
- liye_os `pre-commit` hook run manually on the staged blob (NOT `--no-verify`): guardrail + staged-file gate + env-hygiene + blocklist + forbidden-name lint (staged-blob scan) all passed, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)