### PR TITLE
feat(contracts): PR2 UGE fact-schema carve-in — growth_outcome + user-growth-engine

### DIFF
--- a/.claude/scripts/learning/tests/import_facts_growth_outcome.test.mjs
+++ b/.claude/scripts/learning/tests/import_facts_growth_outcome.test.mjs
@@ -1,0 +1,185 @@
+/**
+ * artifact_type: growth_outcome + source_system: user-growth-engine — positive + negative
+ * coverage via the REAL importer path.
+ * Doctrine: _meta/adr/ADR-UGE-Fact-Taxonomy.md (Accepted 2026-07-02, anchor e62e82e),
+ * mirroring the write_outcome precedent (_meta/adr/ADR-Learning-Fact-Artifact-Type-Taxonomy.md).
+ *
+ * Operator non-negotiable DoD: prove a growth_outcome event with
+ * raw_payload_summary.action_kind=growth.signup.qualified + string-encoded qualified-signup
+ * profile passes ALL THREE importer validation stages end-to-end —
+ *   S1  event schema      (import_facts.mjs:402)
+ *   S1b numeric-not-string (import_facts.mjs:411 — string-encode-all)
+ *   S2  record schema     (import_facts.mjs:489)
+ * via importFacts() (NOT a re-compiled ajv), so it tracks the importer's own validators.
+ *
+ * The positive test is the SPLIT-FAILURE SENTINEL: if the record-schema copies
+ * (fact_run_outcome_record_v1: source_system + artifact_type enums) are NOT widened in
+ * lockstep with the event schema, importFacts rejects at record-validate (rejects=1,
+ * new_records=0) and this test fails — catching the "event passed, record copy didn't" hazard.
+ *
+ * impedance solution (ADR §impedance): a business signup has no natural run identity, so the
+ * UGE lead-ingest job IS the run — playbook_ref=lead_ingest, step_id=ingest, artifact_path =
+ * the signup record's canonical path, trace_id = the ingest run id.
+ *
+ * The synthetic sidecar is DERIVED from the real golden_sidecar.json (a true AGE emit_fact.py
+ * output) and resealed (identity then content) so it stays internally consistent through the
+ * importer's recompute gates.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+
+import { importFacts, computeIdentityKey } from '../import_facts.mjs';
+import { makeStringNode, makeObjectNode } from '../canonical_json.mjs';
+import {
+  goldenAst, withField, reseal, emit, numNode,
+  identityHex, tmpEngineRepo, tmpRoot, writeRegistry, placeSidecar, countLines,
+} from './_helpers.mjs';
+
+// The artifact raw_payload_ref resolves to: ONLY non-PII fields, contact channel scrubbed.
+// Original contact values live in the UGE private lead store/broker — never in this artifact,
+// the event sidecar, or the audit record (ADR-UGE-Fact-Taxonomy §Q7). raw_payload_hash binds
+// the emitted fact to this exact redacted content.
+const REDACTED_PAYLOAD = {
+  seller_category: 'home_kitchen',
+  monthly_gmv_band: '10k-50k',
+  is_amazon_seller: 'true',
+  submitted_asin: 'B0C5Q8L7FP',
+  contactable: 'true',
+  contact_channel: '[REDACTED]',
+  attribution_click_id: 'clk_abc123',
+  utm_source: 'youtube',
+  redaction_status: 'redacted',
+};
+const REDACTED_REF = 'out/facts/growth/signup_redacted.json';
+const REDACTED_TEXT = JSON.stringify(REDACTED_PAYLOAD, null, 2) + '\n';
+const REDACTED_HASH = 'sha256:' + createHash('sha256').update(REDACTED_TEXT).digest('hex');
+
+/** Derive a self-consistent growth_outcome event AST from the golden sidecar. */
+function buildGrowthOutcomeAst({ nativeGmvBand = false, piiInSummary = false, traceId = 'go-default' } = {}) {
+  let ast = goldenAst();
+  ast = withField(ast, 'artifact_type', makeStringNode('growth_outcome'));
+  // UGE engine registration — the new source_system enum value under test.
+  ast = withField(ast, 'source_system', makeStringNode('user-growth-engine'));
+  ast = withField(ast, 'source_repo', makeStringNode('user-growth-engine'));
+  ast = withField(ast, 'source_worktree_id', makeStringNode('user-growth-engine'));
+  // impedance: the UGE lead-ingest job IS the run.
+  ast = withField(ast, 'playbook_ref', makeStringNode('lead_ingest'));
+  ast = withField(ast, 'step_id', makeStringNode('ingest'));
+  ast = withField(ast, 'artifact_path', makeStringNode('out/facts/growth/signup.json'));
+  // PII red line: raw contact never in the fact; ref points to an already-redacted artifact,
+  // and raw_payload_hash binds the fact to that redacted content (deref integrity).
+  ast = withField(ast, 'raw_payload_ref', makeStringNode(REDACTED_REF));
+  ast = withField(ast, 'raw_payload_hash', makeStringNode(REDACTED_HASH));
+  ast = withField(ast, 'redaction_status', makeStringNode('redacted'));
+  // distinct trace_id per test → distinct event_identity_key (trace_id ∈ the 8-key identity set;
+  // raw_payload_summary is NOT, so without this the cases would collide on one identity).
+  ast = withField(ast, 'trace_id', makeStringNode(traceId));
+  // qualified-signup profile — ALL string-encoded (S1b); NO PII contact value, only contactable bool-string.
+  const gmvBand = nativeGmvBand ? numNode(25000) : makeStringNode('10k-50k');
+  const entries = [
+    ['action_kind', makeStringNode('growth.signup.qualified')],
+    ['seller_category', makeStringNode('home_kitchen')],
+    ['monthly_gmv_band', gmvBand],
+    ['is_amazon_seller', makeStringNode('true')],
+    ['submitted_asin', makeStringNode('B0C5Q8L7FP')],
+    ['contactable', makeStringNode('true')],
+    ['attribution_click_id', makeStringNode('clk_abc123')],
+    ['utm_source', makeStringNode('youtube')],
+  ];
+  // boundary probe only: a string-encoded PII value the importer does NOT gate (see PII boundary test).
+  if (piiInSummary) entries.push(['contact_email', makeStringNode('seller@example.com')]);
+  ast = withField(ast, 'raw_payload_summary', makeObjectNode(entries));
+  // identity (8-key) resealed first, then content (over the dict that already contains identity).
+  return reseal(ast, { identity: true, content: true });
+}
+
+function setup(opts) {
+  const ast = buildGrowthOutcomeAst(opts);
+  const identity = computeIdentityKey(ast);
+  const eng = tmpEngineRepo();
+  placeSidecar(eng, '2026-07-02', identityHex(identity) + '.json', emit(ast));
+  // The redacted artifact raw_payload_ref resolves to. Placed under out/facts/growth/ — NOT a
+  // YYYY-MM-DD date dir, so the importer's date-dir filter (import_facts.mjs:574,
+  // /^\d{4}-\d{2}-\d{2}$/) never scans it as a sidecar. Deref is a fixture-level proof, not importer work.
+  const redactedPath = placeSidecar(eng, 'growth', 'signup_redacted.json', REDACTED_TEXT);
+  const root = tmpRoot();
+  const reg = writeRegistry(root, { sourceId: 'user-growth-engine' });
+  const recordsOut = join(root, 'records.jsonl');
+  return {
+    ast, identity, recordsOut, redactedPath,
+    common: { source: 'user-growth-engine', engineRepo: eng, rootDir: root, recordsOut, registryPath: reg },
+  };
+}
+
+test('growth_outcome positive: event(S1) + S1b string-profile + record(S2) all pass via real importer', () => {
+  const { common, recordsOut, identity } = setup({ traceId: 'go-positive' });
+  const r = importFacts({ ...common, mode: 'live' });
+  assert.equal(r.rejects, 0, `unexpected rejects: ${JSON.stringify(r.per_reject)}`);
+  assert.equal(r.new_records, 1);
+  assert.equal(countLines(recordsOut), 1);
+  const rec = JSON.parse(readFileSync(recordsOut, 'utf-8').trim());
+  assert.equal(rec.artifact_type, 'growth_outcome');
+  assert.equal(rec.source_system, 'user-growth-engine');           // new enum value survives (event + record)
+  assert.equal(rec.raw_payload_summary.action_kind, 'growth.signup.qualified');
+  assert.equal(rec.raw_payload_summary.monthly_gmv_band, '10k-50k'); // string-encoded survives
+  assert.equal(rec.raw_payload_summary.contactable, 'true');
+  assert.equal(rec.redaction_status, 'redacted');
+  // PII red line: no raw contact value leaked into the summary (only contactable bool-string).
+  const sumKeys = Object.keys(rec.raw_payload_summary);
+  assert.ok(!sumKeys.some((k) => /email|phone|wechat/i.test(k)), `summary carries a PII contact key: ${sumKeys}`);
+  assert.equal(rec.schema_version, '1.0.0');                         // additive: const unchanged
+  assert.equal(rec.event_identity_key, identity);
+});
+
+test('growth_outcome negative control: native-number monthly_gmv_band → S1b NUMERIC_NOT_STRING reject', () => {
+  const { common, recordsOut } = setup({ nativeGmvBand: true, traceId: 'go-negative' });
+  const r = importFacts({ ...common, mode: 'live' });
+  assert.equal(r.new_records, 0);
+  assert.equal(r.rejects, 1);
+  assert.equal(r.per_reject[0].reason, 'NUMERIC_NOT_STRING');
+  assert.equal(countLines(recordsOut), 0);
+});
+
+test('growth_outcome dry_run: NEW counted, ZERO disk writes', () => {
+  const { common, recordsOut } = setup({ traceId: 'go-dryrun' });
+  const r = importFacts({ ...common, mode: 'dry_run' });
+  assert.equal(r.new_records, 1);
+  assert.equal(r.rejects, 0);
+  assert.equal(existsSync(recordsOut), false, 'dry_run MUST NOT write records.jsonl');
+});
+
+test('growth_outcome PII boundary: importer does NOT gate a string-encoded PII value (enforcement = UGE profile validator, NOT S1b)', () => {
+  // Documents the layer boundary (mirrors the bool caveat in ADR-UGE-Fact-Taxonomy §DoD):
+  // S1b only rejects native numbers, and NO importer stage inspects for PII, so a string email
+  // passes. PII exclusion MUST be enforced upstream by the UGE emitter/profile validator — this
+  // PR intentionally adds NO importer-level PII gate.
+  const { common } = setup({ piiInSummary: true, traceId: 'go-pii-boundary' });
+  const r = importFacts({ ...common, mode: 'live' });
+  assert.equal(r.rejects, 0, 'importer has no PII gate — a string-encoded PII value is not rejected here');
+  assert.equal(r.new_records, 1);
+});
+
+test('growth_outcome PII red line: raw_payload_ref resolves to a redacted artifact with NO cleartext contact', () => {
+  // Completes the ADR §DoD PII proof: not just "summary has no PII key" — the artifact the fact
+  // references is itself redacted, and raw_payload_hash pins the fact to that exact clean content.
+  const { common, recordsOut, redactedPath } = setup({ traceId: 'go-redaction' });
+  const r = importFacts({ ...common, mode: 'live' });
+  assert.equal(r.rejects, 0, `unexpected rejects: ${JSON.stringify(r.per_reject)}`);
+  assert.equal(r.new_records, 1);
+  // 1) the artifact raw_payload_ref points to actually exists on disk
+  assert.ok(existsSync(redactedPath), 'redacted artifact must exist at raw_payload_ref');
+  const redactedText = readFileSync(redactedPath, 'utf-8');
+  // 2) dereferenced content carries NO cleartext contact (email / phone / wechat)
+  assert.ok(!redactedText.includes('seller@example.com'), 'redacted artifact leaks the seed email');
+  assert.ok(!/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/.test(redactedText), 'redacted artifact contains an email address');
+  assert.ok(!/\d{7,}/.test(redactedText), 'redacted artifact contains a phone-like long digit run');
+  assert.ok(!/wechat|weixin/i.test(redactedText), 'redacted artifact references a wechat handle');
+  // 3) raw_payload_hash in the emitted record == sha256 of the redacted artifact (deref integrity)
+  const rec = JSON.parse(readFileSync(recordsOut, 'utf-8').trim());
+  assert.equal(rec.raw_payload_hash, REDACTED_HASH);
+  const actual = 'sha256:' + createHash('sha256').update(redactedText).digest('hex');
+  assert.equal(actual, rec.raw_payload_hash, 'raw_payload_hash must equal sha256 of the redacted artifact');
+});

