### PR TITLE
docs(team): promote iconexpert to full operator

### DIFF
--- a/_meta/portfolio/TEAM_DEV_MODEL.md
+++ b/_meta/portfolio/TEAM_DEV_MODEL.md
@@ -1,6 +1,7 @@
-# Team Dev Model (治理原生的多人开发模型) v0.1
+# Team Dev Model (治理原生的多人开发模型) v0.2
 
-> 状态：v0.1，随 [[ICONEXPERT_ONBOARDING]] 一同首次落地（第 2 位开发者 iconexpert 入场）。
+> 状态：v0.2，随 [[ICONEXPERT_ONBOARDING]] 一同首次落地（第 2 位开发者 iconexpert 入场）。
+> v0.2 更新：2026-07-08 owner directive 将 iconexpert 从 Human-D0 升级为 AGE Full Operator / Human-D3。
 > 定位：本文件定义「**人类开发者如何作为受治理 actor 加入这套系统**」的总原则。
 > 权威序：本文件服从 `_meta/portfolio/SYSTEMS.md`（架构 SSOT）与各 repo 的 contracts/CLAUDE.md；冲突以后者为准。
 
@@ -28,7 +29,7 @@
 | **D0**（入职默认） | 只读数据、fixture/synthetic dry-run、测试、开 PR | — | 不发任何生产 env + 不设 `AGE_WRITE_ENABLED`（凭证缺失即结构性阻断，见 [[ICONEXPERT_ONBOARDING]] §2） |
 | **D1** | staging/sandbox 写、独立修低风险模块 | 3–5 个 PR 通过，无 secret/data/live 边界事故 | 发 sandbox/只读 API 凭证；仍不设 live 保险丝 |
 | **D2** | 备 readiness packet、跑受控 rehearsal | 多次完成端到端闭环 | 受限 env + owner 监督 |
-| **D3** | 可执行 production live | 极少数核心 operator | 现有三重 fail-closed 锁 + 双人 approval |
+| **D3** | 可执行 production live | 极少数核心 operator；owner explicit directive | 现有三重 fail-closed 锁 + 双人 approval；per-action 授权不继承 |
 
 晋升 = owner 卸下审批负担的明确通道，避免 owner 永久成为瓶颈。
 
@@ -37,10 +38,19 @@
 | 角色 | GitHub | Secrets | Data | AGE Live | 说明 |
 |---|---|---|---|---|---|
 | Owner | Admin | Prod + Dev | Full | 可批准 | 你 / 核心负责人 |
+| Full Operator | Write/Maintain（branch protection 仍生效） | Prod + Dev（受控分发，不入库） | Full / DB exclusive-window write | 可执行已授权 live | **iconexpert 当前状态 = Human-D3**；可作为 production runner/operator，但不等于绕过 fail-closed gate |
 | Core Dev | Write/Maintain | Dev + 选定 staging | Read | 不可直接 live | 可独立开发核心模块 |
-| Contributor | Write（feature 分支） | 仅 Dev | Read scoped | 否 | **iconexpert 初期在此 = Human-D0** |
+| Contributor | Write（feature 分支） | 仅 Dev | Read scoped | 否 | iconexpert 初期在此 = Human-D0；2026-07-08 已 superseded |
 | Analyst / FDE | Triage/Read | 客户专属 | Read scoped | 否 / 仅 approval | 看报表、跑部署/诊断 |
 | Automation Bot | 最小 app 权限 | OIDC/service acct | None/scoped | 否（除非 gated） | CI、release（**触发后才建**） |
+
+### 3.1 当前 operator 任命
+
+| Actor | Effective from | Level | Scope | Non-bypass gates |
+|---|---|---|---|---|
+| iconexpert | 2026-07-08 | Human-D3 / AGE Full Operator | AGE canonical worktree preflight；docs/PR；read-only reports；dry-run/rehearsal；Operator Workbench；canonical DB migration/repair in exclusive-access windows；truth-layer/receipt repair with evidence；SP-API/Ads/listing live execution when separately approved | No shared auth/session；no committed secrets；no dirty-main live；no blanket `AGE_WRITE_ENABLED`；no Phase authorization inheritance；dual approval remains when policy requires it |
+
+Full Operator 是受治理 production operator，不是 unrestricted admin。它授予「可承接生产操作流程」的资格；每次 live write、rollback、canonical DB mutation、truth-layer manual repair 仍必须绑定明确 scope、commit/request hash、receipt/readback、rollback path 和当次授权。
 
 ## 4. 真边界 = 服务端 gate（现状，2026-06-30 核实）
 
@@ -54,6 +64,7 @@ CI 暂**不**作 required check：AGE `ci.yml` 仅 guard-rail + best-effort veri
 ## 5. 数据策略（按「他做什么」分流）
 
 - **做 AGE 开发**：D0 阶段**不需要**大数据；warehouse `data/amazon_growth.duckdb`（≈2.7GB）是**单写者 + 跨 worktree 硬链 + 禁并发写**（AGE `CLAUDE.md`），**绝不可用 SMB 共享 live 文件**。需分析时给**带日期的只读快照副本**。
