### PR TITLE
docs(governance): add skill placement policy and github-digest recon workflow

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,89 +1,40 @@
-# Claude Skills
+# liye_os/.claude/skills/ — Registry + L3 pointers (NOT the skill root)
 
-Custom skills for Claude Code integration with LiYe AI.
+> ⚠️ **This directory is NOT where liye_os platform skills live.**
+> It is **not** swept by `sfc_sweep`. Do not put SFC `SKILL.md` skills here.
 
-## What are Claude Skills?
+## What this directory actually holds
 
-Claude Skills are markdown files that extend Claude Code's capabilities by providing:
-- Domain-specific knowledge
-- Workflow guidance
-- Tool instructions
-- Best practices
+| Item | Purpose |
+|------|---------|
+| `index.yaml` | The **unified skill registry** — namespaces (`liye-os` / `amazon` / `external`), roots, discovery, resolution priority. Machine SSOT. |
+| `github-scout.md` | A flat **L3 pointer doc** for the `tools/github-scout/` **Tool** — tells Claude *when/how* to invoke the executable. Manually loaded, not auto-discovered. |
+| `liye-agent.md` | Flat L3 advisory for working with LiYe agents. |
+| `memory/` | Session memory scaffolding. |
 
-## Skill Format
+## Where real skills live
 
-Each skill file follows this structure:
+| You want… | Go to |
+|-----------|-------|
+| A **platform (cross-domain) SFC skill** | `liye_os/Skills/<domain>/<category>/<name>/SKILL.md` (namespace `liye-os`, swept by `sfc_sweep`) |
+| A **domain-specific skill** (e.g. Amazon) | that domain repo's own `.claude/skills/` (e.g. `amazon-growth-engine/.claude/skills/`, namespace `amazon`) |
+| An **executable Tool** (API client, state machine) | `liye_os/tools/<name>/` (+ optionally a 1-page L3 pointer *here*) |
+| A **third-party plugin skill** | `~/.claude/skills/` (namespace `external`, read-only) |
 
-```markdown
-# Skill Name
+## The mental model (1 line)
 
-Brief description of what this skill does.
+> 可执行确定性核进 `tools/`；Claude 工作流进 `Skills/`（跨域）或域 repo `.claude/skills/`（域专属）；
+> 跨域归 liye_os，域专属归域 repo；外部第三方只读归 `~/.claude/skills`。
 
-## When to Use
+## Authoritative docs
 
-- Trigger condition 1
-- Trigger condition 2
+- **Placement policy (decision tree + namespaces + promotion rules):**
+  `_meta/governance/SKILL_PLACEMENT.md`
+- **Skill Constitution (frozen behavioral rules):** `_meta/governance/SKILL_CONSTITUTION_v0.1.md`
+- **Registry (machine SSOT):** `.claude/skills/index.yaml`
 
-## Instructions
+## Adding a flat L3 pointer here (the only thing that belongs in this dir)
 
-Step-by-step instructions for Claude to follow.
-
-## Examples
-
-Example inputs and outputs.
-```
-
-## Available Skills
-
-| Skill | Purpose | Trigger Keywords |
-|-------|---------|------------------|
-| `liye-agent.md` | Working with LiYe AI agents | agent, crew, workflow |
-| `liye-research.md` | Research workflows | research, investigate, analyze |
-
-## Creating a New Skill
-
-1. Copy the template below
-2. Fill in your skill-specific content
-3. Save as `your-skill.md` in this directory
-4. Test by asking Claude to use the skill
-
-## Template
-
-```markdown
-# [Skill Name]
-
-[Brief description]
-
-## When to Use
-
-This skill should be used when:
-- [Condition 1]
-- [Condition 2]
-
-## Prerequisites
-
-- [Prerequisite 1]
-- [Prerequisite 2]
-
-## Instructions
-
-### Step 1: [First Step]
-[Detailed instructions]
-
-### Step 2: [Second Step]
-[Detailed instructions]
-
-## Best Practices
-
-- [Practice 1]
-- [Practice 2]
-
-## Common Issues
-
-### Issue: [Problem]
-**Solution**: [How to fix]
-```
-
-## Integration
-
-Skills in this directory are automatically available when Claude Code operates within the LiYe AI repository.
+Only when you add a **Tool** under `tools/` and want a short "when/how to invoke" doc for Claude.
+Keep it thin — the method and rules live in the Tool's own `declaration.yaml` + L1 methodology,
+never here. Example: `github-scout.md` points at `tools/github-scout/` and its L1 SSOT.

--- a/.claude/skills/github-scout.md
+++ b/.claude/skills/github-scout.md
@@ -12,6 +12,18 @@ report under LiYe governance.
 > in the L1 methodology (SKILL_CONSTITUTION §3 — no reverse dependency). This file
 > only tells Claude *when* and *how* to invoke, and points to L1.
 
+## Siblings & boundary (prior-art has three steps — don't confuse them)
+
+| Step |载体 | Form | 干什么 |
+|------|------|------|--------|
+| **DISCOVER** unknown repos | **this** (`tools/github-scout/` + this L3) | Tool | 给 idea → 搜候选 + license 卡关（advisory） |
+| **RESEARCH** a known repo | [`github-digest`](../../Skills/01_Research_Intelligence/prior-art/github-digest/) | Skill | 给一个**已知** repo → 读懂 → 判断对 LiYe 进化有没有用（verdict） |
+| **INGEST** a chosen repo | `tools/source-intake/` | Tool | 确定要拉进来 → pin + 审计 → 治理 artifact |
+
+Use **this** only to *find* candidates. If the user already has a specific repo URL and asks
+"研究一下它 / 对 LiYe 有没有帮助", that is **`github-digest`**, not scout. Placement rationale
+(Tool vs Skill, platform vs domain): `_meta/governance/SKILL_PLACEMENT.md`.
+
 ## When to Use
 
 - The user floats a new capability/idea and asks "has someone built this?" / "should

--- a/Skills/01_Research_Intelligence/README.md
+++ b/Skills/01_Research_Intelligence/README.md
@@ -1,12 +1,26 @@
 # 01_Research_Intelligence
 
-> **状态**: `PLACEHOLDER` - 规划中，待激活
+> **状态**: `ACTIVE` — 由 `prior-art/github-digest` 激活（2026-07-01）
 
-## 规划定位
+## 域定位
 
-研究智能域 - 负责学术研究、文献综述、信息检索与知识提炼相关的技能。
+研究智能域 - 负责学术研究、文献综述、信息检索，以及开源 **prior-art 侦察**相关的技能。
 
-## 预期技能
+## 原生技能
+
+| 技能 | 状态 | 一句话 |
+|------|------|--------|
+| [`prior-art/github-digest`](./prior-art/github-digest/) | active | 研究已知 GitHub repo，判断对 LiYe 进化的可借鉴性，产出 recon-log 报告（verdict: 忽略/观察/harvest） |
+
+## prior-art 三层分工
+
+| 步骤 | 载体 | 干什么 |
+|------|------|--------|
+| 侦察判断 | `github-digest`（本域） | 已知 repo → 读懂 → 判断对 LiYe 有没有用 |
+| 发现 | `tools/github-scout/` | 未知 → 搜候选 + license 卡关 |
+| 受控 intake | `tools/source-intake/` | 确定要拉进来 → pin + 审计 → 治理 artifact |
+
+## 预期技能（规划中）
 
 - [ ] 文献检索与筛选
 - [ ] 系统综述方法
@@ -14,17 +28,10 @@
 - [ ] 引文网络分析
 - [ ] 研究质量评估
 
-## 激活条件
-
-当以下条件满足时可激活此域：
-1. 有明确的业务需求
-2. 完成技能规范文档
-3. 通过架构评审
-
 ## 参考
 
-- 方法论文档: `/docs/methodology/01_Research_Intelligence/`
+- 方法论文档: `/docs/methodology/01_Research_Intelligence/`（含 `recon-log/`）
 - 技能规范: `/docs/architecture/SKILL_SPEC.md`
 
 ---
-**Created**: 2025-12-28 | **Status**: PLACEHOLDER
+**Created**: 2025-12-28 | **Activated**: 2026-07-01

--- a/Skills/01_Research_Intelligence/index.yaml
+++ b/Skills/01_Research_Intelligence/index.yaml
@@ -1,0 +1,22 @@
+# Skills/01_Research_Intelligence/index.yaml
+# 研究智能域技能索引
+
+domain: 01_Research_Intelligence
+name: 研究智能
+description: 学术研究、文献综述、信息检索、开源 prior-art 侦察相关技能
+
+# 域内原生技能
+native_skills:
+  - path: prior-art/github-digest
+    status: active
+    description: 研究已知 GitHub repo，判断对 LiYe Systems 进化的可借鉴性，产出 recon-log 报告
+    triggers: ["/github-digest", "研究这个 repo", "这个项目对 liye 有没有帮助"]
+    l1_methodology: docs/methodology/01_Research_Intelligence/recon-log/
+    siblings: ["tools/github-scout（发现未知 repo）", "tools/source-intake（受控 intake）"]
+
+# 元数据
+metadata:
+  created: 2026-07-01
+  updated: 2026-07-01
+  version: 1.0.0
+  activated_by: prior-art/github-digest