--- a/_meta/adr/ADR-UGE-Fact-Taxonomy.md
+++ b/_meta/adr/ADR-UGE-Fact-Taxonomy.md
@@ -10,7 +10,7 @@ is_bghs_doctrine: no
 
 > 文件名采非数字前缀（`ADR-UGE-Fact-Taxonomy.md`）以进入 CI-wired BGHS frontmatter gate（`adr-bghs-gate.yml`）的有效扫描域，对齐 write_outcome 先例。
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-01
 **Decision Makers**: LiYe
 **SSOT**: 本文件（UGE fact artifact_type / source_system 分类教条）；schema SSOT = `_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml`（canonical）；UGE 端为未来 byte-pinned vendored copy（UGE repo scaffold 时才建，见 §Cross-repo edit sequence）。
@@ -30,7 +30,7 @@ is_bghs_doctrine: no
 - N-5（Normative，继承自先例 N-5）: `_meta/contracts/scripts/validate-contracts.mjs` —— schema-pass 计数 over 显式 `schemaFiles[]` 数组；全局 Summary pass 计数当前为 **21**。本决策**仅编辑既有数组成员 enum 值、不新增 `schemaFiles[]` entry** → schema-pass 与全局总数**零变化（守 21，无 carve-out）**。
 - S-1（Supporting）: `scratchpad/uge-fact-taxonomy-spike.md`（本 ADR 的 time-boxed spike 决策交付物：决策表 A/B/C/D + 推荐 C + schema-diff 风险 R1-R4 + 本骨架）；write_outcome 先例 micro-discuss `wf_0b114a29`（`generic_is_lossless=true / would_break_importer=false`）。
 