+- **AGE Full Operator / D3 例外**：可在 canonical clean worktree + exclusive-access window 内读写 live warehouse，但必须先确认 no-WAL / no-concurrent-writer，并在 decision log 或 receipt 中记录 postcheck。该例外不适用于 D0-D2。
 - **碰 silkbay / 少宁服饰数据（≈20GB）**：那是 silkbay 产品线数据，**AGE 代码零引用**；仅当涉及 silkbay 时才走 **NAS/SMB 只读挂载、不拷贝**。
 
 ## 6. Secrets 策略（与现有 ADR 一致）

--- a/docs/cowork/ICONEXPERT_ONBOARDING.md
+++ b/docs/cowork/ICONEXPERT_ONBOARDING.md
@@ -1,12 +1,31 @@
-# Iconexpert Onboarding v0.2
+# Iconexpert Onboarding v0.3
 
-> 目标：1–2 天内让 iconexpert 在自己的 **Mac mini** 上，**无生产凭证、不污染主仓、按 Human-D0 边界**参与 **AGE** 开发。
-> 上位文件：[[TEAM_DEV_MODEL]]（总原则 + Human-Dn + 触发表）。本文件是 Day-1 可执行 SOP。
-> 范围：仅 AGE。明确排除：liye_os installer 阻塞、1Password、OIDC bot、CODEOWNERS 重构、中央数据服务、FDE/客户交付、生产写权下放。
+> 目标：记录 iconexpert 从 Human-D0 onboarding 到 **AGE Full Operator / Human-D3** 的治理边界。
+> 上位文件：[[TEAM_DEV_MODEL]]（总原则 + Human-Dn + 触发表）。本文件保留 Day-1 SOP，并记录当前 operator status。
+> 范围：仅 AGE。明确排除：liye_os installer 阻塞、1Password、OIDC bot、CODEOWNERS 重构、中央数据服务、FDE/客户交付。
 
-## 1. D0 边界契约（**先冻结这几条，工具后补**）
+## 0. 当前状态（2026-07-08）
 
-iconexpert 入场即 **Human-D0**。D0 **禁止**以下，且由 `dev_doctor.sh`（PR-2 交付）强制校验：
+Owner directive: iconexpert 从初始 Human-D0 升级为 **AGE Full Operator / Human-D3**。
+
+Full Operator 允许：
+
+- 操作 AGE canonical worktree preflight、docs/PR、read-only report、dry-run/rehearsal、Operator Workbench。
+- 在 exclusive-access window 内执行 canonical DB migration / repair，并记录 no-WAL / no-concurrent-writer guard。
+- 对 truth-layer / receipt 做带证据链的 repair，但必须记录原始 artifact、变更 SQL/脚本、postcheck。
+- 在明确 scope + commit/request hash + rollback path + 人工批准点齐备时，作为 runner 执行 SP-API / Ads / listing live write。
+
+Full Operator 不代表：
+
+- 不代表 GitHub admin 或 branch protection bypass。
+- 不代表共享 owner auth、session、Keychain、Studio shell 或任何不可审计凭证。
+- 不代表长期打开 `AGE_WRITE_ENABLED`；该开关只能在单次已授权 live run 中临时启用。
+- 不代表 Phase 3/4 或任意历史授权自动继承到后续 live write、rollback、DB mutation 或 truth sync。
+- 不代表可跳过双人 approval；当 AGE policy 要求双人 approval 时，Full Operator 只能作为其中一个受治理 actor。
+
+## 1. D0 边界契约（历史基线；2026-07-08 已 superseded）
+
+iconexpert 入场时为 **Human-D0**。以下 D0 禁止项保留为回滚/审计基线；当前实际权限以 §0 的 Full Operator 任命为准：
 
 | # | 禁止 | 为什么（已核实的机制） |
 |---|---|---|
@@ -16,9 +35,9 @@ iconexpert 入场即 **Human-D0**。D0 **禁止**以下，且由 `dev_doctor.sh`
 | D0-4 | **不共享 live DuckDB** | `data/amazon_growth.duckdb`（≈2.7GB）单写者、跨 worktree 硬链、禁并发写（AGE `CLAUDE.md`）。D0 用 fixture/synthetic，不碰 live warehouse |
 | D0-5 | **不进 Mac Studio shell** | Studio 上的 `.env.local`（chmod 600）含多店真生产凭证；给 shell = 绕过 D0-1。Studio 仅 owner 操作 |
 
-**允许**：只读代码、`uv run pytest`（无凭证）、fixture/synthetic dry-run、开 feature 分支 PR。
+**D0 允许**：只读代码、`uv run pytest`（无凭证）、fixture/synthetic dry-run、开 feature 分支 PR。
 