--- a/Skills/01_Research_Intelligence/prior-art/github-digest/SKILL.md
+++ b/Skills/01_Research_Intelligence/prior-art/github-digest/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: github-digest
+description: 研究一个**已知的** GitHub 项目/repo，判断它对 LiYe Systems 的进化有没有可借鉴之处，产出定型的 evolution-recon 报告并归档到 recon-log。Use whenever the user gives a specific GitHub repo URL and asks to 研究/研读/消化/digest/study it, wants to know whether a project 对 LiYe / AGE / loamwise 有没有帮助/可借鉴/值得参考, asks "这个项目对我们有没有用", floats "看看 <repo> 有没有能学的", or types /github-digest — even if they never name the report format. This is the KNOWN-repo research step that sits UPSTREAM of github-scout (which DISCOVERS unknown repos) and source-intake (which INGESTS a chosen repo). Reach for it when the repo is already chosen and the real question is "is it worth our attention / what can LiYe learn". Do NOT use it to search/discover repos (that is github-scout) or to actually vendor/ingest a repo (that is source-intake).
+domain: 01_Research_Intelligence
+category: prior-art
+version: 1.0.0
+status: active
+skeleton: workflow
+triggers:
+  commands: ["/github-digest"]
+  patterns:
+    - "研究这个 repo"
+    - "研究一下这个项目"
+    - "这个项目对 liye 有没有帮助"
+    - "对 liye systems 的进化有什么帮助"
+    - "digest this repo"
+    - "study this github project"
+    - "跑下一个 repo"
+inputs:
+  required: ["repo_url"]
+  optional: ["focus_question"]
+outputs:
+  artifacts:
+    - "docs/methodology/01_Research_Intelligence/recon-log/<YYYY-MM-DD>-<repo-slug>.md"
+    - "recon-log README 索引行"
+failure_modes:
+  - symptom: "克隆失败（网络 / 404 / private）"
+    recovery: "退回 `gh repo view <owner>/<repo>` + 网页元数据；报告显式标注『未能完整获取，判断基于 X』，证据强度降级"
+  - symptom: "repo 内容稀薄 / 几乎为空"
+    recovery: "如实说明，verdict=忽略，不硬凑"
+  - symptom: "强 copyleft（GPL/AGPL）许可"
+    recovery: "仅概念参照；frontmatter 记 license_caution；绝不复制其源码进任何 LiYe 仓"
+verification:
+  evidence_required: true
+  how_to_verify:
+    - "node .claude/scripts/sfc_lint.mjs Skills/01_Research_Intelligence/prior-art/github-digest"
+    - "确认 recon-log 新增条目 frontmatter 有 verdict + 证据强度声明"
+governance:
+  constitution: "_meta/governance/SKILL_CONSTITUTION_v0.1.md"
+  policy: "_meta/policies/DEFAULT_SKILL_POLICY.md"
+---
+
+# GitHub Digestion — 进化情报侦察
+
+给定一个**已知的** GitHub repo，把它读懂，判断对 LiYe Systems 进化有没有可借鉴之处，
+产出一份**定型结构报告**并归档。它回答的是"这东西值不值得我们上心"——站在
+`github-scout`（发现未知 repo）和 `source-intake`（受控 intake 已选 repo）的**上游**。
+
+> **这个 skill 决定不了复用。** 它只出 advisory 报告 + verdict。任何真实复用都要走
+> harvest-ADR / Reference Declaration 仪式（SYSTEMS.md Fork 纪律）。
+
+## 为什么用 subagent 而不是主线直接读
+
+一个真实 repo 读下来是 50–80k tokens（README + 目录 + 关键源码）。**默认 dispatch 一个
+只读研究 subagent** 去啃，让它只回传定型报告——主线上下文不被源码淹没，且每份报告长同一个样、
+可横向比较。只有当 repo 极小（几个文件）时才值得主线内联。
+
+## 工作流
+
+1. **接收输入**：repo URL（必需）+ 可选的关注问题。从 URL 解析 `<owner>/<repo>` 与 `<repo-slug>`。
+2. **Dispatch 研究 subagent**：用 `references/subagent-prompt.md` 作模板，填入目标 URL、
+   clone 目标路径、关注问题。subagent 负责只读获取 + clean-room 读 + 按模板出报告。
+3. **落盘归档**：把 subagent 回传的报告写成 `docs/methodology/01_Research_Intelligence/recon-log/<YYYY-MM-DD>-<repo-slug>.md`
+   （日期用当前实际日期），并在 `recon-log/README.md` 的索引表**顶部**加一行
+   （日期 / repo / verdict emoji / LiYe 层 / 一句话）。
+4. **应用清理策略**（见下）：按 verdict 处置克隆。
+5. **回主线汇报**：verdict-first 摘要（结论 + 最相关的 2–3 点 + 许可风险标记 + 下一步）。
+
+报告结构与 frontmatter 见 `references/recon-report-template.md`——**严格按它产出**，
+否则历史条目无法横向比较。
+
+## 克隆位置与生命周期（清理策略）
+
+- **克隆到 repo 外、持久目录**：`~/.liye-os/github-digest/clones/<repo-slug>/`
+  （`git clone --depth 1`）。**绝不**克隆进 liye_os / 任何工作仓，绝不 fork / vendor。
+  （持久目录而非 session scratchpad，因为 watch 的克隆要留到价值兑现。）
+- **跑完按 verdict 处置克隆**：
+  - `忽略 (ignore)` — 确认没用 → **当下即删**：`rm -rf ~/.liye-os/github-digest/clones/<repo-slug>`。
+  - `值得观察 (watch)` / `harvest-adr 候选` — **保留**：在报告 frontmatter 记
+    `clone_path` + `clone_status: retained`；留到该 repo 的价值兑现（整合进 LiYe systems /
+    走完 harvest-ADR）**或**被判定不再有用，那时才删。
+- 删克隆是 clean-room 收尾，不是 governance 操作；但删 watch 克隆前要确认其价值已了结。
+
+## Governance 硬边界（永远不替用户越过）
+
+- **只读 / clean-room**：可以理解概念，**绝不逐字誊抄源码**进报告或任何 LiYe 仓。
+- **强 copyleft 是硬毒药**：GPL/AGPL 等即使 verdict=watch，也只能概念参照、clean-room
+  重实现，**绝不阅读其源码后照抄**；frontmatter 必标 `license_caution`。
+- **不 fork / 不 clone 进工作仓 / 不 vendor / 不建运行时依赖**——surface，别 act。
+- 任何复用走 harvest-ADR / Reference Declaration（reimplement + ≥3 scenarios）。
+
+## Verdict 语义（三选一，必须落一个）
+
+| Verdict | emoji | 含义 |
+|---------|-------|------|
+| `忽略 (ignore)` | 🔴 | 与 LiYe 无实质增益 → 删克隆 |
+| `值得观察 (watch)` | 🟡 | 有相关性但暂不动手，挂 `watch_trigger` → 留克隆 |
+| `harvest-adr 候选` | 🟢 | 有明确可复用价值，值得走正式复用仪式 → 留克隆 + 指出 source-intake 切入点 |
+
+诚实优先：可借鉴的若只是**概念/设计模式**（LiYe 已有自研版），verdict 是 `watch` 不是
+`harvest` —— harvest 指向"缺口填补 + 可复用资产"，不是"设计参照"。
+
+## 证据强度纪律
+
+每份报告结尾必须标注：哪些结论**读了源码确认**、哪些是**元数据/README 推断**、哪些是
+**架构判断（对 LiYe 各层的映射几乎总是推断）**。浅克隆看不到完整 commit 历史——velocity
+类结论要标注"基于 PR 编号/API 推断"。
+
+## Read First（L1 方法论 = SSOT）
+
+- `docs/methodology/01_Research_Intelligence/recon-log/README.md` — recon-log 定位、
+  报告契约、verdict 图例、与 scout/source-intake 的分工。
+- `references/recon-report-template.md` — 报告 frontmatter + 6 段定型模板。
+- `references/subagent-prompt.md` — 研究 subagent 的派发提示模板（含 LiYe 分层背景）。
+
+## Usage Examples
+
+**示例 1（最常见）：**
+Input: "研究一下这个项目：https://github.com/getredash/redash 看看对 liye systems 的进化有什么帮助没有？"
+Output: dispatch subagent → 定型报告 → 落 `recon-log/<date>-redash.md` + 更新索引 → verdict-first 摘要（redash 🟡 watch，连接器契约/结果快照/tri-state 告警直指 AGE）。
+
+**示例 2（连续跑）：**
+Input: "跑下一个 repo：https://github.com/tinyhumansai/openhuman"
+Output: 同上流程；若命中 GPL-3.0 → frontmatter 标 license_caution，摘要顶部亮许可警告。
+
+**示例 3（判否）：**
+Input: "这个 https://github.com/foo/bar 对我们有用吗"
+Output: 若 repo 与任何层无实质关联 → verdict=🔴 忽略，落一条精简 recon-log，**当下删克隆**。
+
+## Dependencies
+
+- `git`（浅克隆）、`gh` CLI（元数据兜底）。
+- 依赖 subagent 能力（keep 主线 context 干净）；无 subagent 时可主线内联但会更耗 context。
+- 无外部服务；默认 unauthenticated 公开读。
+
+---
+**Created**: 2026-07-01 | 三层位置：L1=docs/methodology/.../recon-log · L3=本文件 · 兄弟=github-scout