-**Commit anchor**: **pending**（Status=Proposed；承载本 ADR 的 liye_os PR 已开、尚未 merge；frontmatter 不预编 SHA）。对齐 ADR-GHL 教条「post-squash merge commit 为 durable anchor；无 pre-squash SHA 具规范性」——PR squash-merge 后回填。
+**Commit anchor**: **`e62e82e`**（liye_os PR #197 squash-merge，2026-07-02；`liyecom/liye-ai` origin/main）。对齐 ADR-GHL 教条「post-squash merge commit 为 durable anchor；无 pre-squash SHA 具规范性」。
 
 ---
 

--- a/_meta/adr/ADR-UGE-Fact-Taxonomy.md
+++ b/_meta/adr/ADR-UGE-Fact-Taxonomy.md
@@ -11,6 +11,7 @@ is_bghs_doctrine: no
 > 文件名采非数字前缀（`ADR-UGE-Fact-Taxonomy.md`）以进入 CI-wired BGHS frontmatter gate（`adr-bghs-gate.yml`）的有效扫描域，对齐 write_outcome 先例。
 
 **Status**: Accepted
+**Accepted-Date**: 2026-07-02
 **Date**: 2026-07-01
 **Decision Makers**: LiYe
 **SSOT**: 本文件（UGE fact artifact_type / source_system 分类教条）；schema SSOT = `_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml`（canonical）；UGE 端为未来 byte-pinned vendored copy（UGE repo scaffold 时才建，见 §Cross-repo edit sequence）。

