### PR TITLE
docs(uge): PR1 decision package — register UGE as Layer-2 engine (Proposed)

### DIFF
--- a/_meta/adr/ADR-UGE-Fact-Taxonomy.md
+++ b/_meta/adr/ADR-UGE-Fact-Taxonomy.md
@@ -1,0 +1,128 @@
+---
+artifact_scope: meta
+artifact_name: UGE-Fact-Taxonomy
+artifact_role: contract
+target_layer: 0
+is_bghs_doctrine: no
+---
+
+# ADR — User Growth Engine (UGE) Fact Taxonomy：content/channel 复用 `write_outcome`，业务结果新增通用 `growth_outcome` + `source_system: user-growth-engine`
+
+> 文件名采非数字前缀（`ADR-UGE-Fact-Taxonomy.md`）以进入 CI-wired BGHS frontmatter gate（`adr-bghs-gate.yml`）的有效扫描域，对齐 write_outcome 先例。
+
+**Status**: Proposed
+**Date**: 2026-07-01
+**Decision Makers**: LiYe
+**SSOT**: 本文件（UGE fact artifact_type / source_system 分类教条）；schema SSOT = `_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml`（canonical）；UGE 端为未来 byte-pinned vendored copy（UGE repo scaffold 时才建，见 §Cross-repo edit sequence）。
+**先例**: `_meta/adr/ADR-Learning-Fact-Artifact-Type-Taxonomy.md`（Accepted 2026-06-14，durable anchor `73e4d00`）—— 本 ADR 完全复用其「generic value + `raw_payload_summary.action_kind` discriminator」无损范式、cross-repo 手同步序、DoD 骨架；仅在两点扩展（见 §Context 末「与先例的差异」）。
+
+**References**:
+- N-1（Normative）: `_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml`（canonical SSOT）——
+  - `source_system.enum` **L49-54**（现 3 值 `amazon-growth-engine / chaming / loamwise`，closed enum；object-level `additionalProperties: false`）
+  - `artifact_type.enum` **L95-102**（现 5 值，末值 `write_outcome`）
+  - doctrine 描述 **L103-110**：「The concrete action kind lives in `raw_payload_summary.action_kind` — NOT a per-kind artifact_type value … minting per-kind values would fork identity space」+ L110 指回 taxonomy 先例 ADR
+  - `event_identity_key` **L152-160**：`sha256(source_system + source_repo + trace_id + artifact_type + artifact_path + playbook_ref + step_id + source_commit_sha)`（8-key locked 原像，`source_system` 与 `artifact_type` 皆在原像内）
+  - `event_content_hash` **L161-168**：排除集 **L166** = `[emitted_at, raw_payload_summary.metric_formatting_hint]` → **`raw_payload_summary.action_kind` 不在排除集 → 进 content fingerprint**
+  - `schema_version` **L170-172** const `"1.0.0"`
+- N-2（Normative）: `_meta/contracts/learning/fact_run_outcome_record_v1.schema.yaml` —— head **L15** 维护契约「本文件 19 个 event 字段必须与 event_v1 保持同步」；`source_system` **L69-72**、`artifact_type` **L104-113**（展开**副本，非 `$ref`**，L106-107 注明与 event_v1 同步 + write_outcome 来源）。→ enum 拓宽**必须双改（event + record）**，否则 event 过、record-validate 拒 = split failure。
+- N-3（Normative，本 ADR 不改 importer；行号实测 worktree base `4865714`）: `.claude/scripts/learning/import_facts.mjs` —— `buildValidators()`（:141，ajv `strict:false / validateFormats:false`）双 schema compile；三关 S1 event-validate / S1b `NUMERIC_NOT_STRING`（~:409 `containsNativeNumber(summaryNode)`，判定逻辑在 `canonical_json.mjs:285`——**只对 `node.t==='num'` 即 native JSON number 返 true，native bool 不触发**）/ record-validate。**growth_outcome 与 user-growth-engine 是纯 enum 拓宽，不触碰 importer 逻辑。**
+- N-4（Normative，继承自先例 N-4，accept 时复核）: `src/reasoning/policy_trial_evaluator.mjs` —— `deriveEvidenceOrigin`（:302）`regression_replay_result`→`golden_regression`，**else→default `production_observed`**；records-scan（:558）仅 `policy_suggestions_json` 驱动 artifact-deref。→ **新值 `growth_outcome` 落 else 分支静默取 `production_observed`，无 unknown-value throw、无 deref，零 evaluator 改动**（与 write_outcome 同待遇）。
+- N-5（Normative，继承自先例 N-5）: `_meta/contracts/scripts/validate-contracts.mjs` —— schema-pass 计数 over 显式 `schemaFiles[]` 数组；全局 Summary pass 计数当前为 **21**。本决策**仅编辑既有数组成员 enum 值、不新增 `schemaFiles[]` entry** → schema-pass 与全局总数**零变化（守 21，无 carve-out）**。
+- S-1（Supporting）: `scratchpad/uge-fact-taxonomy-spike.md`（本 ADR 的 time-boxed spike 决策交付物：决策表 A/B/C/D + 推荐 C + schema-diff 风险 R1-R4 + 本骨架）；write_outcome 先例 micro-discuss `wf_0b114a29`（`generic_is_lossless=true / would_break_importer=false`）。
+
+**Commit anchor**: **pending**（Status=Proposed；承载本 ADR 的 liye_os schema/ADR PR 尚未开；frontmatter 不预编 SHA）。对齐 ADR-GHL 教条「post-squash merge commit 为 durable anchor；无 pre-squash SHA 具规范性」——PR squash-merge 后回填。
+
+---
+
+## Context
+
+UGE（User Growth Engine）作为 Layer-2 域引擎接入 LiYe Systems，其运营动作（内容发布、渠道排期、渠道活动改动）与业务结果（掌象AI SaaS 获客 / lead / trial 归因）需进 GHL learning fact 流。在动任何 UGE wiring / scaffold repo **之前**，必须先钉死这些 fact 的**输出形状**，否则后续每条 content/growth wiring 会各自发明 `artifact_type`，污染 `event_identity_key` 的 8-key identity 空间（N-1 L152-160）——与 write_outcome 先例撞同一条护栏。
+
+UGE 的 fact 分**两类**，命运不同：
+
+- **类 1 — content / channel 动作**（YouTube 发布、小红书发布、blog 发布、抖音/视频号渠道活动改动、排期）= **write/execution receipt**。语义与 AGE 的 CBU write receipt 同级 → **直接复用现有 `write_outcome`**，动作细分走 `raw_payload_summary.action_kind`。**零新 artifact_type，不进本 ADR 的 fork 决策。**
+- **类 2 — growth / 业务结果**（`attributed_qualified_signup`、lead captured、trial started，归因到具体内容/渠道）= **非引擎写出、是观测到的业务结果**。既有 5 个 artifact_type 值（verification / policy_suggestions / step_eval / regression_replay / write_outcome）都不契合其语义 → **这才是本 ADR 的 fork 决策**。
+
+**与 write_outcome 先例的差异（两点）**：
+1. **多一处 enum**：write_outcome 只动 `artifact_type` 且复用现有 engine；UGE 是**新增 Layer-2 引擎**（继 AGE/chaming 后第 3 个 Layer-2 引擎），须在 `source_system.enum`（N-1 L49-54）**新增 `user-growth-engine`**（使其从 3 值增至 4 值——即 **UGE 是第 4 个 `source_system` enum value**，勿与 Layer-2 引擎序号混淆：现有 3 值中 `loamwise` 是 Layer-1）。`source_system` 是「每 source 一值」的**设计扩展点**，故新增一值是**合法登记，非 fork**——与 `artifact_type` per-kind 铸值是反模式恰好相反。
+2. **UGE repo 尚不存在**：write_outcome 先例的第 3 份 vendored 副本在已存在的 AGE 仓；UGE 仓要到 Rung 0 scaffold 才建。故本 ADR accept 时**只有 2 份副本（liye_os event + record）**，UGE vendored 副本是**未来**（scaffold 时 byte-pin 到本 ADR 落地后的 schema）。
+
+## Decision
+
+1. **类 1 content/channel 动作 → 复用 `write_outcome`**（零新 artifact_type）。动作种类走 `raw_payload_summary.action_kind`，约定 `<domain>.<object>.<verb>`：
+   - `content.*`：`content.youtube.publish` / `content.xhs.publish` / `content.blog.publish`
+   - `channel.*`：`channel.douyin.campaign_update` / `channel.video_channel.schedule`
+2. **类 2 业务结果 → 新增 exactly ONE 通用值 `growth_outcome`**（`fact_run_outcome_event_v1.artifact_type.enum` +1，N-1 L95-102）。与 write_outcome 同为「非 eval/inference/replay 的第二类通用 receipt」，可被未来任意 growth-outcome→fact 路径复用。业务动作走 `action_kind`：
+   - `growth.*`：`growth.signup.qualified` / `growth.lead.captured` / `growth.trial.started`
+3. **新增 `source_system: user-growth-engine`**（`fact_run_outcome_event_v1.source_system.enum` +1，N-1 L49-54）—— UGE 引擎登记。
+4. `artifact_type.description` doctrine 从「eval/inference/replay + execution/write outcomes」扩成「+ **observed growth/business outcomes**」；明确 growth_outcome = 观测到的、归因到内容/渠道的业务结果（signup/lead/trial），**非引擎自身的写动作**（那是 write_outcome）。
+5. **北极星契约（`attributed_qualified_signup`）落 `raw_payload_summary` profile**（`action_kind=growth.signup.qualified`），**不进 schema top-level、不铸独立 sealed 文件**（守 21）：
+   - summary keys（非 PII、**全部 string-encoded** per S1b，N-3 :411）：`seller_category` / `monthly_gmv_band` / `is_amazon_seller`（`"true"`/`"false"` 字符串） / `submitted_asin` / `contactable`（`"true"`/`"false"`） / `attribution_click_id` / `utm_source`
+   - **qualified 判定**（哪些字段组合算 qualified）由 UGE lead-ingest playbook 计算后落 summary，**判定规则本身**在 UGE SPEC / ADR-User-Growth-Engine 定义，本 ADR 只钉字段形状与编码约束。
+
+### 决策成立的关键机制（lossless 证明，照先例 §关键机制）
+
+`event_content_hash` 排除集仅 `[emitted_at, raw_payload_summary.metric_formatting_hint]`（N-1 L166）。`raw_payload_summary.action_kind` **不在排除集 → 进 content fingerprint**。故：
+- **identity** 由通用 `growth_outcome`（或 `write_outcome`）+ 其余 7 key（含 `source_system=user-growth-engine`）唯一化，**不因 signup/lead/trial 细分而 fork**；
+- **content** 由 `action_kind` + summary 各字段保真 → 不同业务结果产不同 content hash → D-13 duplicate-vs-conflict 判定正确，**信息零丢失**。
+
+二者正交：通用值收敛 identity，`action_kind`/summary 在 content 层保真。这是「generic + summary-discriminator」相对「per-kind enum」的唯一无损形态（先例已证）。
+
+### impedance 解决（growth 结果无天然「run」身份）
+
+business signup 不是「engine run 产出 artifact」——它无 trace_id / playbook_ref / artifact_path 的天然来源。解法：**UGE lead-ingest job 就是那个 run**。
+- `trace_id` = 该次 ingest run id；`playbook_ref` = `lead_ingest`；`step_id` = ingest step；`artifact_path` = 该 signup record 的规范路径；`source_commit_sha` = UGE 该次运行的 commit。
+- 于是 growth 结果干净 fit 既有 `fact_run_outcome_event_v1`，**无需新独立 schema 家族**（否决 Option D，见 §Rejected）。
+
+## Cross-repo edit sequence（load-bearing；enum 在手同步副本，非 `$ref`）
+
+> **适用范围**：本节 + 下方 DoD 描述的是 **PR2（`uge-fact-schema-carve-in`）**——即真正改 event/record schema enum 的那个 PR。本 taxonomy ADR 落地于 **PR1 决策包**（2 ADR + SYSTEMS.md 两行、**不碰 schema**）；PR1 无需 fixture/importer 测试，那是 PR2 的 DoD。
+
+**PR2 merge 时副本清单 = 2 份（均在 liye_os；UGE 仓尚不存在）**：
+1. liye_os canonical **event** schema（N-1）—— `source_system.enum` +`user-growth-engine`、`artifact_type.enum` +`growth_outcome`。
+2. liye_os **record** schema（N-2，**最易漏**：漏改则 event 过、record-validate `:489` 拒 = split failure）—— 同两处 enum 拓宽。
+
+→ **PR2** 净 enum-array 编辑 = **2 值 × 2 文件 = 4 处**（`source_system` 与 `artifact_type` 各在 event+record 双改）。
+
+**未来第 3 份（不在本 PR）**：UGE repo Rung 0 scaffold 时建 **vendored copy**（`DO-NOT-EDIT` pin + freshness 测试钉 canonical-body sha256 + source-commit），byte-pin 到本 ADR 落地后的 event schema。**UGE 不得在 vendor 前 emit**（否则 `fact_rejects/`）。
+
+**序（forward fail-closed）**：liye_os (1)+(2) 双改于 **PR2** 同 PR merge → （未来）UGE scaffold 时 re-vendor。**`schema_version` 维持 const `"1.0.0"`**（两处 enum 拓宽皆 JSON-Schema 加性、向后兼容、identity/content-hash 算术不变，无 bump）。
+
+- contracts gate **守 21**（enum-only、不增 `schemaFiles[]` entry，N-5 → 无合法 gate 增长、无 carve-out）。
+- 触发 CI：liye_os `contracts-gate.yml` + `learning-importer-tests.yml` + `adr-bghs-gate.yml`。
+- 零行为改动、两门（engine_manifest + learning_sources）仍关、零 fact 发射、frozen anchor 零触碰。
+
+**关键 sequencing 约束**：`source_system: user-growth-engine` 是**已登记引擎的词表项**；**PR2（schema carve-in）应在 PR1（`ADR-User-Growth-Engine` 把 UGE 登记进 SYSTEMS.md 为 Layer-2 引擎）之后 merge**，避免 orphan 词表项。在 UGE 有 emitter 前，该值**inert**（无引擎发射 → 无 fact → 无效果），与 write_outcome 先加值后接 caller 的 fail-closed 序一致。
+
+## Non-negotiable DoD（operator-mandated，照先例；**属 PR2，非 PR1**）
+
+**PR2（schema carve-in）不得只改 enum**。必须含**正向 fixture**，经**真 importer 路径**（N-3，非重写 ajv）证明一条 `artifact_type: growth_outcome` + `source_system: user-growth-engine` + `raw_payload_summary.action_kind=growth.signup.qualified` + **string-encoded summary 字段**同时通过 ① event schema（S1 :402）② S1b `NUMERIC_NOT_STRING`（:411）③ record schema（S2 :489）。实现：从真 `golden_sidecar.json` 派生自洽 growth_outcome sidecar（reseal 重算 identity+content），`importFacts({mode:'live'})` 断言 `new_records=1 / rejects=0`。
+- **split-failure 哨兵**：若漏改 record enum（`source_system` 或 `artifact_type` 任一），此测在 record-validate 直接 `rejects=1 / new_records=0` → 红。
+- **负向控制（仅 native number）**：`monthly_gmv_band` 用 native number（非字符串）→ 断言 `rejects=1` `NUMERIC_NOT_STRING`。**⚠ 实测边界**：importer 的 S1b（`containsNativeNumber`，`import_facts.mjs` ~:409 + `canonical_json.mjs:285`）**只查 native JSON number，不查 native bool**（bool 落 `default:false`）。故 `is_amazon_seller`/`contactable` 的 string-encoding（`"true"`/`"false"`）**不由 importer 强制** → 由 **UGE emitter + profile validator** 保证（PR2/Rung wiring 层测 bool/string，不寄望 S1b）。本 DoD 只对 number 负向。
+- **PII 负向控制（本 ADR 新增）**：fixture 断言联系方式值**不出现在 summary**（只留 `contactable` 布尔字符串），且 `raw_payload_ref` 指向的 artifact 已 redacted（`redaction_status: redacted`，解引用无明文联系值）；防止 signup 联系值意外进 fact 明文。原始联系方式只在 UGE 私有 lead store/broker。
+
+## Forks（已裁）
+
+- **Q1 类 1 归属** = 复用 `write_outcome`（content/channel 是写动作，非业务结果观测；不为其铸新值）。
+- **Q2 类 2 命名** = `growth_outcome`（`signup_*` 太窄、`conversion_*` 与 AGE measurement 混淆；`growth_outcome` 平行于 write_outcome，范畴级）。
+- **Q3 source_system** = 新增 `user-growth-engine`（引擎登记，非 fork；source_system 本就每引擎一值）。
+- **Q4 action_kind** = free-string `<domain>.<object>.<verb>`（不铸第 2 份 growth-kind 枚举，复用先例 free-string 范式）。
+- **Q5 evaluator 分支** = 不加；`growth_outcome` 静默落 default `production_observed`（N-4 实证 else 不抛、不丢 fact）。待真有 growth-evidence 语义需求再开。
+- **Q6 qualified profile 形态** = 留 `raw_payload_summary` doc/convention 层（**不加 sealed schema 文件** → 守 21）；要 machine-validate qualified 判定时另起 carve-out（21→22）。
+- **Q7 PII** = 原始联系方式**只存在 UGE 私有 lead store / broker**，**不进 fact repo artifact、不进 event sidecar、不进 audit 明文**。fact 的 `raw_payload_ref` **只能指向已 redacted 的 artifact**（`redaction_status: redacted` / hash-ref），解引用也拿不到联系方式明文；summary 只保留 `contactable`（布尔字符串），**不放联系值**。
+- **Q8 cross-product provenance** = signup 起源 zhangxiang.com（同事产品，**只读、本地改动永不推送**）→ **不改同事代码**，只在 form 旁挂 fire-and-forget event；UGE lead-ingest job 是 emit 主体（见 impedance 解决）。
+
+## Downstream（本 ADR 之外）
+
+- **`ADR-User-Growth-Engine`**（并行/紧接）：把 UGE 登记为 Layer-2 引擎（SYSTEMS.md）、placeholder engine_manifest v2（`write_capability_declared/effective=none`）、两门 closed。本 taxonomy ADR 被其引用为 fact-output 契约。
+- **UGE SPEC**（contract-first，scaffold 前）：定义 lead-ingest playbook、qualified 判定规则、content_fanout draft、read-only metrics。
+- **UGE Rung 0 scaffold**：建 repo + vendored schema copy + freshness pin（本 ADR §Cross-repo 的未来第 3 份）。
+- **Attribution Blocker**（独立前置）：zhangxiang form 旁挂 fire-and-forget lead event（不改同事代码）+ `attributed_qualified_signup` 定义落地，使北极星可度量——是 growth_outcome fact 有真数据的前提。
+
+## Rejected alternatives
+
+1. **类 2 复用 `write_outcome`** —— 信号是「观测到的业务结果」非「引擎写出」，会污染刚定义的 write receipt 语义边界。**否决**（决策表 Option A）。
+2. **类 2 复用 `verification_json`（measurement/verdict 家族）** —— verification = run 自证正确性 ≠ 业务转化；轻度语义重载。**否决**（Option B，次选但语义不正）。
+3. **新增独立 schema 文件 `growth_outcome_event_v1`** —— contracts gate 21→22（需 carve-out）+ 复制 19 字段；且 impedance 已由「lead-ingest job = run」解决，无需独立家族。write_outcome 先例已明否同型方案（其 Rejected #3）。**否决**（Option D）。
+4. **per-kind artifact_type 值**（`qualified_signup_outcome` / `lead_captured_outcome` 等）—— fork 8-key identity 空间，复活 per-kind 反模式（N-1 L107-109 doctrine 明禁）。**否决**。
+5. **qualified profile 做成 top-level 新字段或 sealed schema** —— 改 20-field top-level 形状 = 破坏性、动 required/identity；或 21→22 需 carve-out。summary 是无损、守 21 的落点。**否决**。