--- a/Skills/01_Research_Intelligence/prior-art/github-digest/references/recon-report-template.md
+++ b/Skills/01_Research_Intelligence/prior-art/github-digest/references/recon-report-template.md
@@ -1,0 +1,71 @@
+# recon-report-template
+
+研究 subagent 回传的报告**严格按此结构**（中文）。落盘为
+`docs/methodology/01_Research_Intelligence/recon-log/<YYYY-MM-DD>-<repo-slug>.md`。
+
+## Frontmatter（YAML）
+
+```yaml
+---
+repo: <owner>/<repo>
+url: https://github.com/<owner>/<repo>
+date: <YYYY-MM-DD>                  # 当前实际日期
+verdict: watch                      # ignore | watch | harvest-adr-candidate
+layer_relevance: <如 "L2 (主, AGE), L0"，或 "无实质关联">
+license: <SPDX，如 MIT / BSD-2-Clause / GPL-3.0>
+license_caution: <仅当强 copyleft 时：一句风险说明；否则删除本字段>
+stars: <~N>
+last_commit: <YYYY-MM-DD 或 unknown>
+evidence: <一句：哪些源码确认、哪些推断>
+clone_path: <仅当 verdict != ignore 时：~/.liye-os/github-digest/clones/<repo-slug>>
+clone_status: <retained（verdict!=ignore）| deleted（verdict==ignore）>
+watch_trigger: <仅当 verdict=watch/harvest：什么条件下回取重评>
+low_cost_action: <可选：一个无许可风险的即时概念引用动作>
+---
+```
+
+## 正文 6 段
+
+```markdown
+# 进化情报侦察报告 — <owner>/<repo>
+
+## 1. 是什么
+一句话定位 + 成熟度信号（star / 最近 commit / license SPDX / 语言技术栈 / 形态：
+软件系统 · prompt 目录 · 数据集 · 框架 · 规范）。每个信号标证据来源（API/源码/推断）。
+
+## 2. 核心思想（3–5 点）
+架构/机制关键点，概念级。真实软件要区分子系统。**读源码确认的**优先，标出文件路径。
+
+## 3. 对 LiYe 哪一层有关
+明确指向 Layer 0/1/2/3 的具体 repo（liye_os / loamwise / AGE / chaming / silkbay …），
+说清"为什么是这一层"。无关就直说"无实质关联"。**这一节几乎总是架构推断，须标注。**
+
+## 4. 可借鉴的 pattern
+每条概念级可学点，**逐条注明"思想借鉴，非代码复用"**。无则直说无。
+
+## 5. Verdict
+三选一（忽略 / 值得观察 / harvest-adr 候选）+ 一句为什么。
+诚实：只是设计参照且 LiYe 已有自研版 → watch，不是 harvest。
+
+## 6. 下一步
+- watch → 归档 + 挂 watch_trigger（什么时候回取）。
+- harvest 候选 → 指出接 source-intake / harvest-ADR 的具体切入点 + ≥3 scenarios。
+- ignore → 归档精简条目 + 当下删克隆。
+
+---
+**证据强度标注**：逐项说明源码确认 vs 元数据推断 vs 架构判断；浅克隆的 velocity 结论标"基于 PR/API 推断"。
+
+---
+
+> **来源纪律**：本报告为 clean-room 只读侦察产出，目标 repo 未 vendor 进任何 LiYe 仓。
+> <若强 copyleft：⚠️ 加一句 GPL/AGPL 只可概念参照、绝不照抄源码。>
+> 任何复用须走 harvest-ADR / Reference Declaration 仪式（SYSTEMS.md Fork 纪律）。
+```
+
+## 落盘后：更新索引
+
+在 `recon-log/README.md` 索引表**顶部**插一行（最新在上）：
+
+```markdown
+| <date> | [<repo-slug>](./<date>-<repo-slug>.md) | <🔴|🟡|🟢> <verdict> | <层> | <一句话> |
+```

--- a/Skills/01_Research_Intelligence/prior-art/github-digest/references/subagent-prompt.md
+++ b/Skills/01_Research_Intelligence/prior-art/github-digest/references/subagent-prompt.md
@@ -1,0 +1,47 @@
+# subagent-prompt
+
+研究 subagent 的派发提示模板。用 `general-purpose` agent（需要 clone + 读 + 综合判断）。
+填入 `{{REPO_URL}}` / `{{OWNER_REPO}}` / `{{REPO_SLUG}}` / `{{FOCUS}}`（无关注问题则删 FOCUS 段），
+并把 clone 目标路径替换成实际的 `~/.liye-os/github-digest/clones/{{REPO_SLUG}}`。
+
+---
+
+你是 LiYe Systems 的「进化情报侦察 (evolution recon)」研究 agent。任务：研究一个已知的
+GitHub 开源项目，判断它对 LiYe Systems 的进化有没有可借鉴之处，回传一份**定型结构报告**。
+
+## 目标项目
+{{REPO_URL}}
+{{FOCUS: 关注问题：<focus_question>}}
+
+## 第一步：只读获取（严守边界）
+- **浅克隆到 repo 外的持久目录**，绝不进任何工作仓：
+  `git clone --depth 1 {{REPO_URL}} ~/.liye-os/github-digest/clones/{{REPO_SLUG}}`
+  （先 `mkdir -p ~/.liye-os/github-digest/clones`）
+- 克隆失败（网络/404/private）→ 用 `gh repo view {{OWNER_REPO}}` + 网页元数据尽力研究，
+  报告里**显式标注"未能完整获取，判断基于 X"**，证据强度降级。
+- 只读：不 fork、不改、不 vendor。看完留在该目录（主对话按 verdict 决定去留）。
+
+## 第二步：读懂它（clean-room，概念级）
+先判断形态（软件系统 / prompt 目录 / 数据集 / 框架 / 规范），再针对性拆子系统。
+读 README、目录结构、关键源码、架构文档、license、star/最近 commit/活跃度。
+clean-room 纪律：理解概念可以，**绝不逐字誊抄源码**进报告（描述思路，别贴大段代码）。
+
+## LiYe Systems 架构背景（用来判断"对哪一层有用"）
+- **Layer 0 liye_os**：制度底座 — 治理原语 / 引擎协议 (engine_manifest) / 世界模型 /
+  contracts / verdicts。BGHS 教义（Brain/Governance/Hands/Session 分层）。fail-closed、
+  人机闸门、可审计、SSOT、只读侦察 vs 受控 intake 分离。
+- **Layer 1 loamwise**：编排中间层 — CARGE 管线 / Task Ledger / 治理门禁。
+- **Layer 2 域引擎**：amazon-growth-engine（亚马逊广告优化：多数据源接入 SP-API/Ads-API/
+  SellerSprite/Sif + 指标计算 + 报表）、chaming（域名投资）。
+- **Layer 3 产品线**：silkbay（Medusa 电商后端）、storefronts、kits、themes、growth-hub、sites。
+- **Fork 纪律**：不能随手抄开源；任何复用走 harvest-ADR / Reference Declaration
+  （reimplement + ≥3 scenarios）。强 copyleft（GPL/AGPL）对商业化 Layer 2/3 是硬毒药。
+
+## 第三步：回传定型报告
+严格按 recon-report-template 的 frontmatter + 6 段结构（是什么 / 核心思想 / 对哪一层有关 /
+可借鉴 pattern / Verdict / 下一步），结尾附**证据强度标注**。
+
+诚实优先：可借鉴的若只是概念/设计模式而 LiYe 已有自研版 → verdict=watch 不是 harvest；
+repo 内容稀薄就直说，别硬凑；强 copyleft 必标 license_caution。
+
+只回传报告本身（它就是返回值，不是寒暄）。