--- a/_meta/adr/ADR-User-Growth-Engine.md
+++ b/_meta/adr/ADR-User-Growth-Engine.md
@@ -11,19 +11,19 @@ is_bghs_doctrine: no
 > 文件名采非数字前缀以进入 CI-wired BGHS frontmatter gate（`adr-bghs-gate.yml`）有效扫描域。
 > **本 ADR 只做「登记 / 边界 / 门控」，不塞任何实现**：无 engine_manifest 文件、无 schema enum 编辑、无 Hands 代码、无 content。实现全部后置（见 §Non-scope 与 §Downstream 的 PR 排序）。
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-07-01
 **Decision Makers**: LiYe
 **SSOT**: 本文件（UGE 引擎定位 / 双平面边界 / 门控阶梯的架构决策）；生态分层/成熟度以 `_meta/portfolio/SYSTEMS.md` 为准（本 ADR 提议其新增登记行，见 §Decision-1）。
 **References**:
 - N-1（Normative）: `_meta/adr/ADR-001-control-plane-vs-domain-engine.md`（Accepted 2026-02-08）—— 控制平面（LiYe OS：调度/学习/治理/投递/计量）vs 域引擎（纯函数 playbooks，**禁自行调度/学习治理/投递/读写 OS 状态**，消费 learned bundle）的边界宪法。本 ADR **在其上新增一维**：UGE 的**执行物理发生在独立 Mac mini（Hands）**，而非控制面本机。