--- a/_meta/adr/ADR-UGE-Fact-Taxonomy.md
+++ b/_meta/adr/ADR-UGE-Fact-Taxonomy.md
@@ -30,7 +30,7 @@ is_bghs_doctrine: no
 - N-5（Normative，继承自先例 N-5）: `_meta/contracts/scripts/validate-contracts.mjs` —— schema-pass 计数 over 显式 `schemaFiles[]` 数组；全局 Summary pass 计数当前为 **21**。本决策**仅编辑既有数组成员 enum 值、不新增 `schemaFiles[]` entry** → schema-pass 与全局总数**零变化（守 21，无 carve-out）**。
 - S-1（Supporting）: `scratchpad/uge-fact-taxonomy-spike.md`（本 ADR 的 time-boxed spike 决策交付物：决策表 A/B/C/D + 推荐 C + schema-diff 风险 R1-R4 + 本骨架）；write_outcome 先例 micro-discuss `wf_0b114a29`（`generic_is_lossless=true / would_break_importer=false`）。
 
-**Commit anchor**: **pending**（Status=Proposed；承载本 ADR 的 liye_os schema/ADR PR 尚未开；frontmatter 不预编 SHA）。对齐 ADR-GHL 教条「post-squash merge commit 为 durable anchor；无 pre-squash SHA 具规范性」——PR squash-merge 后回填。
+**Commit anchor**: **pending**（Status=Proposed；承载本 ADR 的 liye_os PR 已开、尚未 merge；frontmatter 不预编 SHA）。对齐 ADR-GHL 教条「post-squash merge commit 为 durable anchor；无 pre-squash SHA 具规范性」——PR squash-merge 后回填。
 
 ---
 