--- a/_meta/governance/SKILL_PLACEMENT.md
+++ b/_meta/governance/SKILL_PLACEMENT.md
@@ -1,0 +1,157 @@
+# LiYe OS · Skill & Tool Placement Policy
+
+**Status:** Active (Policy tier — overridable with justification, not frozen)
+**Effective:** 2026-07-03
+**Enforcement:** WARNING (advisory). This is a **Policy**, not the frozen Constitution.
+See `SKILL_CONSTITUTION_v0.1.md` for the tier model (Constitution = HARD BLOCK, Policy = WARNING).
+**Namespace SSOT:** `.claude/skills/index.yaml` (the machine-readable registry) is authoritative
+for namespace → root → discovery. This doc is the human-readable *why* and the decision tree.
+
+---
+
+## One-line rule
+
+> 可执行确定性核进 `tools/`；Claude 工作流进 `Skills/`（跨域）或域 repo `.claude/skills/`（域专属）；
+> 跨域归 liye_os，域专属归域 repo；外部第三方只读归 `~/.claude/skills`。
+
+Everything below just makes that rule unambiguous.
+
+---
+
+## Why this exists
+
+Two **orthogonal** axes were being conflated, which made placements *look* inconsistent when
+they were actually correct:
+
+- **Axis A — FORM**: is it a *Tool* (deterministic executable) or a *Skill* (Claude workflow)?
+- **Axis B — SCOPE**: is it *platform / cross-domain* or *domain-specific* or *external*?
+
+`github-scout` (Tool) and `github-digest` (Skill) sit in different places **because they are
+different forms**, not because placement is ad-hoc. This policy pins both axes down.
+
+---
+
+## Axis A — FORM: Tool vs Skill
+
+| | **Hands Tool** | **Skill** |
+|---|---|---|
+| Litmus | Has a **deterministic executable core** — `.py`/`.mjs` that hits an API, runs a state machine, parses/computes | A **knowledge / workflow / judgment recipe** with no deterministic core (may *orchestrate* tools/subagents) |
+| Physical home | `<owner-repo>/tools/<name>/` | `Skills/<domain>/…` (liye_os) or `<domain-repo>/.claude/skills/<name>/` |
+| Extras | BGHS `declaration.yaml`; optional 1-page L3 pointer in `.claude/skills/<name>.md` telling Claude *when/how* to invoke | SFC-format `SKILL.md` (frontmatter + body), swept into a namespace |
+| Examples | `github-scout` (license-gated GitHub client), `source-intake` (URL→artifact rail) | `github-digest`, `skill-creator`, `asin-growth` |
+
+**Litmus test:** *Is there deterministic code that does the work?* → Tool. *Is the capability
+"read + judge + orchestrate" with no deterministic core?* → Skill.
+
+**Composition:** Skills **orchestrate** Tools. A Skill may shell out to a Tool for the
+deterministic part (e.g. `github-digest` could call `github-scout` for license gating). That two
+forms coexist for one problem area (prior-art) is by design, not duplication.
+
+---
+
+## Axis B — SCOPE: Platform vs Domain vs External
+
+| Scope | Owned by | Home | Namespace |
+|---|---|---|---|
+| **Platform / cross-domain** | liye_os (Layer 0) | `liye_os/Skills/<domain>/` (skills) · `liye_os/tools/` (tools) | `liye-os` |
+| **Domain-specific** | the domain engine/product repo (Layer 2/3) | `<domain-repo>/.claude/skills/<name>/` (skills) · `<domain-repo>/tools/` (tools) | `amazon` (and future peer repos) |
+| **External / third-party** | not ours | `~/.claude/skills/` (read-only) | `external` |
+
+**Litmus test:** *Does this capability belong to one domain engine, or is it usable across the
+whole ecosystem?* Ecosystem-general → liye_os. Tied to one domain → that domain's **own repo**,
+co-located with the engine it serves.
+
+---
+
+## The placement decision tree
+
+Run any new capability through this; it yields exactly one home:
+
+```
+① Third-party / not authored by us?
+      → external:  ~/.claude/skills/            (read-only, lock+drift)
+
+② Has a deterministic executable core (API / state machine / parser / compute)?
+      → it is a TOOL:  <owner-repo>/tools/<name>/
+        + BGHS declaration.yaml
+        + optional 1-page L3 pointer in .claude/skills/<name>.md
+
+③ Otherwise it is a SKILL (knowledge / workflow / judgment):
+      ├─ cross-domain / platform-general?  → liye_os/Skills/<domain>/<category>/<name>/   (SFC)
+      └─ specific to one domain engine?     → <domain-repo>/.claude/skills/<name>/         (SFC)
+```
+
+---
+
+## Namespaces (mirror of `.claude/skills/index.yaml`)
+
+| Namespace | Root | Discovery | Mutability | Holds |
+|---|---|---|---|---|
+| `liye-os` (highest priority) | `liye_os/Skills/<domain>/` | `sfc_sweep` | internal, patchable, **must be SFC-compliant** | platform SFC skills |
+| `amazon` | `amazon-growth-engine/.claude/skills/` | `sfc_sweep_multi` | local patchable, vendored read-only | AGE domain skills |
+| `external` | `~/.claude/skills/` | `lockfile+drift` | **read-only** | third-party plugin skills |
+
+Resolution priority: `liye-os` > `amazon` > `external`.
+
+> **Note on `liye_os/.claude/skills/`**: this directory is **NOT** an SFC skill root. It holds
+> the registry (`index.yaml`), flat **L3 pointer docs** for Tools (e.g. `github-scout.md`), and
+> `memory/`. It is *not* swept by `sfc_sweep`. Real platform skills live in `Skills/` (capital S).
+> See `.claude/skills/README.md`.
+
+---
+
+## Current-state mapping (verifies the policy is self-consistent)
+
+| Capability | Form | Scope | Home | ✓ |
+|---|---|---|---|---|
+| `github-scout` | Tool | platform | `liye_os/tools/github-scout/` + L3 `.claude/skills/github-scout.md` | ✅ |
+| `source-intake` | Tool | platform | `liye_os/tools/source-intake/` | ✅ |
+| `github-digest` | **Skill** | platform | `liye_os/Skills/01_Research_Intelligence/prior-art/github-digest/` | ✅ |
+| `skill-creator`, `prompt-engineering`, `document-processing/*` | Skill | platform | `liye_os/Skills/00_Core_Utilities/…` | ✅ |
+| `asin-growth`, `ads-governance`, `marketplace-growth`, `product-selection` | Skill | AGE domain | `amazon-growth-engine/.claude/skills/…` | ✅ |
+| `age-md2html` | Skill (+CLI) | AGE domain | `amazon-growth-engine/.claude/skills/age-md2html/` | ✅ |
+
+Everything is currently placed correctly. The confusion was the absence of this single table, plus
+doc-rot in `.claude/skills/README.md` (now corrected).
+
+---
+
+## Promotion rules
+
+There are **two** kinds of promotion. Do not confuse them.
+
+### 1. Maturity promotion (within a namespace)
+
+New platform skills incubate in `Skills/99_Incubator/`, then graduate to a formal domain once
+they are: (a) validated on real cases, (b) SFC-lint clean, (c) reviewed. Update the domain
+`index.yaml` on graduation. (A skill may skip incubation if it is already validated — e.g.
+`github-digest` was proven on 3 real repos before landing in `01_Research_Intelligence`.)
+
+### 2. Mechanism ascension (cross-layer abstraction) — **generic mechanisms rise, domain workflows do NOT move**
+
+When a **domain** skill contains a *generic mechanism* that is valuable ecosystem-wide, promote
+the **mechanism** up into liye_os L1 methodology / a platform contract — **but leave the skill
+body in the domain repo.**
+
+> **Worked example:** `asin-growth`'s `compile → execute → receipt → verdict` control loop is a
+> generic governed-execution mechanism. That *pattern* may be abstracted into a liye_os
+> methodology/contract (so `chaming`, `silkbay`, etc. can reuse it). But `asin-growth` **stays in
+> AGE** — it is an Amazon single-ASIN workflow, not a platform capability.
+
+**Anti-rule (hard):** **Never platformize a domain skill's body.** Do not move `asin-growth` (or
+any domain workflow) into `liye_os/Skills/`. Domain workflows belong to their engine's repo.
+Only the *reusable mechanism* ascends; the *domain workflow* does not relocate.
+
+---
+
+## Cross-references
+
+- `Skills/01_Research_Intelligence/prior-art/github-digest/` — the KNOWN-repo research Skill
+- `tools/github-scout/` (+ `.claude/skills/github-scout.md`) — the DISCOVER-unknown-repos Tool
+- `tools/source-intake/` — the INGEST-a-chosen-repo Tool
+- `docs/methodology/01_Research_Intelligence/recon-log/` — recon-log methodology + scout/source-intake boundary
+- `_meta/governance/SKILL_CONSTITUTION_v0.1.md` — the frozen behavioral Constitution (tier model)
+- `.claude/skills/index.yaml` — namespace registry (machine SSOT)
+
+---
+**Version**: 1.0.0 | **Tier**: Policy (overridable) | **Created**: 2026-07-03

--- a/docs/methodology/01_Research_Intelligence/README.md
+++ b/docs/methodology/01_Research_Intelligence/README.md
@@ -15,6 +15,7 @@ Skills in this domain enable agents to:
 | Skill | Description | Status |
 |-------|-------------|--------|
 | [`github-scout`](./github-scout/) | Read-only, license-gated GitHub prior-art recon (advisory; Hands tool at `tools/github-scout/`) | Active (Phase 0) |
+| [`recon-log`](./recon-log/) | Evolution recon 归档：研究已知 repo，判断对 LiYe 进化的可借鉴性（verdict: ignore/watch/harvest） | Active (log) |
 | `web-research` | Systematic web search and information extraction | Planned |
 | `academic-search` | Academic database queries (PubMed, Scholar, etc.) | Planned |
 | `source-verification` | Credibility assessment and fact-checking | Planned |