-- N-2（Normative）: `_meta/adr/ADR-UGE-Fact-Taxonomy.md`（Proposed，本决策包同 PR）—— UGE 的 fact 输出形状（content/channel→`write_outcome`；growth→`growth_outcome`；`source_system: user-growth-engine`）。本 ADR 引用其为 UGE→GHL learning 流的契约，解决 `source_system` 词表不 orphan 的 sequencing。
+- N-2（Normative）: `_meta/adr/ADR-UGE-Fact-Taxonomy.md`（Accepted 2026-07-02，anchor `e62e82e`；PR1 同批 merged）—— UGE 的 fact 输出形状（content/channel→`write_outcome`；growth→`growth_outcome`；`source_system: user-growth-engine`）。本 ADR 引用其为 UGE→GHL learning 流的契约，解决 `source_system` 词表不 orphan 的 sequencing。
 - N-3（Normative）: `_meta/contracts/engine/engine_manifest.schema.v2.yaml`（**当前活动版**，`schema_version: "2.0"`；未声明 schema_version 的旧 manifest 才 fallback 到 v1 `engine_manifest.schema.yaml`）—— D0→D1 登记的目标契约。UGE 的 placeholder manifest 须用 **v2 字段**：`write_capability_declared` + `write_capability_effective`（初始皆 `none`；v2.0 期 legacy `write_capability` 仅 deprecated_but_accepted）、`capabilities[]`（`status: placeholder`）、`runtime_gates[]`（`default_state: closed` + `evidence_required_for_open`）、`playbooks` + `data_sources`。**本 ADR 不创建 manifest 实例**（那是 Rung 0，PR2 之后）；仅声明 UGE 将来按 v2 协议注册。
 - N-4（Normative，Hands 治理模式，引用不重述）: `_meta/adr/ADR-Credential-Mediation.md`（凭证中介：平台/provider 明文密钥**不跨线抵达 Hands**，控制面只派发 `cred://` 引用，Hands 本地解析）、`_meta/adr/ADR-AGE-Wake-Resume.md`（Wake/Resume：append-only event stream 保证跨睡眠/重启不丢不重）、`_meta/adr/ADR-Loamwise-Guard-Content-Security.md`（内容写前 GuardChain）。UGE-Hands **复用**这些模式；KillSwitch(position-0) / WriteGate(shadow-first, deny-by-default) / TrustBoundaryDecl 等 Hands 执行细则由**后续独立 Hands-execution ADR** 正式钉死，不在本 ADR 展开。
 - N-5（Normative）: `_meta/portfolio/SYSTEMS.md` —— Codebase Registry（列 `Codebase|Layer|Role|Upstream|Downstream|Maturity|CLAUDE.md`）+ Domain 成熟度模型（D0 Standalone / D1 Registered / D2 Dispatchable / D3 Governed）+ 当前状态表（AGE/Chaming 现均 D0）。
 - S-1（Supporting）: a16z「New Media, One Year In」框架（signal from people not brands / barbell content / one longform→fan-out / owned vs rented audience / measured impact）；掌象AI（FirstLightClaw，`zhangxiang.com`）作为 AGE 对外 SaaS 版本的获客案例。
 
-**Commit anchor**: **pending**（Status=Proposed；承载本决策包的 liye_os PR 已开、尚未 merge）。post-squash merge 后回填。
+**Commit anchor**: **`e62e82e`**（liye_os PR #197 squash-merge，2026-07-02；`liyecom/liye-ai` origin/main）。
 
 ---
 