--- a/_meta/adr/ADR-User-Growth-Engine.md
+++ b/_meta/adr/ADR-User-Growth-Engine.md
@@ -23,7 +23,7 @@ is_bghs_doctrine: no
 - N-5（Normative）: `_meta/portfolio/SYSTEMS.md` —— Codebase Registry（列 `Codebase|Layer|Role|Upstream|Downstream|Maturity|CLAUDE.md`）+ Domain 成熟度模型（D0 Standalone / D1 Registered / D2 Dispatchable / D3 Governed）+ 当前状态表（AGE/Chaming 现均 D0）。
 - S-1（Supporting）: a16z「New Media, One Year In」框架（signal from people not brands / barbell content / one longform→fan-out / owned vs rented audience / measured impact）；掌象AI（FirstLightClaw，`zhangxiang.com`）作为 AGE 对外 SaaS 版本的获客案例。
 
-**Commit anchor**: **pending**（Status=Proposed；承载本决策包的 liye_os PR 尚未开）。post-squash merge 后回填。
+**Commit anchor**: **pending**（Status=Proposed；承载本决策包的 liye_os PR 已开、尚未 merge）。post-squash merge 后回填。
 
 ---
 

--- a/_meta/adr/ADR-User-Growth-Engine.md
+++ b/_meta/adr/ADR-User-Growth-Engine.md
@@ -1,0 +1,115 @@
+---
+artifact_scope: meta
+artifact_name: User-Growth-Engine
+artifact_role: contract
+target_layer: 2
+is_bghs_doctrine: no
+---
+
+# ADR — User Growth Engine (UGE)：Layer-2 域引擎登记 · 双平面边界 · 门控阶梯
+
+> 文件名采非数字前缀以进入 CI-wired BGHS frontmatter gate（`adr-bghs-gate.yml`）有效扫描域。
+> **本 ADR 只做「登记 / 边界 / 门控」，不塞任何实现**：无 engine_manifest 文件、无 schema enum 编辑、无 Hands 代码、无 content。实现全部后置（见 §Non-scope 与 §Downstream 的 PR 排序）。
+
+**Status**: Proposed
+**Date**: 2026-07-01
+**Decision Makers**: LiYe
+**SSOT**: 本文件（UGE 引擎定位 / 双平面边界 / 门控阶梯的架构决策）；生态分层/成熟度以 `_meta/portfolio/SYSTEMS.md` 为准（本 ADR 提议其新增登记行，见 §Decision-1）。
+**References**:
+- N-1（Normative）: `_meta/adr/ADR-001-control-plane-vs-domain-engine.md`（Accepted 2026-02-08）—— 控制平面（LiYe OS：调度/学习/治理/投递/计量）vs 域引擎（纯函数 playbooks，**禁自行调度/学习治理/投递/读写 OS 状态**，消费 learned bundle）的边界宪法。本 ADR **在其上新增一维**：UGE 的**执行物理发生在独立 Mac mini（Hands）**，而非控制面本机。
+- N-2（Normative）: `_meta/adr/ADR-UGE-Fact-Taxonomy.md`（Proposed，本决策包同 PR）—— UGE 的 fact 输出形状（content/channel→`write_outcome`；growth→`growth_outcome`；`source_system: user-growth-engine`）。本 ADR 引用其为 UGE→GHL learning 流的契约，解决 `source_system` 词表不 orphan 的 sequencing。
+- N-3（Normative）: `_meta/contracts/engine/engine_manifest.schema.v2.yaml`（**当前活动版**，`schema_version: "2.0"`；未声明 schema_version 的旧 manifest 才 fallback 到 v1 `engine_manifest.schema.yaml`）—— D0→D1 登记的目标契约。UGE 的 placeholder manifest 须用 **v2 字段**：`write_capability_declared` + `write_capability_effective`（初始皆 `none`；v2.0 期 legacy `write_capability` 仅 deprecated_but_accepted）、`capabilities[]`（`status: placeholder`）、`runtime_gates[]`（`default_state: closed` + `evidence_required_for_open`）、`playbooks` + `data_sources`。**本 ADR 不创建 manifest 实例**（那是 Rung 0，PR2 之后）；仅声明 UGE 将来按 v2 协议注册。
+- N-4（Normative，Hands 治理模式，引用不重述）: `_meta/adr/ADR-Credential-Mediation.md`（凭证中介：平台/provider 明文密钥**不跨线抵达 Hands**，控制面只派发 `cred://` 引用，Hands 本地解析）、`_meta/adr/ADR-AGE-Wake-Resume.md`（Wake/Resume：append-only event stream 保证跨睡眠/重启不丢不重）、`_meta/adr/ADR-Loamwise-Guard-Content-Security.md`（内容写前 GuardChain）。UGE-Hands **复用**这些模式；KillSwitch(position-0) / WriteGate(shadow-first, deny-by-default) / TrustBoundaryDecl 等 Hands 执行细则由**后续独立 Hands-execution ADR** 正式钉死，不在本 ADR 展开。
+- N-5（Normative）: `_meta/portfolio/SYSTEMS.md` —— Codebase Registry（列 `Codebase|Layer|Role|Upstream|Downstream|Maturity|CLAUDE.md`）+ Domain 成熟度模型（D0 Standalone / D1 Registered / D2 Dispatchable / D3 Governed）+ 当前状态表（AGE/Chaming 现均 D0）。
+- S-1（Supporting）: a16z「New Media, One Year In」框架（signal from people not brands / barbell content / one longform→fan-out / owned vs rented audience / measured impact）；掌象AI（FirstLightClaw，`zhangxiang.com`）作为 AGE 对外 SaaS 版本的获客案例。
+
+**Commit anchor**: **pending**（Status=Proposed；承载本决策包的 liye_os PR 尚未开）。post-squash merge 后回填。
+
+---
+
+## Context
+
+UGE（User Growth Engine）是拟接入 LiYe Systems 的**新增 Layer-2 域引擎**，与 AGE（亚马逊广告）、chaming（域名投资）平行——继二者之后**第 3 个 Layer-2 引擎**（勿与「第 4 个 `source_system` enum value」混淆：`source_system` 现有 3 值 `amazon-growth-engine / chaming / loamwise`，其中 loamwise 是 Layer-1；UGE 加入使其成第 4 值，见 N-2）。它把「用户增长 / 内容运营」自动化为一个受治理的域引擎，**北极星 = 掌象AI（`zhangxiang.com`，AGE 的对外 SaaS 版本）的获客**。
+
+三点现实迫使「先登记、先钉边界」，而非直接建 repo：
+
+1. **双平面物理分离**：UGE 在**控制面本机（LiYe main Mac）构建与治理**，但**执行在独立 Mac mini（Hands，跑 openclaw + codex + claude code）**。ADR-001（N-1）只区分了「控制面 vs 域引擎」两个逻辑角色，未处理「执行发生在另一台物理机」这一维度。不先钉死这条边界，后续 Hands 代码会与控制面职责混淆。
+2. **自动化的「两个世界」**（以下平台能力与法规均为 **operating assumption，Rung 1 前须 live-probe / 官方来源 pin**，不作既成事实）：YouTube + 自托管 blog 有官方 API、假定可全自动；抖音（API 代发但假定撞反同质化红线）/ 视频号（假定无发布 API）/ 小红书（假定发布须真机扫码、多账号同 Wi-Fi 降权）+ 各平台**直播** = 人工门。AI 内容标注合规（含各地生效日期）由 compliance guard 与人工发布环节双重负责。不先钉死「哪些可安全自动、哪些必须人工」，引擎会越界。
+3. **北极星当前不可度量**：目标是 `attributed_qualified_signup`（**归因合格注册**，非 raw signup）。但 `zhangxiang.com` 联系入口是纯 mailto、kuachu.com CTA 是硬编码 affiliate 直链——两处都不落 lead/attribution event（详见 §Decision-4 与 Downstream Attribution Blocker）。不先把北极星定义与度量前提钉死，引擎会优化一个测不准的目标。
+
+## Decision
+
+### D1. 登记 UGE 为 Layer-2 域引擎，成熟度 **D0（Proposed）**，write_capability = **none**
+
+UGE 遵守 engine_manifest 协议（N-3）、通过 loamwise 调度（目标态）、在用户增长领域产出 **domain truth**（内容计划 / 渠道排期 / 增长 verdict）。**当前不创建 manifest**（D0=Standalone，未注册协议），故登记为 D0(Proposed)。SYSTEMS.md 提议新增两行（本决策包 PR1 落地，**无 schema 变更**）：
+
+- Codebase Registry：
+  `| user-growth-engine | 2 | 用户增长引擎（掌象AI 获客） | loamwise (目标态) | — | D0 (Proposed) | — |`
+- 当前状态：
+  `| UGE | D0 (Proposed) | none | 内容/渠道增长；执行在独立 Mac mini Hands；两门 closed；北极星=attributed_qualified_signup |`
+
+### D2. 双平面边界（在 ADR-001 之上新增「Hands」物理维度）
+
+| 角色 | 物理位置 | 拥有 | 禁止 |
+|------|----------|------|------|
+| **控制面** LiYe OS | main Mac | 调度 / 学习流水线 / 晋升·漂移·回滚治理 / 投递 / 计量 / **派发已批准的写意图给 Hands** | — |
+| **UGE 域引擎** | （逻辑，随控制面 build/治理） | 纯函数 playbooks：inputs→verdict + 内容/渠道计划 + growth 判定；声明 write_capability | 自行调度 / 学习治理 / 读写 OS 状态（承 ADR-001） |
+| **UGE-Hands** 执行面 | 独立 Mac mini | 在 GuardChain/WriteGate/KillSwitch 下**实际执行**已批准写（发布内容、改渠道活动）；本地解析 `cred://` | **不自行决策该不该写**（决策在引擎/控制面）；平台明文密钥**不跨线抵达**（承 N-4 凭证中介） |
+
+**关键澄清**：UGE-the-engine 仍是 ADR-001 意义上的纯函数 domain-truth 生产者；「写」是一个**独立受治理的执行面（Hands）**行为，由控制面派发、Hands 执行，**不是引擎自己调度自己去写**。三者职责不可混。
+
+### D3. 资产范围（四阵地）· 自动化两个世界 · 资源配比
+
+- **四阵地**：(A) 掌象官方账号（抖音/视频号/小红书/YouTube/官方 blog）；(B) 杨过跨境个人 IP（同渠道 + 个人 blog）；(C) kuachu.com（跨境出海百科 wiki，LiYe autosite）；北极星落点 = 掌象AI SaaS（`zhangxiang.com`）。
+- **自动化边界（两个世界）**：
+  - **可全自动**（有官方 API）：YouTube、自托管 blog（官方/个人）、kuachu 内容与 CTA。
+  - **人工门**（引擎只产计划/草稿，人工执行）：抖音（反同质化红线）、视频号（无发布 API）、小红书（真机扫码 + 多账号降权）、**所有平台直播**。
+  - **AI 内容标注合规**：**可全自动渠道（safe-write）也须过 compliance guard**（自动标注 + 平台规则校验），而非仅依赖人工发布环节；人工门渠道由人工 + guard 双重负责。具体法规日期/规则为 operating assumption，Rung 1 前 pin 官方来源。
+- **资源配比**：**60 / 25 / 15**（杨过跨境个人 IP / kuachu / 掌象官方 + Blog）。
+- **内容范式**（承 a16z S-1）：barbell content；每周 1 篇 longform → 多平台 fan-out；signal 来自人（个人 IP）非品牌；owned（blog/站）优先于 rented（平台）。
+
+### D4. 门控阶梯（两门 closed，deny-by-default，逐级开）
+
+- **两门**（承 GHL 双门模型）初始 **全 closed**：manifest v2（`capabilities[].status=placeholder` + `runtime_gates[].default_state=closed`）与 learning_sources.yaml。**激活 = 物理编辑 manifest 文件**（status placeholder→active + default_state closed→open + `write_capability_effective` none→提升），**而非仅翻 env var**——gate 可为 `kind=env_var`，但 manifest 内的 `default_state`/`status`/`write_capability_effective` 才是权威 fail-closed 开关（未配置时按 default_state=closed）。
+- **write_capability_declared = write_capability_effective = none**（初始）；任何写先走 shadow（WriteGate shadow-first），人工/BusinessSuccess 验证后才逐级 `observe → recommend → execute_limited`（承 ADR-001 3-tier）。
+- **Rung 阶梯**（登记本 ADR，实现后置）：
+  - **Rung 0**：scaffold UGE repo + placeholder engine_manifest v2（`write_capability_declared/effective=none`，两门 closed）+ vendored fact-schema copy（byte-pin + freshness，承 N-2 §Cross-repo 未来第 3 份）。
+  - **Rung 1**：read-only metrics（各阵地只读指标）+ content_fanout **draft**（只产计划，不发）。
+  - **Rung 2**：fact emit（growth_outcome / write_outcome 进 GHL 流，仍不写外部平台）。
+  - **Rung 3**：safe write（先可全自动世界：YouTube/blog/kuachu，shadow→execute_limited）。
+- **北极星 = `attributed_qualified_signup`**（非 raw signup）。qualified 判定字段形状由 N-2 taxonomy ADR 的 summary profile 钉死；**判定规则**在 UGE SPEC 定义。**度量前提 = Attribution Blocker**（见 Downstream）：北极星在 lead/attribution event 落地前**不可度量**，故 Rung 2 的 growth fact 有真数据依赖 PR3。
+
+### D5. 只读参考边界（同事产品 / 上游 fork）
+
+- 掌象AI 代码 = **FirstLightClaw**（同事拥有、负责迭代）：**只读参考，本地改动永不推送、不改其业务逻辑**。北极星的 lead ingest **不改同事代码**——只在 `zhangxiang.com` form **旁**挂 fire-and-forget event，UGE lead-ingest job 是 emit 主体（承 N-2 impedance 解决）。
+- 承 SYSTEMS.md Fork 纪律：上游 fork 只作模式基准，不搬模块。
+
+## Non-scope（本 ADR 明确不做，防 scope 蔓延）
+
+- ❌ 不创建 engine_manifest.yaml 实例（Rung 0 / PR2 之后）
+- ❌ 不编辑 fact-schema enum（`source_system`/`artifact_type` 的实际 carve-in = PR2）
+- ❌ 不写 Hands 执行代码、不定 KillSwitch/WriteGate/TrustBoundary 细则（后续 Hands-execution ADR）
+- ❌ 不定具体内容日历 / KPI 数值 / playbook 实现（UGE SPEC）
+- ❌ **PR1 不碰任何运行代码**（zhangxiang / FirstLightClaw / kuachu）。未来 PR3/PR4 是**受控的 instrumentation / router 改动**（zhangxiang form 旁挂 fire-and-forget event、kuachu CTA 迁 Link Router），**均不改 FirstLightClaw 业务逻辑、不改同事产品行为**（承 D5 只读边界）。
+
+## Consequences
+
+**优势**：UGE 边界与门控在写任何代码前钉死；double-plane 职责不混；北极星以可度量的 `attributed_qualified_signup` 定义，防优化虚荣指标；两门 closed + Rung 阶梯保证 deny-by-default、可回滚。
+**代价**：多一层 Hands 物理边界 → 需凭证中介 + Wake/Resume + GuardChain 三套已有模式协同；北极星度量被 Attribution Blocker 阻塞，Rung 2 真数据需等 PR3。
+
+## Downstream（决策包与 PR 排序；本 ADR 之外）
+
+- **PR1 `uge-contracts-proposed`**（本决策包）：`ADR-UGE-Fact-Taxonomy.md` + 本 ADR + SYSTEMS.md 两行登记（Proposed/D0）。**无 schema enum 编辑。**
+- **PR2 `uge-fact-schema-carve-in`**：`source_system +user-growth-engine`、`artifact_type +growth_outcome`（event+record 双改）+ fixtures + importer/validator 测试（承 N-2 §DoD，守 21）。**须在本 ADR + taxonomy ADR review 通过后。**
+- **PR3 `uge-lead-ingest-attribution`**（Attribution Blocker）：zhangxiang form 旁挂 lead event + UGE-owned ingest + PII redaction + qualified summary validator。使北极星可度量。
+- **PR4 `kuachu-router-attribution`**：kuachu CTA 从硬编码 affiliate 直链迁到 Link Router（mint click_id）。
+- 之后：Rung 0 scaffold → Rung 1 read-only + fanout draft → Rung 2 fact emit → Rung 3 safe write。
+
+## Rejected alternatives
+
+1. **UGE 作为 Layer-3 产品线** —— UGE 产 domain truth（增长判定）并被 loamwise 调度，是引擎不是产品；掌象AI/kuachu 才是产品。**否决**。
+2. **执行放控制面本机（不分 Hands）** —— 违背用户既定的双平面部署；且平台自动化/直播/真机操作需独立执行节点隔离 blast radius。**否决**。
+3. **「能自动就全自动」（含抖音/小红书/直播）** —— 撞平台反同质化/降权红线与 AI 标注法；风险不对称。**否决**：可全自动世界（YouTube/blog/kuachu）先行，风险世界人工门。
+4. **北极星 = raw signup** —— 可被刷量/低质注册污染，非商业价值。**否决**：定义为 `attributed_qualified_signup`。
+5. **先 scaffold repo 再补契约** —— 会让每条 wiring 各自发明 artifact_type/边界，污染 identity 空间与职责边界。**否决**：contract-first，先登记后建。
+6. **本 ADR 同时改 fact-schema enum** —— 把「决策包」与「contract mutation 包」混进一个 PR，回滚粒度差、review 焦点散。**否决**：schema carve-in 拆到 PR2，本 PR 保持纯决策。

