### PR TITLE
ci(contracts-gate): wire governed-work-loop validator (C1-C8) into gate

### DIFF
--- a/.github/workflows/contracts-gate.yml
+++ b/.github/workflows/contracts-gate.yml
@@ -15,6 +15,7 @@ on:
       - 'engine_manifest.yaml'
       - '.claude/scripts/proactive/**'
       - 'data/traces/**'
+      - '.github/workflows/contracts-gate.yml'
   push:
     branches:
       - main
@@ -24,6 +25,7 @@ on:
       - 'engine_manifest.yaml'
       - '.claude/scripts/proactive/**'
       - 'data/traces/**'
+      - '.github/workflows/contracts-gate.yml'
 
 jobs:
   validate-contracts:
@@ -41,7 +43,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm install yaml
+          npm install yaml ajv ajv-formats
 
       - name: Create policies directories (if not exist)
         run: |
@@ -52,6 +54,13 @@ jobs:
       - name: Run Contracts Validator
         run: |
           node _meta/contracts/scripts/validate-contracts.mjs
+
+      - name: Run Governed Work Loop Validator (C1-C8)
+        run: |
+          # Layer A (ajv structural / cross-field C1-C8) + Layer B (semantic derivations).
+          # Expect-table semantics: valid_*/templates MUST pass, invalid_* MUST be rejected.
+          # Exit 1 on any expectation miss (fail-closed).
+          node _meta/contracts/scripts/validate-governed-work-loop.mjs
 
       - name: Check SSOT (Single Source of Truth)
         run: |

--- a/_meta/contracts/loop/README.md
+++ b/_meta/contracts/loop/README.md
@@ -87,8 +87,15 @@ rejection is for the right reason. Exit 0 = all met expectation, 1 = fail-closed
 - Not declaring loamwise Layer 1 a unified autonomous loop runner — WriteEngine is a
   single-TaskRun orchestrator ("Not a scheduler. Not a worker. Not an autonomous loop.")
   with mock dispatchers (beta-readiness). Runner is a later, attested build.
-- **CI / contracts-gate wiring deferred** (Actions billing blocked). This validator is
-  **not** registered in the contracts gate (`validate-contracts.mjs`), so a green
-  Contracts-Gate / CI run does **not** exercise C1–C8 or the Layer-B derivations —
-  enforcement is by running this script directly (operator/local). Wiring it into the
-  gate is a tracked follow-up; CI-green must not be read as "C1–C8 covered".
+- Not registering the loop schema in `validate-contracts.mjs` `schemaFiles[]` — the loop
+  contract stays one of the dedicated-validator contracts in the 21-schema gate count
+  (enum-only carve-out), because its expect-table semantics (`invalid_*` fixtures MUST be
+  rejected) don't fit the generic validator's pass-only model.
+
+## CI wiring (since contracts-gate step "Run Governed Work Loop Validator")
+
+This validator runs as a dedicated fail-closed step in
+`.github/workflows/contracts-gate.yml`: any PR touching `_meta/contracts/**` (or the
+workflow itself) fails the Contracts Gate if a template/fixture stops meeting its
+expectation — C1–C8 at Layer A, or a Layer-B derivation. A green Contracts-Gate run
+now DOES exercise C1–C8. Local enforcement is unchanged: run the script directly.


### PR DESCRIPTION
## What

Wires `_meta/contracts/scripts/validate-governed-work-loop.mjs` (C1-C8, two-layer) into the Contracts Gate as a dedicated fail-closed CI step. Operator-approved batch item 1/3 (loop-engineering plan Wave 0.1).

## Why

`_meta/contracts/loop/README.md` self-disclosed since #194: the validator was **not** registered in any gate — "CI-green must not be read as 'C1-C8 covered'". The contract language layer's own gate had no gate. This is the smallest, hardest, highest-yield fix and a precondition for all future runner work.

## Changes (2 files, +22/-6)

- `.github/workflows/contracts-gate.yml`
  - new step `Run Governed Work Loop Validator (C1-C8)` after the existing contracts validator (expect-table semantics: `valid_*`/templates MUST pass, `invalid_*` MUST be rejected; exit 1 = red)
  - `npm install yaml` → `npm install yaml ajv ajv-formats` (validator uses real ajv; both already declared in package.json dependencies)
  - workflow file added to its own `paths:` triggers — future edits to the gate re-run the gate
- `_meta/contracts/loop/README.md`
  - deferred-wiring honesty paragraph replaced with the actual CI-wiring state
  - explicitly keeps loop schema OUT of `validate-contracts.mjs` `schemaFiles[]`: dedicated-validator carve-out, 21-gate count unchanged (enum-only discipline per ADR-UGE-Fact-Taxonomy)

## Verification (clean worktree from origin/main @ bddc837, mirrors CI exactly)

- `npm install yaml ajv ajv-formats` from empty node_modules → ok (3s)
- `node _meta/contracts/scripts/validate-governed-work-loop.mjs` → **All 12 files met expectation**, exit 0
- `node _meta/contracts/scripts/validate-contracts.mjs` → PASSED, exit 0
- `node _meta/contracts/scripts/validate-contracts.mjs --check-ssot` → PASSED, exit 0
- workflow YAML parse → ok

This PR itself touches `_meta/contracts/**`, so the new step runs on this very PR — the wiring self-demonstrates.

## Blast radius / rollback

Additive CI step only; no schema, fixture, or validator-logic change. Rollback = revert the workflow step (README paragraph would need re-flipping to stay honest). If the step is red on this PR, that is the gate working — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)