--- a/docs/methodology/01_Research_Intelligence/recon-log/2026-07-01-agency-agents.md
+++ b/docs/methodology/01_Research_Intelligence/recon-log/2026-07-01-agency-agents.md
@@ -1,0 +1,70 @@
+---
+repo: msitarzewski/agency-agents
+url: https://github.com/msitarzewski/agency-agents
+date: 2026-07-01
+verdict: watch                      # ignore | watch | harvest-adr-candidate
+layer_relevance: L0 (primary), L1
+license: MIT
+stars: ~121759
+last_commit: 2026-06-30
+evidence: mechanisms source-confirmed; LiYe-layer mapping inferred
+watch_trigger: "LiYe 要把 Skills/Agents 资产向多宿主（Claude Code / openclaw / FirstLightClaw）分发时，重评其 tools.json 契约模型与 convert_openclaw 切分"
+---
+
+# Evolution Recon 报告：msitarzewski/agency-agents
+
+## 1. 是什么
+
+一句话定位：**一个「AI 机构」式的 agent 人格提示词目录（agent-persona catalog）** — 232 个专业分工的 AI agent，每个是一份带人格/流程/交付物的 Markdown prompt，配一套把「单一 canonical 定义」转译并安装进 14 种 agentic 工具（Claude Code / Cursor / Codex / Gemini CLI / OpenClaw / Osaurus 等）的 shell 工具链。
+
+成熟度信号（均为元数据/源码确认）：
+- **Star ~121,759 / Fork ~19,891 / Watchers 907** — 顶流量级开源项目（gh API 确认）。
+- **最近 commit：2026-06-30**，高度活跃；有配套原生桌面 app（独立 repo）+ 官网 agencyagents.app。
+- **License：MIT (SPDX: MIT)**，`Copyright (c) 2025 AgentLand Contributors`（LICENSE 确认）。
+- **技术栈**：主体是 277 个 `.md`（agent 定义）+ Shell（install.sh 51KB / convert.sh 20KB）+ 少量 Python（originality 检查、hermes 插件构建）。GitHub 主语言标为 Shell。
+- 起源：README 自述「源于一个 Reddit thread」，社区贡献驱动。
+
+## 2. 核心思想（源码确认）
+
+1. **Prompt-as-artifact / 人格化 agent 定义**：每个 agent = 一份 Markdown，YAML frontmatter（`name/description/color/emoji/vibe`，lint 强制 `name/description/color`）+ 结构化 body（`Identity & Memory` / `Core Mission` / `Critical Rules` / `Workflow Phases`）。不是「Act as X」泛提示，而是带强人格、明确交付物、成功指标的固化资产。
+2. **单一来源 → 多工具渲染（canonical → N formats）**：`convert.sh` 里每个工具一个 `convert_<tool>` 函数，把同一份 `.md` 渲染成 TOML/MDC/SKILL.md/多文件工作区等；`tools.json` 用 `format`（保证字节级一致）+ `installKind`（`per-agent`/`roster`/`plugin`）声明安装契约。这是一套**声明式的「能力资产分发适配层」**。
+3. **catalog SSOT + CI 一致性门禁**：`divisions.json` / `tools.json` 是显式标注的 source-of-truth；三个 GitHub workflow（check-divisions / check-tools / lint-agents）在 CI 上校验「磁盘目录 ↔ JSON ↔ install.sh/convert.sh 数组」四方不一致就 fail build。SSOT 漂移被机器拦截。
+4. **原创性治理（反 re-skin 抄袭）**：`check-agent-originality.sh` 用「实体中性化 + 8-word shingle Jaccard 重叠」检测新 agent 是否是既有 agent 的 find-replace 换皮（把 country/platform 专名归一后仍算重复），阈值 WARN 20% / FAIL 40%，基线库最坏同对相似度 ~1.5%。这是一个**防止资产库被低质复制稀释的量化门禁**。
+5. **多 agent 编排层（概念级，非运行时）**：`strategy/` 下有 NEXUS pipeline —— `agents-orchestrator`（PM→Arch→[Dev↔QA loop]→Integration，含 3-retry 上限 + 质量闸）、`handoff-templates.md`（标准化 agent 间交接文档，防上下文丢失）、`testing-reality-checker`（默认判 NEEDS WORK、要求压倒性证据才 certify 的 fail-closed 验收 agent）。**注意：这些是 prompt/模板，不是执行引擎**——编排靠人/宿主工具跑，本 repo 不含 runtime。
+
+## 3. 对 LiYe 哪一层有关
+
+**主要落点是分发/适配机制，而非某个域引擎。**
+
+- **Layer 0 liye_os（最相关）**：两点直接呼应治理底座。
+  - **`tools.json` 的 `format`+`installKind` 声明式安装契约** ≈ liye_os 的 `engine_manifest` / contracts 思路：用一份机器可读契约描述「一个能力资产如何被 N 个宿主消费」。
+  - **`convert_openclaw` 的 body 拆分**把一份 agent 按 `## header` 关键词切成 `SOUL.md`（identity/communication/critical-rules）+ `AGENTS.md`（mission/workflow）+ `IDENTITY.md` —— 这是**BGHS 教义里 Brain/persona 与 Hands/operations 分离的一个外部实证**。而且它们已经原生支持 **openclaw**（正是索引外的 liyecom/openclaw / FirstLightClaw 生态用的运行时）。
+- **Layer 1 loamwise（相关）**：`agents-orchestrator` 的「阶段闸 + 3-strike retry + handoff 契约」和 `reality-checker` 的 fail-closed 验收，概念上映射 CARGE 管线 + 治理门禁；`check-agent-originality` 的量化门禁映射 loamwise 的 Task Ledger/gate 精神。
+- **Layer 2/3（弱）**：marketing/paid-media/sales 分区里有大量亚马逊/跨境/PPC 主题 agent（`paid-media-search-query-analyst`、`marketing-cross-border-ecommerce` 等），与 AGE/chaming 域**题材撞车但无机制增益**——都是泛化 prompt，深度远不及 AGE 已落地的 ads-governance / asin-growth skill 闭环，不构成可复用价值。
+
+## 4. 可借鉴的 pattern（全部标注：思想借鉴，非代码复用）
+
+1. **声明式「资产分发契约」（`format`/`installKind`/`dest` 三元组）** — 用一份机器可读清单描述「能力资产 → N 宿主」的渲染与安装契约，CI 校验四方一致。*思想借鉴*：可启发 liye_os 把 Skills/Agents 资产向多宿主（Claude Code / openclaw / FirstLightClaw）分发时的 manifest 设计。非代码复用。
+2. **canonical-source + per-target renderer 的适配层分离** — 单一 SSOT，渲染器按目标格式转译，绝不手改下游。*思想借鉴*：与 liye_os「SSOT + 下游只读实例化」哲学同构。非代码复用。
+3. **量化反抄袭门禁（entity-neutralized shingle Jaccard）** — 用实体归一后的 n-gram 重叠自动识别「换皮复制」。*思想借鉴*：这恰好是 LiYe **fork 纪律 / harvest-ADR「≥3 scenarios、reimplement 而非誊抄」** 的一个可机检化侧影——可作为「判断某资产是不是别处换皮」的检测思路。非代码复用。
+4. **soul/operations 按 header 关键词自动切分（BGHS 落地）** — 把一份人格定义拆成「持久人格面」与「操作面」两个文件。*思想借鉴*：BGHS 分层的一个外部对照实现，验证「人格/操作可静态切分」这个假设。非代码复用。
+5. **handoff 契约模板 + fail-closed 验收 agent** — 标准化交接文档（元数据/上下文/验收标准/证据要求）+ 默认判不通过的 reality-checker。*思想借鉴*：呼应 loamwise 门禁与 liye_os fail-closed/可审计底色，但 LiYe 已有更强的机器执行版本。非代码复用。
+
+## 5. Verdict
+
+**值得观察（watch）** — 一句话为什么：它的**能力资产多宿主分发契约（tools.json）+ 量化反换皮门禁 + soul/hands 静态切分**在概念上与 liye_os 的 manifest/contract/BGHS/fork-纪律高度同构，是一个规模验证过（121k star、232 资产、CI 门禁齐全）的**外部对照样本**；但它整体是「静态 prompt 目录 + shell 适配器」，**无 runtime、无治理语义、无 verdict 体系**，深度与执行力全面弱于 LiYe 现有制度层，没有可直接落地的机制增益到需要立刻动手的程度。域层 agent（亚马逊/跨境）与 AGE 撞题但无增益。
+
+## 6. 下一步
+
+**观察即可，不立即接 harvest-ADR。** 建议：
+- **归档本报告**为一次 recon 记录；把 repo 留在 scratchpad 或直接删除（已 clean-room 读完，未 vendor 进任何仓）。
+- **设一个观察触发条件**：当 LiYe 未来真的要「把 Skills/Agents 资产向 openclaw / FirstLightClaw 等多宿主分发」时，把本项目的 `tools.json`（`format`/`installKind`/`dest` 契约模型）和 `convert_openclaw`（soul/hands 切分）**作为设计参考再评估一次**——那时若确认要复用其 manifest 建模思路，才升级为 harvest-ADR 候选，走 Reference Declaration + reimplement + ≥3 scenarios 仪式（绝不誊抄其 shell）。
+- 其 `check-agent-originality.sh` 的「实体归一 shingle Jaccard」算法思路可单独记一笔，作为「检测资产换皮」的候选工具灵感。
+
+---
+
+**证据强度声明**：第 1 节数字全部 gh API / LICENSE 源文件确认；第 2、4 节机制均**读了 `convert.sh` / `tools.json` / `divisions.json` / `check-agent-originality.sh` / `lint-agents.sh` / `agents-orchestrator.md` / `handoff-templates.md` / `testing-reality-checker.md` 源码确认**；第 3 节对 LiYe 各层的映射是**架构判断（推断）**，非项目自述。项目自身不含任何 runtime/执行引擎——由「277 md + shell + 无 src 服务代码」的目录结构确认。
+
+---
+
+> **来源纪律**：本报告为 clean-room 只读侦察产出，目标 repo 未 vendor 进任何 LiYe 仓。任何复用须走 harvest-ADR / Reference Declaration 仪式（SYSTEMS.md Fork 纪律）。