--- a/_meta/portfolio/SYSTEMS.md
+++ b/_meta/portfolio/SYSTEMS.md
@@ -34,6 +34,7 @@
 | loamwise | 1 | 编排中间层 | liye_os (contracts) | domain engines | — | Y |
 | amazon-growth-engine | 2 | 亚马逊广告引擎 | loamwise (目标态) | — | D0 | Y |
 | chaming | 2 | 域名投资管理 | loamwise (目标态) | — | D0 | — |
+| user-growth-engine | 2 | 用户增长引擎（掌象AI 获客） | loamwise (目标态) | — | D0 (Proposed) | — |
 | silkbay | 3 | Medusa v2 后端 Hub | — | storefront-kit, sf-* | — | Y |
 | storefronts | 3 | 品牌店铺前端集合 | silkbay, storefront-kit | — | — | Y |
 | kits | 3 | 共享包 (attribution-kit) | — | storefronts, growth-hub | — | — |
@@ -95,13 +96,14 @@ attribution-kit → growth-hub     npm: @loudmirror/attribution-kit
 |--------|--------|-----------------|------|
 | AGE | D0 | limited (internal) | 有独立治理框架，可写 bids/keywords/budget |
 | Chaming | D0 | none | 只读分析 + 人工执行 |
+| UGE | D0 (Proposed) | none | 内容/渠道增长；执行在独立 Mac mini Hands；两门 closed；北极星=attributed_qualified_signup（见 ADR-User-Growth-Engine） |
 
 ### Engine 接入清单
 
 **D0 → D1 (Registered):**
