### PR TITLE
Rung 0b: register user-growth-engine learning source (inert, enabled:false)

### DIFF
--- a/.claude/config/learning_sources.yaml
+++ b/.claude/config/learning_sources.yaml
@@ -63,3 +63,29 @@ sources:
       Phase 1a (AGE emit_fact.py landing) is time-locked to Sprint 9 readout (≥ 2026-05-13Z).
       Sprint 9 readout ETA ≈ 2026-05-28Z (per project_ghl_baseline.md).
       Until then, this source remains enabled=false; manifest_hash unverified.
+
+  user-growth-engine:
+    source_id: user-growth-engine
+    domain: user-growth
+    # Identity-only field: NOT a fetch target (same discipline as AGE above).
+    # Changing it does NOT flip enabled and does NOT arm expected_manifest_hash.
+    engine_repo: https://github.com/liyecom/user-growth-engine
+
+    # Branch allowlist (per N-2 I-01).
+    allowed_branches:
+      - main
+
+    # null = un-armed. UGE emits nothing until Rung 2; do NOT arm before then
+    # (every imported fact provenance_dirty by design, same as AGE).
+    expected_manifest_hash: null
+
+    # Fact emission paths (per EV2-I-01 date-sharded UTC + event sidecar).
+    # Declared for shape only — Rung 0 has NO emit entry (no emit_script; UGE
+    # emits nothing yet). emit_script is added when the Rung 2 emit path lands.
+    fact_emit_path: out/facts/<UTC_DATE>/fact_run_outcome_events.jsonl
+    event_sidecar_path: out/facts/<UTC_DATE>/<event_identity_key>.json
+
+    # Rung 0 inert registration (UGE SPEC anchor 29df235): the registry knows UGE
+    # exists but does NOT trust / import / execute it. enabled=false and
+    # expected_manifest_hash=null keep it 100% inert.
+    enabled: false


### PR DESCRIPTION
## Rung 0b — UGE registry entry (registry-only, inert)

控制面登记 User Growth Engine（Layer-2）。这是 **Rung 0 的控制面登记，不是激活**：registry 现在知道 UGE 存在，但**不信任、不导入、不执行**。

配对已合并的 UGE repo scaffold（`liyecom/user-growth-engine#1`，merge `3afac68`）+ UGE SPEC anchor `29df235`，收口 Rung 0 的"两边闭环"。

### 改动（单文件）
`.claude/config/learning_sources.yaml` +26，加 `user-growth-engine` 一个 source 块：
- `enabled: false`
- `expected_manifest_hash: null`（un-armed；UGE 到 Rung 2 前不 emit，不得 arm）
- **无 `emit_script`**（Rung 0 无 emit 入口）
- 无 notes；engine_repo 为 identity-only（非 fetch target）

### 验收（全部本地已验证）
- [x] diff 单文件（`learning_sources.yaml` +26）
- [x] `enabled: false`
- [x] `expected_manifest_hash: null`
- [x] contracts gate 仍 **Passed 21**（config instance，非 schema，不加 `schemaFiles[]`）
- [x] importer 全量测试 **63/63**（新 source enabled:false，不被 discover/import 触及）
- [x] pre-commit 全门过（forbidden-name lint / blocklist / env hygiene / guardrail），无 `--no-verify`

### 刻意不做
不 arm hash · 不加 emit_script · 不碰 manifest reality · 不改 schema · 不进 Rung 1（metrics/draft）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