--- a/docs/methodology/01_Research_Intelligence/recon-log/2026-07-01-openhuman.md
+++ b/docs/methodology/01_Research_Intelligence/recon-log/2026-07-01-openhuman.md
@@ -1,0 +1,64 @@
+---
+repo: tinyhumansai/openhuman
+url: https://github.com/tinyhumansai/openhuman
+date: 2026-07-01
+verdict: watch                      # ignore | watch | harvest-adr-candidate
+layer_relevance: L0 (primary), L1
+license: GPL-3.0
+license_caution: "强 copyleft — 代码层面对 LiYe 商业化 Layer 2/3 是硬毒药；仅限概念参照，绝不 vendor / 逐字复用"
+stars: ~34039
+last_commit: 2026-07-01
+evidence: governance 模块读源码确认; velocity 由 PR 编号推断(浅克隆无完整 commit 史); 产品功能面 README 交叉印证
+watch_trigger: "LiYe 重构 governance kernel 的『信任标签/taint 传播』层时，把 turn_origin.rs 枚举设计（Unknown fail-closed + SubconsciousTainted 降权）作为只读设计参照（clean-room 重实现，不看 GPL 代码）"
+low_cost_action: "推进 source-intake trust-audit taxonomy(#188/#190) 时，把 openhuman 的 taint→封锁 external-effect 工具面作为对照案例写进 rationale，验证分类完备性（纯概念引用，无许可风险）"
+---
+
+# 进化情报侦察报告 — tinyhumansai/openhuman
+
+## 1. 是什么
+**一句话**：面向个人/社区的开源 agentic 桌面助手（Tauri v2 + React 前端 + Rust 核心），主打「本地记忆 + 一键集成 + 后台自主性」，把一个 personal AI 做成有脸的桌面 mascot。
+
+**成熟度信号**（均为元数据/API 确认）：
+- **Star**：34,039（Trendshift/ProductHunt 上榜，高热度）
+- **License**：**GPL-3.0**（强 copyleft — 见 Verdict，这是硬约束）
+- **技术栈**：Rust 主体（2,393 个 `.rs`，`src/openhuman/*` 按 domain 切成 ~130 个模块）+ TS/React 前端（900 tsx / 883 ts），Tauri 桌面壳
+- **活跃度**：`pushed_at` = 2026-07-01；最新 commit 引用 PR #4350 → 累计 4000+ PR，极高开发速度。**注**：depth-1 浅克隆导致 git 历史被压平（shortlog 只显示 1 author），velocity 结论基于 GitHub API + PR 编号，非 commit 历史
+- **形态**：完整可运行的**软件产品**（有 installer/Homebrew tap/deb/msi、e2e 套件、CI），非 prompt 目录或数据集。状态自称 early-beta
+
+## 2. 核心思想（读了源码 + 模块 README 确认，非营销话术）
+1. **Turn-origin 信任标签 + fail-closed**（`src/openhuman/agent/turn_origin.rs`，读源码确认）：每次 agent turn 都强制携带一个 provenance 标签（`WebChat` / `ExternalChannel` / `TrustedAutomation` / `Cli` / `Unknown`）。未打标签的路径一律当 `Unknown` → 闸门 fail-closed。这是全系统信任决策的单一锚点。
+2. **Taint 传播**：`TrustedAutomationSource::SubconsciousTainted` — 当后台 tick 处理的记忆里混入了外部同步来源（Gmail/Slack/Notion）的 chunk，该 turn 被标为 tainted，**external-effect 工具面被整体封锁**。即「读了不可信数据的自主回合，不许对外产生副作用」。
+3. **两级人机闸门**：(a) `approval` gate — async 中间件拦截所有 `external_effect=true` 的工具（发邮件/Slack/shell），parked-future + SQLite 持久化 pending 行 + UI 弹窗 + 10min TTL，denial/timeout/channel-drop **全部 fail-closed**，并做 PII redaction + 终态执行审计；(b) `plan_review` gate — 把 live turn 停在 plan 上，用户 Approve/Reject/Revise 后原 turn 恢复执行。
+4. **权限天花板 + 确定性工具策略**（`agent_tool_policy`）：per-channel `PermissionLevel` ceiling，把每个工具分类成 Allow/RequireApproval/Deny/HideFromPrompt，产出不可变 `ToolPolicySession` 快照，未知工具默认 `Deny`。
+5. **确定性 verdict 契约**：`prompt_injection` 用 regex+heuristic 打分 → `Allow/Review/Block` + score + 稳定 reason codes + SHA-256 prompt hash 审计（PII-safe）；`mcp_audit` 把所有 MCP write-tool 尝试（含失败）落 SQLite 审计表。记忆侧 `memory_tree` 把所有接入数据压成 ≤3k-token Markdown chunk 存本地 SQLite + Obsidian 兼容 vault（Karpathy-style）。
+
+## 3. 对 LiYe 哪一层有关
+**Layer 0（liye_os）+ Layer 1（loamwise）**，这是实质关联，且关联度很高：
+
+- **Layer 0 治理原语**：openhuman 的 `turn_origin`（信任标签/taint）、`approval`（fail-closed 人机闸）、`agent_tool_policy`（permission ceiling + 未知即 Deny）、`prompt_injection`（Allow/Review/Block verdict 契约）、`mcp_audit`（write 审计流）几乎是 LiYe **BGHS + fail-closed + SSOT + verdict 语义 + 只读侦察/受控 intake 分离**教义的一个**已在生产落地的平行实现**。尤其 `AgentTurnOrigin::Unknown → fail-closed` 与 LiYe 的「未标注即最严」同构。
+- **Layer 1 编排**：`agent_orchestration`（parent/child lineage + run_ledger + delegation.rs）+ `DELEGATION_POLICY.md`（4-tier direct-first 决策树）+ `scheduler_gate`（按主机负载/电量 gate 后台 AI 工作）对应 loamwise 的 **CARGE 管线 / Task Ledger / 治理门禁**。
+- 与 Layer 2/3（AGE 数据源接入、silkbay 电商）**无实质关联** — openhuman 是水平 agent harness，不碰亚马逊广告/域名/电商域逻辑。
+
+## 4. 可借鉴的 pattern（全部为**思想借鉴，非代码复用** — 理由见 Verdict）
+1. **Turn-origin 作为单一信任锚点**（思想借鉴）：LiYe 的 governance 目前散在 contracts/verdicts；openhuman 把「谁调度了这个回合」收敛成一个 typed task-local，被 approval + tool-policy 两个闸门共同读取。这个「单点 provenance，多闸门共读」的收敛方式值得 liye_os kernel 参考。
+2. **Taint = 数据来源污染 turn 的外部副作用面**（思想借鉴）：读了外部同步数据的自主 tick 自动降权、封锁对外副作用。直接映射到 LiYe 的「只读侦察 vs 受控 intake 分离」+ source-intake trust-audit taxonomy（正是本仓库近期 #188/#190 在做的事）。
+3. **fail-closed 的具体实现清单**（思想借鉴）：persist 失败 / channel drop / TTL timeout / 未知 origin **四条路径全部 Deny**，且 TTL 路径会 re-read 持久化决策以避免 approve-in-race 被误 deny。这是 fail-closed 的工程细节参考。
+4. **plan_review parked-turn 模式**（思想借鉴）：把 live turn 停在 plan 上等 Approve/Reject/**Revise(feedback)**，与 LiYe 的 plan-mode / 人机闸门一致，`Revise` 分支（带反馈重新规划再 re-park）是可借鉴的循环设计。
+5. **verdict 契约的可审计形状**（思想借鉴）：`{verdict, score, reason_codes, hash}` + 只记 hash 不记原文的 PII-safe 审计行 — 与 liye_os `verdicts/` 的人类可读判定语义思路一致，可作为 verdict schema 的字段参考。
+
+## 5. Verdict
+**值得观察（Watch）** — 一句为什么：**治理哲学与 LiYe 高度同构、且是罕见的「生产级平行实现」，值得作为设计参照持续跟踪；但 GPL-3.0 强 copyleft 使任何代码复用对 LiYe 的商业化 Layer 2/3 都是硬毒药，且 LiYe 的 fork 纪律本就要求 reimplement，因此现在不够格直接进 harvest-ADR。**
+
+（为何不是 harvest-ADR 候选：harvest 通常指向「有明确可复用价值、值得走正式复用仪式引入」。这里可借鉴的是**概念/设计模式**而非可移植资产 — LiYe 已有 turn-origin/taint/fail-closed 的自研版本（source-intake trust-audit、Band-B clock、approval 教义），openhuman 提供的是**验证与细节参照**，不是缺口填补。GPL 又叠加了代码层面的隔离要求。故 Watch 更诚实。）
+
+## 6. 下一步
+- **归档 + 挂观察**：把本报告存入进化情报库，标记 `watch: openhuman`。触发再看的条件 = 当 LiYe 要重构 governance kernel 的**信任标签/taint 传播**层时，把 `turn_origin.rs` 的枚举设计（尤其 `Unknown` fail-closed + `SubconsciousTainted` 降权）作为**只读设计参照**（clean-room 重实现，不看其 GPL 代码）。
+- **不接 source-intake / harvest-ADR**：无可 vendor 资产；且 GPL-3.0 下任何逐字复用会污染 LiYe 许可，与 fork 纪律冲突。
+- **一个具体的低成本动作**（可选）：若近期继续推进本仓库的 source-intake trust-audit taxonomy（#188/#190 线），可把 openhuman 的「taint 来源 → 封锁 external-effect 工具面」作为**对照案例**写进该 taxonomy 的 rationale，验证 LiYe 分类的完备性 —— 这是纯概念引用，无许可风险。
+
+---
+**证据强度标注**：核心思想（§2）、governance 模块语义（§3-4）均**读了模块 README + `turn_origin.rs`/`plan_review/types.rs` 源码确认**；star/license/language/pushed_at 为 **GitHub API 确认**；velocity（4000+ PR）**由 PR 编号 + pushed_at 推断**（浅克隆无法看完整 commit 历史）；产品功能面（memory tree/auto-fetch/mascot）部分来自 **README 描述 + 模块 README 交叉印证**，未逐一跑通运行时。项目内容**不稀薄** — 是一个真实、活跃、体量很大的生产级 codebase。
+
+---
+
+> **来源纪律**：本报告为 clean-room 只读侦察产出，目标 repo 未 vendor 进任何 LiYe 仓。⚠️ **GPL-3.0 强 copyleft**：即便未来复用，也只能 clean-room 重实现其概念，**绝不阅读/复制其 GPL 源码到 LiYe 任何仓**。任何复用须走 harvest-ADR / Reference Declaration 仪式（SYSTEMS.md Fork 纪律）。

--- a/docs/methodology/01_Research_Intelligence/recon-log/2026-07-01-redash.md
+++ b/docs/methodology/01_Research_Intelligence/recon-log/2026-07-01-redash.md
@@ -1,0 +1,79 @@
+---
+repo: getredash/redash
+url: https://github.com/getredash/redash
+date: 2026-07-01
+verdict: watch                      # ignore | watch | harvest-adr-candidate
+layer_relevance: L2 (primary, AGE), L0 (structural)
+license: BSD-2-Clause
+stars: ~28669
+last_commit: 2026-07-01
+evidence: subsystems source-confirmed; LiYe-layer mapping inferred
+watch_trigger: "AGE 开工『统一数据源 intake 契约』或『指标 freshness/快照层』时，回取 connector-contract + content-addressed result snapshot + tri-state fail-safe alert 三个 pattern；SP-API/Ads-API/SellerSprite 天然满足 harvest-ADR ≥3 scenarios"
+---
+
+# 进化情报侦察报告：getredash/redash
+
+## 1. 是什么
+
+**开源自助式 BI / 数据查询与可视化平台** —— 让任何人（含非技术者）连接 35+ 数据源、写 SQL/NoSQL 查询、做可视化与看板、定时刷新、阈值告警，一切在浏览器内完成，且全功能有对等 REST API。
+
+成熟度信号（均为**元数据/API 确认**，证据强）：
+- **Star ≈ 28,669**，Fork ≈ 4,614，开源 issue ≈ 795（getredash/redash）
+- **高度活跃**：`pushed_at` = 2026-07-01，HEAD commit `Snapshot: 26.07.0-dev`；未 archived；创建于 2013
+- **License = BSD-2-Clause**（SPDX，宽松许可，商用/复用几乎无限制）
+- **技术栈**：后端 Python 3.13 / Flask + Flask-RESTful + SQLAlchemy（Postgres）；任务队列 **RQ + rq-scheduler + Redis**；前端 React（`client/`）+ 独立可视化库 `viz-lib`（TS）；`gunicorn/gevent` 部署；Docker/compose 部署形态
+- 结构真实，非 prompt 目录：`redash/query_runner/`（71 个连接器文件）、`redash/destinations/`（13 个告警渠道）、`redash/tasks/`、`redash/models/`、`viz-lib/`
+
+## 2. 核心思想（读源码确认）
+
+1. **数据源连接器抽象层（query_runner）** —— `BaseQueryRunner` / `BaseSQLQueryRunner` 抽象基类定义统一契约：`configuration_schema()`（声明式 JSON-schema 配置）、`run_query()`、`get_schema()`、`test_connection()`、统一列类型集（`TYPE_INTEGER/FLOAT/BOOLEAN/STRING/DATETIME/DATE`）。71 个数据源各自实现同一接口，通过全局 `register()` + `import_query_runners()`（`__import__` 动态导入）注册进 `query_runners` 字典。**新增数据源 = 实现契约 + 注册，零核心改动**。（源码：`redash/query_runner/__init__.py`）
+
+2. **查询结果 = 内容寻址快照缓存** —— 每条查询按 `gen_query_hash(query_text)` 生成 32 位哈希；`QueryResult` 表以 `(query_hash, data_source)` 存历史结果，`get_latest(max_age=...)` 用 `retrieved_at + max_age >= now()` 做**新鲜度门**取缓存，`max_age=-1` 走可配 TTL，`store_result()` 追加不覆盖（可回溯历史结果）。查询与结果解耦：查询是定义，结果是不可变事实快照。（`models/__init__.py` QueryResult）
+
+3. **哈希锁 + 幂等去重的异步执行** —— `enqueue_query()` 用 Redis `query_hash_job:{ds}:{hash}` 做分布式锁：同一 (hash, data_source) 若已有活跃 job 则复用，避免重复执行；job 完成/取消/过期则清锁重排。执行走 RQ 队列（区分 `queue_name` 与 `scheduled_queue_name`），有 per-org/user 动态 `query_time_limit`。（`tasks/queries/execution.py`）
+
+4. **声明式阈值告警（tri-state + rearm）** —— `Alert.evaluate()` 从最新 QueryResult 取列值（支持 `selector: first/min/max`），套声明式 `op`（`>,<,>=,==,!=`）与 `threshold`，产出**三态** `OK / TRIGGERED / UNKNOWN`（`next_state()`：非数值+序关系算子→UNKNOWN，即 fail-safe 到未知而非误报）；`rearm` 控制重复触发抑制。告警投递抽象成 `BaseDestination.notify()`，13 个渠道（Slack/PagerDuty/Webhook/Email…）同一契约 + `register()`。（`models/__init__.py` + `destinations/`）
+
+5. **权限/多租户 + 安全护栏** —— 组-based 访问控制（`has_access_to_groups`，view=1/modify=2 级别，admin 短路）+ API-key 对象级访问 + `require_permission/owner` 装饰器；多组织隔离（`BelongsToOrgMixin`）。安全面：Python 数据源用 **RestrictedPython** 沙箱（`compile_restricted` + `safe_builtins` + `custom_write`）；HTTP 类连接器用 **advocate** 库做 SSRF 防护（`UnacceptableAddressException` 拦私网地址）；定时刷新/schema 刷新/幽灵锁清理等周期任务集中在 `periodic_job_definitions()`。
+
+## 3. 对 LiYe 哪一层有关
+
+**主要命中 Layer 2 — amazon-growth-engine (AGE)**，其次是**结构性借鉴命中 Layer 0 liye_os**。
+
+- **AGE（Layer 2）—— 强相关**。AGE 的本质就是"大量异构数据源接入（SP-API / Ads-API / SellerSprite / Sif）+ 指标计算 + 报表"。redash 恰好把这套的**通用骨架**抽象过：数据源连接器契约、结果快照缓存、哈希去重执行、定时刷新、阈值告警。AGE 的 recon 中已知痛点（多数据源接入的 flush / receipt_id 口径 / 哈希分歧 / allocator 字段等 carry-forward gaps）与 redash 的"统一连接器契约 + 内容寻址结果表"是同构问题域。
+
+- **liye_os（Layer 0）—— 结构性相关，非功能相关**。redash 的两个模式与 liye_os 世界模型/verdicts 教义**同频**：(a) "查询定义 vs 不可变结果快照"解耦 ≈ liye_os"数据即事实、可审计"；(b) 告警 `next_state()` 在不可判定时 fail-safe 到 `UNKNOWN` ≈ liye_os 的 **fail-closed** 底色。这是**思想印证**，不是可搬运的组件。
+
+- **silkbay / loamwise —— 弱/无实质关联**。silkbay 是电商交易后端（写路径），redash 是只读分析层，形态不同；loamwise 是编排门禁，redash 无对应物。
+
+## 4. 可借鉴的 pattern（全部为思想借鉴，非代码复用）
+
+1. **数据源连接器契约抽象**（思想借鉴）：`BaseQueryRunner` 式的"声明式 configuration_schema + run_query/get_schema/test_connection + 统一列类型 + register 注册表"。可为 AGE 的 SP-API/Ads-API/SellerSprite/Sif 提供**统一 intake 契约**，让新数据源=实现契约+注册，与 liye_os engine_manifest 协议精神一致。
+
+2. **内容寻址的结果快照 + 新鲜度门**（思想借鉴）：`query_hash → QueryResult(retrieved_at)` + `get_latest(max_age)`。直接对应 AGE 指标/报表的"结果即带时间戳的事实快照 + freshness gate"——与本仓库 recon memory 里反复出现的 **freshness drift / window_end==asof** 主题同构，可为"哪些指标是新鲜的、哪些用缓存"提供成熟范式。
+
+3. **哈希锁幂等去重执行**（思想借鉴）：`_job_lock_id` 用 (hash, source) 做分布式锁避免重复拉取/计算。对 AGE 批量拉数据源（速率受限的 SP-API/Ads-API）很有价值。
+
+4. **声明式 tri-state 阈值告警 + rearm**（思想借鉴）：`op + threshold + selector → OK/TRIGGERED/UNKNOWN` 且不可判定 fail-safe 到 UNKNOWN、rearm 抑制重复。可为 AGE 的 ACOS/CVR 异常检测、marketplace-growth 的容器化告警提供一个干净、可审计、fail-closed 的判定语义骨架（呼应 liye_os verdicts）。
+
+5. **告警投递渠道抽象（destinations）**（思想借鉴）：`BaseDestination.notify()` + register，13 渠道同契约。若 AGE/loamwise 未来要多渠道通知，这是干净的抽象参照。
+
+6. **不可信执行沙箱**（思想借鉴，非当前需求）：RestrictedPython + advocate SSRF 防护，作为"受控 intake"安全面的参考，不建议现在动手。
+
+## 5. Verdict
+
+**值得观察（watch）** —— 有明确概念相关性（尤其连接器契约、结果快照+freshness gate、tri-state fail-safe 告警对 AGE 高度对味），但**当前不满足动手门槛**：AGE 主线正卡在 CBU producer / budget_rows producer 的具体 gap 上（见 recon memory），是"补齐既有链路"而非"引入新抽象"的阶段；且 redash 是重型 BI 平台，与 AGE 的 headless 引擎形态差异大，整体架构不可搬。定位为**架构模式参考库**，在下一次设计 AGE 数据源 intake 契约或指标 freshness 层时再回取。
+
+## 6. 下一步
+
+- **归档 + 观察**：把本报告记为 AGE 数据源/指标层的**设计参考条目**（"redash: connector-contract + content-addressed result snapshot + tri-state alert"）。scratchpad 克隆看完即可留置，**不 vendor、不 fork 进任何仓**。
+- **触发升级到 harvest-ADR 的条件**（未来）：当 AGE 真正开工"统一数据源 intake 契约"或"指标 freshness/快照层"时，届时 pattern #1/#2 满足 harvest-ADR 的 reimplement + ≥3 scenarios 门槛（SP-API / Ads-API / SellerSprite 即天然 3 场景），可正式走 source-intake → Reference Declaration → harvest-ADR 仪式，引用 redash 的连接器契约与结果快照思想（clean-room 重实现，不复制 BSD 代码）。
+- 现在**不建议**开 harvest-ADR：会与 A 主线（已 SEALED build-complete-until-AGE-emits）和 AGE 当前 producer gap 争夺注意力。
+
+---
+
+**证据强度标注**：star/fork/license/活跃度=**GitHub API 确认**；连接器抽象/结果快照缓存/哈希锁执行/tri-state 告警/权限模型/沙箱=**均读源码确认**（文件路径已在正文标注）；对 LiYe 各层的相关性判断=**基于架构背景的推断**。
+
+---
+
+> **来源纪律**：本报告为 clean-room 只读侦察产出，目标 repo 未 vendor 进任何 LiYe 仓。任何复用须走 harvest-ADR / Reference Declaration 仪式（SYSTEMS.md Fork 纪律）。

--- a/docs/methodology/01_Research_Intelligence/recon-log/README.md
+++ b/docs/methodology/01_Research_Intelligence/recon-log/README.md
@@ -1,0 +1,35 @@
+# recon-log — 进化情报侦察归档
+
+「研究一个**已知** GitHub 项目，判断对 LiYe Systems 进化有没有可借鉴之处」的定型报告归档。
+
+## 定位（跟邻居的区别）
+
+| 步骤 | 工具 | 干什么 |
+|------|------|--------|
+| **侦察判断**（本目录） | evolution recon（研究 subagent + 模板） | 已知 repo → 读懂 → 判断对 LiYe 有没有用（verdict） |
+| 发现 | [`github-scout`](../github-scout/) | 未知 → 搜候选 + license 卡关（advisory） |
+| 受控 intake | `tools/source-intake/` | 确定要拉进来 → pin + 审计 → 治理 artifact |
+
+recon 站在 scout / source-intake 的**上游**：它回答「这东西值不值得我们上心」。它**只读、clean-room、绝不 vendor**——任何复用要走 harvest-ADR / Reference Declaration（SYSTEMS.md Fork 纪律）。
+
+## 报告契约
+
+每条 recon 是一份 `YYYY-MM-DD-<repo-slug>.md`，带 frontmatter（`repo/url/date/verdict/layer_relevance/license/evidence/watch_trigger`）+ 6 段定型正文：
+1. 是什么（定位 + 成熟度信号）
+2. 核心思想（3–5 点，概念级）
+3. 对 LiYe 哪一层有关
+4. 可借鉴 pattern（每条标注「思想借鉴 / 非代码复用」）
+5. **Verdict**：`ignore` | `watch` | `harvest-adr-candidate`
+6. 下一步
+
+结尾附**证据强度声明**（哪些源码确认、哪些是架构推断）。
+
+## 索引
+
+| 日期 | Repo | Verdict | LiYe 层 | 一句话 |
+|------|------|---------|---------|--------|
+| 2026-07-01 | [openhuman](./2026-07-01-openhuman.md) | 🟡 watch | L0(主), L1 | agentic 桌面助手；turn-origin 信任标签/taint/fail-closed 闸门/verdict 契约 是 LiYe 治理教义的生产级平行实现；⚠️ **GPL-3.0** 只可概念参照 |
+| 2026-07-01 | [redash](./2026-07-01-redash.md) | 🟡 watch | L2(主, AGE), L0 | 开源 BI 平台；连接器契约 + 内容寻址结果快照/freshness 门 + tri-state fail-safe 告警 直指 AGE 多源接入/指标层；BSD-2，模式参考库 |
+| 2026-07-01 | [agency-agents](./2026-07-01-agency-agents.md) | 🟡 watch | L0(主), L1 | 232-agent 人格 prompt 目录 + 多宿主 shell 适配；`tools.json` 分发契约/反换皮门禁/soul-hands 切分与 liye_os 同构，但无 runtime/治理语义 |
+
+**Verdict 图例**：🔴 ignore · 🟡 watch · 🟢 harvest-adr-candidate


### PR DESCRIPTION
## Summary
- Add a human-readable Skill & Tool placement policy covering Tool vs Skill and platform vs domain placement.
- Add the `github-digest` SFC workflow skill for known-repo evolution recon.
- Add recon-log methodology plus three existing recon reports, and cross-link `github-scout`, `github-digest`, and `source-intake`.

## Scope
- Docs and skill-definition only.
- No runtime code changes.
- Base branch: `main` at `29df235` when the branch was created.

## Validation
- Pre-commit gates passed during commit creation.
- `git diff --check` passed for staged and unstaged state.

## Not Included
- `_meta/contracts/ledger/manifest_reality_amazon-growth-engine.jsonl` remains dirty in the local worktree and is intentionally excluded.
- `.codegraph/` remains untracked in the local worktree and is intentionally excluded.

## Review Notes
- The policy intentionally keeps AGE domain workflows such as `asin-growth` in the AGE repo. Only generic mechanisms ascend to LiYe OS methodology/contracts.