-## 2. Day-1 执行（AGE，他的 Mac mini）
+## 2. Day-1 执行（历史 D0 onboarding；AGE，他的 Mac mini）
 
 前提：他自己的 GitHub 账号、自己的 Claude/Codex 登录、SSH key 已加到 GitHub。
 
@@ -42,19 +61,22 @@ uv run pytest
 
 **dry-run 里程碑（待 PR-2 解锁）**：`execute_request --mode dry_run` 需要一个 `EXECUTION_REQUEST_PATH` synthetic fixture。本 PR（契约先落）**不提供** fixture，故此步暂不可跑，勿假装可跑。PR-2 的 `dev_doctor.sh` 落地并附带最小 synthetic request 后，D0 里程碑才升级为「dry-run 产出 `DRY_RUN_APPLIED` receipt（默认 `dry_run` + `AGE_WRITE_ENABLED` 未设）」。
 
-## 3. 服务端边界（已就位 / 待办）
+## 3. 服务端边界（D0 baseline + current non-bypass rules）
 
-- AGE main：✅ branch protection 已配（PR + 1 review、禁 force-push/删除、`required_status_checks=null`、admin 保留 bypass）。iconexpert（write、非 admin）改 main 必须走 PR + owner 审。
+- AGE main：✅ branch protection 已配（PR + 1 review、禁 force-push/删除、`required_status_checks=null`、admin 保留 bypass）。iconexpert 升级为 Full Operator 后仍不默认获得 admin bypass；改 main 必须走 PR + review。
 - AGE secret scanning：❌ 私有仓不可用（需 GHAS）。→ 密钥防线 = 本地 hooks（必装）+ CI leak-guard（`koi-leakage-lint`/`bare-ads-write-lint`/`amazon-leak-guard`）+ D0-1 凭证缺失。
 - AGE CI：**暂不作 required check**（`ci.yml` 仅 guard-rail + best-effort；重测试在 post-merge；曾因计费/runner `steps:[]` 失败）。合并门 = **PR 人审 + 本地验证记录**，等 CI 连续绿再加 required。
-- liye_os：iconexpert 首战不碰；其 branch protection 由 liyecom owner 单独开（见 [[TEAM_DEV_MODEL]] §4/§7）。
+- liye_os：本次 Full Operator scope 是 AGE production/operator lane；liye_os SSOT 修改仍走 PR + owner review，不因 AGE operator 身份自动获得 control-plane admin。
 
 ## 4. 权限发放
 
-- org 邀请 iconexpert → AGE **Write（feature 分支）**；初期不动既有 CODEOWNERS。
-- 不发任何生产凭证（D0-1）。进入 D1/sandbox 或只读 API 时，才按 [[TEAM_DEV_MODEL]] §2 发 sandbox 凭证，且经安全信道、可撤权。
+- 当前状态：iconexpert → AGE **Full Operator / Human-D3**（见 [[TEAM_DEV_MODEL]] §3.1）。
+- GitHub 权限建议为 Write/Maintain；branch protection 继续生效，不授予默认 admin bypass。
+- 生产凭证可按 Full Operator scope 经安全信道受控分发；不得提交、同步、截图或写入任何 repo / memory / artifact。
+- `AGE_WRITE_ENABLED` 不作为常驻环境变量分发；仅在单次已授权 live run 命令环境中临时设置。
+- 若任意生产凭证、DB write、truth-layer repair、rollback 或 live write 超出当次授权 scope，必须停下重新取得明确授权。
 
-## 5. 配套 PR 路线（本文件 = PR-0；契约先落，工具后补）
+## 5. 配套 PR 路线（历史 D0 route；契约先落，工具后补）
 
 | PR | 交付 | 目的 |
 |---|---|---|
@@ -66,7 +88,7 @@ uv run pytest
 
 ## 6. 撤权（offboarding 预案）
 
-30 分钟内可撤：GitHub org 权限 + 任何分发的 sandbox token + （若曾给）Studio 独立账号。
+30 分钟内可撤：GitHub org 权限 + 任何分发的 sandbox/prod token + （若曾给）Studio 独立账号。撤权后必须 rotation/revoke 所有曾向 iconexpert 分发的 production secrets，并记录最后一次 AGE live/DB/truth-layer 操作的 receipt 或 decision log。
 
 ---
 


### PR DESCRIPTION
## Summary

- Promote iconexpert from Human-D0 to AGE Full Operator / Human-D3 in `TEAM_DEV_MODEL`.
- Update `ICONEXPERT_ONBOARDING` so the current status is D3 while preserving the original D0 onboarding contract as historical baseline.
- Define what Full Operator can do and which gates remain non-bypassable.

## Guardrails Kept

- No GitHub admin / branch protection bypass is granted by this model change.
- No shared owner auth, session, Keychain, Studio shell, or committed secrets.
- No blanket `AGE_WRITE_ENABLED`; it remains per-run and per-authorization.
- No Phase authorization inheritance.
- Dual approval remains when AGE policy requires it.

## Validation

- `git diff --check`
- pre-commit hooks passed on commit