--- a/_meta/adr/ADR-User-Growth-Engine.md
+++ b/_meta/adr/ADR-User-Growth-Engine.md
@@ -12,6 +12,7 @@ is_bghs_doctrine: no
 > **本 ADR 只做「登记 / 边界 / 门控」，不塞任何实现**：无 engine_manifest 文件、无 schema enum 编辑、无 Hands 代码、无 content。实现全部后置（见 §Non-scope 与 §Downstream 的 PR 排序）。
 
 **Status**: Accepted
+**Accepted-Date**: 2026-07-02
 **Date**: 2026-07-01
 **Decision Makers**: LiYe
 **SSOT**: 本文件（UGE 引擎定位 / 双平面边界 / 门控阶梯的架构决策）；生态分层/成熟度以 `_meta/portfolio/SYSTEMS.md` 为准（本 ADR 提议其新增登记行，见 §Decision-1）。

--- a/_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml
+++ b/_meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml
@@ -1,8 +1,8 @@
 # Fact Run Outcome Event Contract v1.0.0
 # SSOT: _meta/contracts/learning/fact_run_outcome_event_v1.schema.yaml
 #
-# AGE 端 emit_fact.py (D-14) 写入的 source event。
-# 落点 (per EV2-I-01 date-sharded UTC log):
+# 引擎端 emit_fact.py (D-14) 写入的 source event（emit_fact.py 首见于 AGE；schema 泛化支持所有已登记引擎，如 user-growth-engine）。
+# 落点 (per EV2-I-01 date-sharded UTC log；路径按引擎 <source_repo>/out/facts/…，下以 AGE 为例):
 #   amazon-growth-engine/out/facts/<UTC_DATE_FROM_emitted_at>/fact_run_outcome_events.jsonl
 #   amazon-growth-engine/out/facts/<UTC_DATE_FROM_emitted_at>/<event_identity_key>.json (event sidecar)
 #
@@ -13,7 +13,7 @@
 $schema: "http://json-schema.org/draft-07/schema#"
 $id: "https://liye.com/contracts/learning/fact_run_outcome_event.v1"
 title: "Fact Run Outcome Event Schema"
-description: "AGE-emitted source event capturing one run outcome artifact. Importer wraps this into fact_run_outcome_record_v1."
+description: "Engine-emitted source event capturing one run outcome artifact (e.g. AGE amazon-growth-engine; also user-growth-engine and other registered engines). Importer wraps this into fact_run_outcome_record_v1."
 version: "1.0.0"
 type: object
 
@@ -52,6 +52,7 @@ properties:
       - amazon-growth-engine
       - chaming
       - loamwise
+      - user-growth-engine
     description: "Layer-2/Layer-1 engine identifier emitting the event"
 
   source_repo:
@@ -100,14 +101,19 @@ properties:
       - step_evaluation_instance
       - regression_replay_result
       - write_outcome
+      - growth_outcome
     description: |
-      Engine artifact category. Covers AGE evaluation / inference / replay artifacts AND
-      execution/write outcomes. write_outcome = a write/execution receipt mapped into a fact
-      (e.g. an APPLIED CAMPAIGN_BUDGET_UPDATE). The concrete action kind lives in
-      raw_payload_summary.action_kind — NOT a per-kind artifact_type value: artifact_type is one of the
-      8 locked event_identity_key inputs, so minting per-kind values would fork identity space.
+      Engine artifact category. Covers AGE evaluation / inference / replay artifacts,
+      execution/write outcomes, AND observed growth/business outcomes. write_outcome = a
+      write/execution receipt mapped into a fact (e.g. an APPLIED CAMPAIGN_BUDGET_UPDATE).
+      growth_outcome = an observed business result attributed to content/channel (signup /
+      lead / trial) — NOT an engine's own write action (that is write_outcome). The concrete
+      action kind lives in raw_payload_summary.action_kind — NOT a per-kind artifact_type value:
+      artifact_type is one of the 8 locked event_identity_key inputs, so minting per-kind values
+      would fork identity space.
       Governance decisions (PROMOTED / DEMOTED / lifecycle / trust_matrix) use governance_event_v1 (per N-2 B-04).
       Taxonomy doctrine + rationale: _meta/adr/ADR-Learning-Fact-Artifact-Type-Taxonomy.md