-- [ ] 创建 engine_manifest.yaml 实例（参照 `liye_os/_meta/contracts/engine/engine_manifest.schema.yaml`）
+- [ ] 创建 engine_manifest.yaml 实例（**新 engine 参照 `engine_manifest.schema.v2.yaml`**：`schema_version: "2.0"` + `write_capability_declared`/`write_capability_effective` + `capabilities[]` + `runtime_gates[]`；旧无 `schema_version` 的 manifest 才 fallback `engine_manifest.schema.yaml` v1）
 - [ ] 声明 playbooks + required_permissions
-- [ ] 声明 data_sources + write_capability 级别
+- [ ] 声明 data_sources + `write_capability_declared`/`write_capability_effective` 级别
 - [ ] 通过 schema 验证
 
 **D1 → D2 (Dispatchable):**


### PR DESCRIPTION
## What

PR1 of the User Growth Engine (UGE) landing sequence: a **pure decision package**. Two `Proposed` ADRs + SYSTEMS.md registration. **No schema mutation** — contracts gate stays **21**; enum carve-in is deferred to PR2.

## Contents

- **`ADR-User-Growth-Engine.md`** (Proposed) — register UGE as the **3rd Layer-2 engine** (after AGE, chaming; 4th `source_system` enum value since loamwise is Layer-1), maturity **D0**, `write_capability none`. Encodes the double-plane boundary (governed/built on control-plane main Mac; executed on a separate Mac mini "Hands"), the Rung 0–3 gating ladder, and the read-only reference boundary vs the colleague's zhangxiang/FirstLightClaw code.
- **`ADR-UGE-Fact-Taxonomy.md`** (Proposed) — **Option C**: content/channel actions reuse existing `write_outcome`; growth business outcomes get **one generic `growth_outcome`**; add `source_system: user-growth-engine`. Both enum-only edits (gate stays 21). Cross-repo edit sequence + non-negotiable DoD are explicitly scoped to **PR2** (the schema carve-in), not this PR. PII red line: raw contact values live only in a UGE private lead store/broker — never in the fact artifact, event sidecar, or audit cleartext; `raw_payload_ref` may only point to an already-redacted artifact.
- **`SYSTEMS.md`** — Codebase Registry + status rows (UGE = D0 Proposed, write none); the D0→D1 checklist now references `engine_manifest.schema.v2.yaml` (v1 is fallback only for manifests without `schema_version`).

## Scope discipline

- `contracts/` untouched → **no new sealed schema, gate 21 preserved**.
- No running code touched. PR3/PR4 (downstream) are controlled instrumentation/router work, not changes to the colleague's business logic.
- Both ADRs are `Status: Proposed` — this PR registers the decision, it does not activate anything (both runtime gates + learning source remain closed by design).

## PR sequence (for reviewer context)

PR1 (this) `uge-contracts-proposed` → PR2 `uge-fact-schema-carve-in` (event+record enum + fixtures + real-importer DoD; **precondition = these two ADRs reviewed, not the SPEC**) → PR3 `uge-lead-ingest-attribution` → PR4 `kuachu-router-attribution`.

## Review notes

Two codex review rounds applied; load-bearing facts verified against the repo (v2 schema fields exist; importer `containsNativeNumber` only guards native JSON number, not bool; `learning_sources.yaml` is a single control-plane registry). Latest round hardened the PII boundary, pointed the D0→D1 checklist at v2, and disambiguated the Cross-repo/DoD text so a reviewer does not mistake PR1 for needing PR2's fixture/importer test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)