+      UGE growth taxonomy (growth_outcome + source_system user-growth-engine): _meta/adr/ADR-UGE-Fact-Taxonomy.md
 
   artifact_path:
     type: string

--- a/_meta/contracts/learning/fact_run_outcome_record_v1.schema.yaml
+++ b/_meta/contracts/learning/fact_run_outcome_record_v1.schema.yaml
@@ -72,6 +72,7 @@ properties:
       - amazon-growth-engine
       - chaming
       - loamwise
+      - user-growth-engine
 
   source_repo:
     type: string
@@ -105,12 +106,14 @@ properties:
     type: string
     # Kept in sync with fact_run_outcome_event_v1.schema.yaml (per the line-15 maintenance contract).
     # write_outcome added per _meta/adr/ADR-Learning-Fact-Artifact-Type-Taxonomy.md (2026-06-14).
+    # growth_outcome added per _meta/adr/ADR-UGE-Fact-Taxonomy.md (2026-07-02, anchor e62e82e).
     enum:
       - verification_json
       - policy_suggestions_json
       - step_evaluation_instance
       - regression_replay_result
       - write_outcome
+      - growth_outcome
 
   artifact_path:
     type: string


### PR DESCRIPTION
## What

PR2 of the UGE landing sequence: the **schema carve-in** that executes the decision in `ADR-UGE-Fact-Taxonomy` (Accepted 2026-07-02, anchor `e62e82e`, merged in #197). Additive **enum-only** edits — contracts gate stays **21**.

Depends on PR1 #197 (the two ADRs) — merged.

## Changes (5 files, +207/-13)

**Schema carve-in (event + record, in lockstep):**
- `fact_run_outcome_event_v1` + `fact_run_outcome_record_v1`: `source_system` enum `+user-growth-engine`; `artifact_type` enum `+growth_outcome` (2 values × 2 files = 4 enum edits).
- Event `artifact_type.description` generalized to cover **observed growth/business outcomes** (growth_outcome = a business result attributed to content/channel — signup/lead/trial — NOT an engine's own write action, which is write_outcome).
- Event header generalized from AGE-only to **engine-emitted** (AGE kept as the concrete example).

**ADR lifecycle (folded in per decision — no separate micro-PR):**
- `ADR-UGE-Fact-Taxonomy` + `ADR-User-Growth-Engine`: `Status: Proposed → Accepted`; `Commit anchor: pending → e62e82e`. Engine-ADR N-2 cross-ref to the taxonomy ADR updated to Accepted. (ADR lifecycle only — UGE stays D0 / write none / gates closed; activation is a separate axis.)

**DoD — `import_facts_growth_outcome.test.mjs` (5 tests, through the REAL importer, not a re-compiled ajv):**
1. **positive** — event(S1) + S1b string-profile + record(S2) all pass. This is the **split-failure sentinel**: if the record-schema enum copies aren't widened in lockstep, record-validate rejects and this test fails.
2. **native-number negative** — `monthly_gmv_band` as a native number → S1b `NUMERIC_NOT_STRING` reject.
3. **dry_run** — NEW counted, zero disk writes.
4. **PII layer boundary** — a string-encoded PII value is NOT rejected by the importer (documents that PII enforcement belongs to the UGE emitter/profile validator, not S1b — this PR adds no importer-level PII gate).
5. **PII red-line deref proof** — `raw_payload_ref` resolves to a redacted artifact that exists, carries no cleartext contact (email/phone/wechat), and whose sha256 equals the record's `raw_payload_hash`.

## Verification (local)

- `node --test .claude/scripts/learning/tests/*.test.mjs` → **63/63 pass** (58 existing + 5 new), including `golden.test.mjs` byte-equality → **no regression** from the enum edits.
- `node _meta/contracts/scripts/validate-contracts.mjs` → **Passed 21** (enum-only, no new `schemaFiles[]` entry).

## Scope discipline

- Additive enum widening only — JSON-Schema backward-compatible; `schema_version` const `1.0.0` unchanged; identity/content-hash arithmetic unchanged.
- No importer logic touched. No PII gate added at the importer layer (by design).
- UGE vendored schema copy is NOT in this PR (that's Rung 0, after the UGE repo is scaffolded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)