### PR TITLE
governance: add governed execution contract v0

### DIFF
--- a/.github/workflows/contracts-gate.yml
+++ b/.github/workflows/contracts-gate.yml
@@ -62,6 +62,13 @@ jobs:
           # Exit 1 on any expectation miss (fail-closed).
           node _meta/contracts/scripts/validate-governed-work-loop.mjs
 
+      - name: Run Governed Execution Contract Validator (v0)
+        run: |
+          # Layer A (ajv structure/conditions) + Layer B (identity, receipt,
+          # readback, and verdict recomputation). Negative fixtures bind an
+          # intended layer + marker, so unrelated rejection is not a green test.
+          node _meta/contracts/scripts/validate-governed-execution.mjs
+
       - name: Check SSOT (Single Source of Truth)
         run: |
           # Delegate to validator's own checkSSOT() — accepts legacy learned_policy.schema

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,9 @@
 
 | 资产 | 路径 | 一句话 |
 |------|------|--------|
-| 契约 SSOT（21-schema gate） | `_meta/contracts/` | learning×13 · engine×2（v1+v2）· governance×3 · loop×1 · playbook×1 · proactive×1；其中 16 个注册在 `validate-contracts.mjs` `schemaFiles[]`，5 个由专用校验器覆盖 |
+| 契约 SSOT（22-schema gate） | `_meta/contracts/` | learning×13 · engine×2（v1+v2）· governance×3 · loop×1 · execution×1 · playbook×1 · proactive×1；其中 16 个注册在 `validate-contracts.mjs` `schemaFiles[]`，6 个由专用校验器覆盖 |
 | loop contract v2（C1-C13） | `_meta/contracts/loop/` | governed work loop 契约语言层：schema + template + fixtures，两层校验（ajv 结构 + 语义派生）；v2 增 stop_condition/kill_switch/evidence_package/词表收紧；`contract_status: schema_validated_only`，背后无 runner |
+| execution contract v0 | `_meta/contracts/execution/` | 受治理执行的 schema + template + fixtures：approval/resume/receipt/readback/verdict/rollback-ref；`contract_status: schema_validated_only`，不隐含 runner/runtime |
 | 政策 | `_meta/policies/` | `DEFAULT_SKILL_POLICY.md`（9 条，Policy 9=Surgical Scope）+ `BACKLOG_INTAKE_POLICY.md`（agent 只 propose、operator 翻牌） |
 | ADR | `_meta/adr/` | 22 份；新决策先查重再增 |
 | SPEC | `_meta/specs/` | 跨仓 SPEC（含 user-growth-engine） |
@@ -35,6 +36,7 @@
 node _meta/contracts/scripts/validate-contracts.mjs              # 契约总校验
 node _meta/contracts/scripts/validate-contracts.mjs --check-ssot # SSOT 单实例检查
 node _meta/contracts/scripts/validate-governed-work-loop.mjs     # loop C1-C13（已接 contracts-gate CI）
+node _meta/contracts/scripts/validate-governed-execution.mjs    # execution v0（结构+语义双层，已接 CI）
 python3 _meta/contracts/scripts/validate_manifest_reality.py     # Hard Gate 5 / manifest reality
 node .claude/scripts/guardrail.mjs                               # 本文件+packs 字数门
 npm test                                                         # vitest（已 exclude node:test 系列）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,6 @@ launchd `com.liye.manifest-reality-clock`：每日本地 09:05 跑 `_meta/contra
 
 ---
 
-**Version**: 3.1（C2 SSOT/navigation truth-sync）
+**Version**: 3.2（C4 execution contract v0）
 **Last Updated**: 2026-07-10
 **前身**: v2.2（2026-01-13，描绘 src/ 运行时与 Notion/packs 工作流——该形态已归入静止区，历史见 git）

--- a/_meta/contracts/execution/README.md
+++ b/_meta/contracts/execution/README.md
@@ -1,0 +1,63 @@
+# Governed Execution Contract v0
+
+This package is the long-lived contract language for governed execution. It harvests
+five semantics already exercised by Loamwise: approval, checkpoint-authoritative
+resume, immutable receipt/readback, receipt-bound verdict, and rollback references
+for reversible actions.
+
+`contract_status: schema_validated_only` is an honesty boundary. The schema, template,
+fixtures, validator, and CI gate exist; no runner is bound by this package yet. A valid
+document does **not** imply that any execution engine, queue, scheduler, state broker,
+or cross-domain runtime exists.
+
+## Package layers
+
+| Layer | Location | Meaning |
+|---|---|---|
+| schema | `governed_execution_v0.schema.yaml` | draft-07 shape and cross-field constraints |
+| template | `templates/governed_execution.template.yaml` | fixed semantic profile, with no invented run evidence |
+| per-run | an engine-owned evidence location | one execution identity, authority, resume source, receipt, and verdict |
+
+The contract lives here; implementations remain inside each domain engine. A future
+engine binding must cite this schema and provide per-run evidence. It does not inherit
+authority merely by conforming.
+
+## Machine-enforced invariants
+
+The dedicated validator runs two layers:
+
+- **Layer A (AJV):** closed objects; template/per-run separation; live execution must
+  cite an existing envelope and either a pre-authorization artifact or an explicit
+  approved decision; live execution must declare a called-party, enable-required brake
+  and required readback; checkpoint resume must carry a complete hash-anchored snapshot;
+  available rollback capability must carry `rollback_ref`; `HOLD` must carry a reason.
+- **Layer B (semantic recomputation):** execution, receipt, and verdict identities must
+  match; explicit approval request/decision IDs must match; receipt summary and aggregate
+  readback are recomputed from entries; dry-run/live status vocabularies cannot mix; the
+  verdict is derived conservatively from the receipt. A live `PASS` requires at least one
+  success, no failure/partial/halt/simulation, and verified readback.
+
+Negative fixtures carry an explicit expectation table in the validator. Each must fail
+in its intended layer and with its intended marker; rejection for an unrelated defect is
+not counted as a green test.
+
+## Validate
+
+```bash
+node _meta/contracts/scripts/validate-governed-execution.mjs
+```
+
+The same command is a fail-closed step in `.github/workflows/contracts-gate.yml`.
+
+## Deliberately absent from v0
+
+- runner, worker, queue, scheduler, state broker, or mission broker;
+- action payloads or a universal action taxonomy;
+- a rollback executor (the contract records a reference, not an implementation);
+- cell routing or cross-client mutation authority;
+- D0-D3 promotion logic or a D2 rewrite;
+- `EXPAND` verdict semantics (declared in older code, but not emitted by the verified
+  Loamwise verdict builder).
+
+Schema evolution is demand-pulled by a real engine binding or execution case. The
+contract is not a warrant for speculative runtime or compatibility work.

--- a/_meta/contracts/execution/fixtures/invalid_approval_request_mismatch.yaml
+++ b/_meta/contracts/execution/fixtures/invalid_approval_request_mismatch.yaml
@@ -1,0 +1,6 @@
+fixture_kind: governed_execution_mutation
+base_fixture: valid_live_explicit_approval.yaml
+mutations:
+  - operation: replace
+    json_pointer: /authority/approval_decision/request_id
+    value: approval-wrong

--- a/_meta/contracts/execution/fixtures/invalid_identity_mismatch.yaml
+++ b/_meta/contracts/execution/fixtures/invalid_identity_mismatch.yaml
@@ -1,0 +1,6 @@
+fixture_kind: governed_execution_mutation
+base_fixture: valid_live_pre_authorized.yaml
+mutations:
+  - operation: replace
+    json_pointer: /receipt/task_id
+    value: task-wrong

--- a/_meta/contracts/execution/fixtures/invalid_live_without_authorization.yaml
+++ b/_meta/contracts/execution/fixtures/invalid_live_without_authorization.yaml
@@ -1,0 +1,6 @@
+fixture_kind: governed_execution_mutation
+base_fixture: valid_live_pre_authorized.yaml
+mutations:
+  - operation: replace
+    json_pointer: /authority/kind
+    value: not_required

--- a/_meta/contracts/execution/fixtures/invalid_pass_without_readback.yaml
+++ b/_meta/contracts/execution/fixtures/invalid_pass_without_readback.yaml
@@ -1,0 +1,9 @@
+fixture_kind: governed_execution_mutation
+base_fixture: valid_live_pre_authorized.yaml
+mutations:
+  - operation: replace
+    json_pointer: /receipt/entries/0/readback_verified
+    value: null
+  - operation: replace
+    json_pointer: /receipt/readback_verified
+    value: null

--- a/_meta/contracts/execution/fixtures/invalid_readback_aggregate_mismatch.yaml
+++ b/_meta/contracts/execution/fixtures/invalid_readback_aggregate_mismatch.yaml
@@ -1,0 +1,6 @@
+fixture_kind: governed_execution_mutation
+base_fixture: valid_live_pre_authorized.yaml
+mutations:
+  - operation: replace
+    json_pointer: /receipt/readback_verified
+    value: false

--- a/_meta/contracts/execution/fixtures/invalid_resume_without_checkpoint.yaml
+++ b/_meta/contracts/execution/fixtures/invalid_resume_without_checkpoint.yaml
@@ -1,0 +1,5 @@
+fixture_kind: governed_execution_mutation
+base_fixture: valid_resumed_dry_run.yaml
+mutations:
+  - operation: remove
+    json_pointer: /resume/checkpoint

--- a/_meta/contracts/execution/fixtures/invalid_rollback_available_without_ref.yaml
+++ b/_meta/contracts/execution/fixtures/invalid_rollback_available_without_ref.yaml
@@ -1,0 +1,5 @@
+fixture_kind: governed_execution_mutation
+base_fixture: valid_live_explicit_approval.yaml
+mutations:
+  - operation: remove
+    json_pointer: /receipt/entries/0/rollback/rollback_ref

--- a/_meta/contracts/execution/fixtures/invalid_summary_mismatch.yaml
+++ b/_meta/contracts/execution/fixtures/invalid_summary_mismatch.yaml
@@ -1,0 +1,6 @@
+fixture_kind: governed_execution_mutation
+base_fixture: valid_live_pre_authorized.yaml
+mutations:
+  - operation: replace
+    json_pointer: /receipt/summary/succeeded
+    value: 0

--- a/_meta/contracts/execution/fixtures/invalid_verdict_receipt_mismatch.yaml
+++ b/_meta/contracts/execution/fixtures/invalid_verdict_receipt_mismatch.yaml
@@ -1,0 +1,6 @@
+fixture_kind: governed_execution_mutation
+base_fixture: valid_live_pre_authorized.yaml
+mutations:
+  - operation: replace
+    json_pointer: /verdict/receipt_id
+    value: receipt-wrong

--- a/_meta/contracts/execution/fixtures/valid_live_explicit_approval.yaml
+++ b/_meta/contracts/execution/fixtures/valid_live_explicit_approval.yaml
@@ -1,0 +1,85 @@
+contract_kind: governed_execution
+schema_version: "0.1.0"
+contract_status: schema_validated_only
+instance_scope: per_run
+template_ref: _meta/contracts/execution/templates/governed_execution.template.yaml
+semantic_profile:
+  approval: envelope_or_explicit_decision
+  resume: checkpoint_authoritative
+  receipt: immutable_hash_anchored_with_readback
+  verdict: receipt_bound
+  reversible_execution: rollback_ref_when_available
+execution_identity:
+  execution_id: exec-example-001
+  task_id: task-example-001
+  run_id: run-example-001
+  changeset_id: changeset-example-001
+  execution_mode: live
+authority:
+  kind: explicit_decision
+  envelope_ref: envelopes/example-write-v1
+  approval_request:
+    request_id: approval-example-001
+    artifact_ref: evidence/approval/request-example-001.yaml
+    sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  approval_decision:
+    request_id: approval-example-001
+    decision: APPROVED
+    decided_at: "2026-07-10T01:00:00Z"
+    artifact_ref: evidence/approval/decision-example-001.yaml
+    sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+resume:
+  mode: fresh
+live_safety:
+  brake:
+    placement: called_party
+    policy: enable_required
+    mechanism_ref: called-party/write-gate
+    drill_evidence_ref: evidence/drills/write-gate-example.json
+    drill_evidence_sha256: cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  readback:
+    required: true
+receipt:
+  receipt_id: receipt-example-001
+  execution_id: exec-example-001
+  task_id: task-example-001
+  run_id: run-example-001
+  changeset_id: changeset-example-001
+  execution_mode: live
+  emitted_at: "2026-07-10T01:02:00Z"
+  receipt_sha256: dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+  entries:
+    - action_id: action-example-001
+      action_kind: update_example
+      status: SUCCESS
+      idempotency_result: EXECUTE
+      readback_verified: true
+      external_action_ref: external/example-001
+      rollback:
+        capability: available
+        rollback_ref: rollback/example-001
+    - action_id: action-example-002
+      action_kind: update_example
+      status: SKIPPED
+      idempotency_result: SKIP
+      readback_verified: null
+      rollback:
+        capability: unavailable
+  readback_verified: true
+  summary:
+    total: 2
+    succeeded: 1
+    partial_success: 0
+    failed: 0
+    skipped: 1
+    halted: 0
+    simulated: 0
+verdict:
+  verdict_id: verdict-example-001
+  execution_id: exec-example-001
+  task_id: task-example-001
+  run_id: run-example-001
+  changeset_id: changeset-example-001
+  receipt_id: receipt-example-001
+  decision: PASS
+  issued_at: "2026-07-10T01:03:00Z"

--- a/_meta/contracts/execution/fixtures/valid_live_pre_authorized.yaml
+++ b/_meta/contracts/execution/fixtures/valid_live_pre_authorized.yaml
@@ -1,0 +1,69 @@
+contract_kind: governed_execution
+schema_version: "0.1.0"
+contract_status: schema_validated_only
+instance_scope: per_run
+template_ref: _meta/contracts/execution/templates/governed_execution.template.yaml
+semantic_profile:
+  approval: envelope_or_explicit_decision
+  resume: checkpoint_authoritative
+  receipt: immutable_hash_anchored_with_readback
+  verdict: receipt_bound
+  reversible_execution: rollback_ref_when_available
+execution_identity:
+  execution_id: exec-example-002
+  task_id: task-example-002
+  run_id: run-example-002
+  changeset_id: changeset-example-002
+  execution_mode: live
+authority:
+  kind: pre_authorized
+  envelope_ref: envelopes/example-write-v1
+  authorization_ref: evidence/authorization/envelope-example-002.yaml
+  authorization_sha256: eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+resume:
+  mode: fresh
+live_safety:
+  brake:
+    placement: called_party
+    policy: enable_required
+    mechanism_ref: called-party/write-gate
+    drill_evidence_ref: evidence/drills/write-gate-example.json
+    drill_evidence_sha256: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  readback:
+    required: true
+receipt:
+  receipt_id: receipt-example-002
+  execution_id: exec-example-002
+  task_id: task-example-002
+  run_id: run-example-002
+  changeset_id: changeset-example-002
+  execution_mode: live
+  emitted_at: "2026-07-10T02:02:00Z"
+  receipt_sha256: "1111111111111111111111111111111111111111111111111111111111111111"
+  entries:
+    - action_id: action-example-003
+      action_kind: update_example
+      status: SUCCESS
+      idempotency_result: EXECUTE
+      readback_verified: true
+      external_action_ref: external/example-003
+      rollback:
+        capability: unavailable
+  readback_verified: true
+  summary:
+    total: 1
+    succeeded: 1
+    partial_success: 0
+    failed: 0
+    skipped: 0
+    halted: 0
+    simulated: 0
+verdict:
+  verdict_id: verdict-example-002
+  execution_id: exec-example-002
+  task_id: task-example-002
+  run_id: run-example-002
+  changeset_id: changeset-example-002
+  receipt_id: receipt-example-002
+  decision: PASS
+  issued_at: "2026-07-10T02:03:00Z"

--- a/_meta/contracts/execution/fixtures/valid_resumed_dry_run.yaml
+++ b/_meta/contracts/execution/fixtures/valid_resumed_dry_run.yaml
@@ -1,0 +1,65 @@
+contract_kind: governed_execution
+schema_version: "0.1.0"
+contract_status: schema_validated_only
+instance_scope: per_run
+template_ref: _meta/contracts/execution/templates/governed_execution.template.yaml
+semantic_profile:
+  approval: envelope_or_explicit_decision
+  resume: checkpoint_authoritative
+  receipt: immutable_hash_anchored_with_readback
+  verdict: receipt_bound
+  reversible_execution: rollback_ref_when_available
+execution_identity:
+  execution_id: exec-example-003
+  task_id: task-example-003
+  run_id: run-example-003
+  changeset_id: changeset-example-003
+  execution_mode: dry_run
+authority:
+  kind: not_required
+resume:
+  mode: from_checkpoint
+  checkpoint:
+    checkpoint_id: checkpoint-example-003
+    phase: dry_run
+    snapshot_version: "1"
+    state_snapshot_ref: evidence/checkpoints/checkpoint-example-003.json
+    state_snapshot_sha256: "2222222222222222222222222222222222222222222222222222222222222222"
+    persisted_at: "2026-07-10T03:00:00Z"
+    checkpoint_status: resumable
+receipt:
+  receipt_id: receipt-example-003
+  execution_id: exec-example-003
+  task_id: task-example-003
+  run_id: run-example-003
+  changeset_id: changeset-example-003
+  execution_mode: dry_run
+  emitted_at: "2026-07-10T03:02:00Z"
+  receipt_sha256: "3333333333333333333333333333333333333333333333333333333333333333"
+  entries:
+    - action_id: action-example-004
+      action_kind: update_example
+      status: DRY_RUN_SIMULATED
+      idempotency_result: EXECUTE
+      readback_verified: null
+      rollback:
+        capability: unavailable
+  readback_verified: null
+  summary:
+    total: 1
+    succeeded: 0
+    partial_success: 0
+    failed: 0
+    skipped: 0
+    halted: 0
+    simulated: 1
+verdict:
+  verdict_id: verdict-example-003
+  execution_id: exec-example-003
+  task_id: task-example-003
+  run_id: run-example-003
+  changeset_id: changeset-example-003
+  receipt_id: receipt-example-003
+  decision: HOLD
+  hold_reason: AWAITING_OBSERVATION
+  issued_at: "2026-07-10T03:03:00Z"

--- a/_meta/contracts/execution/governed_execution_v0.schema.yaml
+++ b/_meta/contracts/execution/governed_execution_v0.schema.yaml
@@ -1,0 +1,405 @@
+# Governed Execution Contract v0.1.0
+# SSOT: _meta/contracts/execution/governed_execution_v0.schema.yaml
+#
+# This contract harvests only execution semantics already proven in Loamwise:
+# approval, checkpoint-authoritative resume, receipt/readback, receipt-bound verdict,
+# and rollback references for reversible actions. It defines no runner, queue,
+# scheduler, state broker, or cross-domain orchestration protocol.
+#
+# contract_status is deliberately locked to schema_validated_only. A conforming YAML
+# document proves only that the contract package and its semantic validator accept the
+# document; it does not prove that an execution engine is bound to this contract.
+
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://liye.com/contracts/execution/governed_execution.v0"
+title: "Governed Execution Contract v0"
+description: "Schema/template/per-run language for governed execution evidence; no runner implied."
+version: "0.1.0"
+type: object
+additionalProperties: false
+required:
+  - contract_kind
+  - schema_version
+  - contract_status
+  - instance_scope
+  - semantic_profile
+properties:
+  contract_kind:
+    const: governed_execution
+  schema_version:
+    const: "0.1.0"
+  contract_status:
+    const: schema_validated_only
+  instance_scope:
+    enum: [template, per_run]
+  template_ref:
+    type: string
+    minLength: 1
+  semantic_profile:
+    type: object
+    additionalProperties: false
+    required: [approval, resume, receipt, verdict, reversible_execution]
+    properties:
+      approval:
+        const: envelope_or_explicit_decision
+      resume:
+        const: checkpoint_authoritative
+      receipt:
+        const: immutable_hash_anchored_with_readback
+      verdict:
+        const: receipt_bound
+      reversible_execution:
+        const: rollback_ref_when_available
+  execution_identity:
+    $ref: "#/definitions/execution_identity"
+  authority:
+    $ref: "#/definitions/authority"
+  resume:
+    $ref: "#/definitions/resume"
+  live_safety:
+    $ref: "#/definitions/live_safety"
+  receipt:
+    $ref: "#/definitions/receipt"
+  verdict:
+    $ref: "#/definitions/verdict"
+
+allOf:
+  - if:
+      properties:
+        instance_scope: { const: template }
+      required: [instance_scope]
+    then:
+      required: [template_ref]
+      not:
+        anyOf:
+          - required: [execution_identity]
+          - required: [authority]
+          - required: [resume]
+          - required: [live_safety]
+          - required: [receipt]
+          - required: [verdict]
+  - if:
+      properties:
+        instance_scope: { const: per_run }
+      required: [instance_scope]
+    then:
+      required: [template_ref, execution_identity, authority, resume, receipt, verdict]
+  - if:
+      properties:
+        execution_identity:
+          properties:
+            execution_mode: { const: live }
+          required: [execution_mode]
+      required: [execution_identity]
+    then:
+      required: [live_safety]
+      properties:
+        authority:
+          properties:
+            kind:
+              enum: [pre_authorized, explicit_decision]
+  - if:
+      properties:
+        authority:
+          properties:
+            kind: { const: not_required }
+          required: [kind]
+      required: [authority]
+    then:
+      properties:
+        execution_identity:
+          properties:
+            execution_mode: { const: dry_run }
+        authority:
+          not:
+            anyOf:
+              - required: [envelope_ref]
+              - required: [authorization_ref]
+              - required: [authorization_sha256]
+              - required: [approval_request]
+              - required: [approval_decision]
+  - if:
+      properties:
+        authority:
+          properties:
+            kind: { const: pre_authorized }
+          required: [kind]
+      required: [authority]
+    then:
+      properties:
+        authority:
+          required: [envelope_ref, authorization_ref, authorization_sha256]
+          not:
+            anyOf:
+              - required: [approval_request]
+              - required: [approval_decision]
+  - if:
+      properties:
+        authority:
+          properties:
+            kind: { const: explicit_decision }
+          required: [kind]
+      required: [authority]
+    then:
+      properties:
+        authority:
+          required: [envelope_ref, approval_request, approval_decision]
+          not:
+            anyOf:
+              - required: [authorization_ref]
+              - required: [authorization_sha256]
+  - if:
+      properties:
+        resume:
+          properties:
+            mode: { const: fresh }
+          required: [mode]
+      required: [resume]
+    then:
+      properties:
+        resume:
+          not:
+            required: [checkpoint]
+  - if:
+      properties:
+        resume:
+          properties:
+            mode: { const: from_checkpoint }
+          required: [mode]
+      required: [resume]
+    then:
+      properties:
+        resume:
+          required: [checkpoint]
+
+definitions:
+  sha256:
+    type: string
+    pattern: "^[a-f0-9]{64}$"
+  execution_identity:
+    type: object
+    additionalProperties: false
+    required: [execution_id, task_id, run_id, changeset_id, execution_mode]
+    properties:
+      execution_id: { type: string, minLength: 1 }
+      task_id: { type: string, minLength: 1 }
+      run_id: { type: string, minLength: 1 }
+      changeset_id: { type: string, minLength: 1 }
+      execution_mode:
+        enum: [dry_run, live]
+  authority:
+    type: object
+    additionalProperties: false
+    required: [kind]
+    properties:
+      kind:
+        enum: [not_required, pre_authorized, explicit_decision]
+      envelope_ref:
+        type: string
+        minLength: 1
+      authorization_ref:
+        type: string
+        minLength: 1
+      authorization_sha256:
+        $ref: "#/definitions/sha256"
+      approval_request:
+        type: object
+        additionalProperties: false
+        required: [request_id, artifact_ref, sha256]
+        properties:
+          request_id: { type: string, minLength: 1 }
+          artifact_ref: { type: string, minLength: 1 }
+          sha256:
+            $ref: "#/definitions/sha256"
+      approval_decision:
+        type: object
+        additionalProperties: false
+        required: [request_id, decision, decided_at, artifact_ref, sha256]
+        properties:
+          request_id: { type: string, minLength: 1 }
+          decision: { const: APPROVED }
+          decided_at: { type: string, format: date-time }
+          artifact_ref: { type: string, minLength: 1 }
+          sha256:
+            $ref: "#/definitions/sha256"
+  resume:
+    type: object
+    additionalProperties: false
+    required: [mode]
+    properties:
+      mode:
+        enum: [fresh, from_checkpoint]
+      checkpoint:
+        type: object
+        additionalProperties: false
+        required:
+          - checkpoint_id
+          - phase
+          - snapshot_version
+          - state_snapshot_ref
+          - state_snapshot_sha256
+          - persisted_at
+          - checkpoint_status
+        properties:
+          checkpoint_id: { type: string, minLength: 1 }
+          phase:
+            enum: [gate_check, approval_wait, dry_run, live_pending, measuring]
+          snapshot_version: { type: string, minLength: 1 }
+          state_snapshot_ref: { type: string, minLength: 1 }
+          state_snapshot_sha256:
+            $ref: "#/definitions/sha256"
+          persisted_at: { type: string, format: date-time }
+          checkpoint_status:
+            const: resumable
+  live_safety:
+    type: object
+    additionalProperties: false
+    required: [brake, readback]
+    properties:
+      brake:
+        type: object
+        additionalProperties: false
+        required: [placement, policy, mechanism_ref, drill_evidence_ref, drill_evidence_sha256]
+        properties:
+          placement:
+            const: called_party
+          policy:
+            const: enable_required
+          mechanism_ref: { type: string, minLength: 1 }
+          drill_evidence_ref: { type: string, minLength: 1 }
+          drill_evidence_sha256:
+            $ref: "#/definitions/sha256"
+      readback:
+        type: object
+        additionalProperties: false
+        required: [required]
+        properties:
+          required:
+            const: true
+  receipt:
+    type: object
+    additionalProperties: false
+    required:
+      - receipt_id
+      - execution_id
+      - task_id
+      - run_id
+      - changeset_id
+      - execution_mode
+      - emitted_at
+      - receipt_sha256
+      - entries
+      - readback_verified
+      - summary
+    properties:
+      receipt_id: { type: string, minLength: 1 }
+      execution_id: { type: string, minLength: 1 }
+      task_id: { type: string, minLength: 1 }
+      run_id: { type: string, minLength: 1 }
+      changeset_id: { type: string, minLength: 1 }
+      execution_mode:
+        enum: [dry_run, live]
+      emitted_at: { type: string, format: date-time }
+      receipt_sha256:
+        $ref: "#/definitions/sha256"
+      entries:
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/definitions/receipt_entry"
+      readback_verified:
+        type: [boolean, "null"]
+      summary:
+        $ref: "#/definitions/receipt_summary"
+  receipt_entry:
+    type: object
+    additionalProperties: false
+    required:
+      - action_id
+      - action_kind
+      - status
+      - idempotency_result
+      - readback_verified
+      - rollback
+    properties:
+      action_id: { type: string, minLength: 1 }
+      action_kind: { type: string, minLength: 1 }
+      status:
+        enum: [SUCCESS, PARTIAL_SUCCESS, FAILED, SKIPPED, HALTED, DRY_RUN_SIMULATED]
+      idempotency_result:
+        enum: [EXECUTE, SKIP, UNKNOWN_STATE]
+      readback_verified:
+        type: [boolean, "null"]
+      external_action_ref:
+        type: string
+        minLength: 1
+      error:
+        type: string
+        minLength: 1
+      rollback:
+        type: object
+        additionalProperties: false
+        required: [capability]
+        properties:
+          capability:
+            enum: [unavailable, available]
+          rollback_ref:
+            type: string
+            minLength: 1
+        allOf:
+          - if:
+              properties:
+                capability: { const: available }
+              required: [capability]
+            then:
+              required: [rollback_ref]
+          - if:
+              properties:
+                capability: { const: unavailable }
+              required: [capability]
+            then:
+              not:
+                required: [rollback_ref]
+  receipt_summary:
+    type: object
+    additionalProperties: false
+    required: [total, succeeded, partial_success, failed, skipped, halted, simulated]
+    properties:
+      total: { type: integer, minimum: 1 }
+      succeeded: { type: integer, minimum: 0 }
+      partial_success: { type: integer, minimum: 0 }
+      failed: { type: integer, minimum: 0 }
+      skipped: { type: integer, minimum: 0 }
+      halted: { type: integer, minimum: 0 }
+      simulated: { type: integer, minimum: 0 }
+  verdict:
+    type: object
+    additionalProperties: false
+    required: [verdict_id, execution_id, task_id, run_id, changeset_id, receipt_id, decision, issued_at]
+    properties:
+      verdict_id: { type: string, minLength: 1 }
+      execution_id: { type: string, minLength: 1 }
+      task_id: { type: string, minLength: 1 }
+      run_id: { type: string, minLength: 1 }
+      changeset_id: { type: string, minLength: 1 }
+      receipt_id: { type: string, minLength: 1 }
+      decision:
+        enum: [PASS, FAIL, HOLD]
+      hold_reason:
+        enum: [INSUFFICIENT_EVIDENCE, AWAITING_OBSERVATION, PARTIAL_VERIFICATION]
+      issued_at: { type: string, format: date-time }
+    allOf:
+      - if:
+          properties:
+            decision: { const: HOLD }
+          required: [decision]
+        then:
+          required: [hold_reason]
+      - if:
+          properties:
+            decision:
+              enum: [PASS, FAIL]
+          required: [decision]
+        then:
+          not:
+            required: [hold_reason]

--- a/_meta/contracts/execution/templates/governed_execution.template.yaml
+++ b/_meta/contracts/execution/templates/governed_execution.template.yaml
@@ -1,0 +1,14 @@
+# Governed Execution — template layer only.
+# This is a contract-language profile, not an engine binding or a runner claim.
+contract_kind: governed_execution
+schema_version: "0.1.0"
+contract_status: schema_validated_only
+instance_scope: template
+template_ref: _meta/contracts/execution/templates/governed_execution.template.yaml
+
+semantic_profile:
+  approval: envelope_or_explicit_decision
+  resume: checkpoint_authoritative
+  receipt: immutable_hash_anchored_with_readback
+  verdict: receipt_bound
+  reversible_execution: rollback_ref_when_available

--- a/_meta/contracts/scripts/validate-governed-execution.mjs
+++ b/_meta/contracts/scripts/validate-governed-execution.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+/**
+ * Governed Execution Contract validator v0.1.0.
+ *
+ * Layer A: AJV draft-07 structure and conditional constraints.
+ * Layer B: recomputed identities, receipt summary/readback, and conservative verdict.
+ *
+ * Invalid fixtures are compact mutation cases over a valid fixture. The expectation
+ * table below pins both the intended rejection layer and a semantic error marker, so
+ * an invalid case rejected only because of an unrelated defect does not count as green.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { parse as parseYaml } from 'yaml';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EXECUTION_DIR = join(__dirname, '..', 'execution');
+const SCHEMA_FILE = join(EXECUTION_DIR, 'governed_execution_v0.schema.yaml');
+const TEMPLATE_DIR = join(EXECUTION_DIR, 'templates');
+const FIXTURE_DIR = join(EXECUTION_DIR, 'fixtures');
+
+const GREEN = '\x1b[32m';
+const RED = '\x1b[31m';
+const DIM = '\x1b[2m';
+const RESET = '\x1b[0m';
+
+const EXPECTED_INVALID = new Map([
+  ['invalid_approval_request_mismatch.yaml', { ajv: 'pass', marker: 'E_APPROVAL_REQUEST' }],
+  ['invalid_identity_mismatch.yaml', { ajv: 'pass', marker: 'E_IDENTITY_BINDING' }],
+  ['invalid_live_without_authorization.yaml', { ajv: 'reject', marker: 'E_LIVE_AUTHORITY' }],
+  ['invalid_readback_aggregate_mismatch.yaml', { ajv: 'pass', marker: 'E_READBACK_AGGREGATE' }],
+  ['invalid_resume_without_checkpoint.yaml', { ajv: 'reject', marker: 'E_RESUME_CHECKPOINT' }],
+  ['invalid_rollback_available_without_ref.yaml', { ajv: 'reject', marker: 'E_ROLLBACK_REF' }],
+  ['invalid_verdict_receipt_mismatch.yaml', { ajv: 'pass', marker: 'E_VERDICT_RECEIPT' }],
+  ['invalid_summary_mismatch.yaml', { ajv: 'pass', marker: 'E_SUMMARY_COUNTS' }],
+  ['invalid_pass_without_readback.yaml', { ajv: 'pass', marker: 'E_PASS_READBACK' }],
+]);
+
+function loadYaml(path) {
+  return parseYaml(readFileSync(path, 'utf8'));
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function pointerSegments(pointer) {
+  if (typeof pointer !== 'string' || !pointer.startsWith('/')) {
+    throw new Error(`invalid json_pointer: ${JSON.stringify(pointer)}`);
+  }
+  return pointer
+    .slice(1)
+    .split('/')
+    .map((part) => part.replace(/~1/g, '/').replace(/~0/g, '~'));
+}
+
+function applyMutation(document, mutation) {
+  const parts = pointerSegments(mutation?.json_pointer);
+  let parent = document;
+  for (const part of parts.slice(0, -1)) {
+    if (parent === null || typeof parent !== 'object' || !(part in parent)) {
+      throw new Error(`mutation path does not exist: ${mutation.json_pointer}`);
+    }
+    parent = parent[part];
+  }
+  const key = parts.at(-1);
+  if (parent === null || typeof parent !== 'object' || !(key in parent)) {
+    throw new Error(`mutation target does not exist: ${mutation.json_pointer}`);
+  }
+  if (mutation.operation === 'remove') {
+    if (Array.isArray(parent)) parent.splice(Number(key), 1);
+    else delete parent[key];
+    return;
+  }
+  if (mutation.operation === 'replace') {
+    parent[key] = mutation.value;
+    return;
+  }
+  throw new Error(`unsupported mutation operation: ${JSON.stringify(mutation.operation)}`);
+}
+
+function materializeInvalid(path) {
+  const spec = loadYaml(path);
+  if (spec?.fixture_kind !== 'governed_execution_mutation') {
+    throw new Error('invalid fixture must declare fixture_kind: governed_execution_mutation');
+  }
+  if (basename(spec.base_fixture || '') !== spec.base_fixture || !spec.base_fixture.startsWith('valid_')) {
+    throw new Error(`base_fixture must be a local valid_ fixture: ${JSON.stringify(spec.base_fixture)}`);
+  }
+  if (!Array.isArray(spec.mutations) || spec.mutations.length === 0) {
+    throw new Error('invalid fixture must declare at least one mutation');
+  }
+  const basePath = join(FIXTURE_DIR, spec.base_fixture);
+  if (!existsSync(basePath)) throw new Error(`base fixture not found: ${spec.base_fixture}`);
+  const document = clone(loadYaml(basePath));
+  for (const mutation of spec.mutations) applyMutation(document, mutation);
+  return document;
+}
+
+function error(code, detail) {
+  return { code, detail };
+}
+
+function expectedReadback(entries) {
+  const observed = entries
+    .map((entry) => entry?.readback_verified)
+    .filter((value) => typeof value === 'boolean');
+  if (observed.length === 0) return null;
+  return observed.every(Boolean);
+}
+
+const STATUS_TO_SUMMARY = {
+  SUCCESS: 'succeeded',
+  PARTIAL_SUCCESS: 'partial_success',
+  FAILED: 'failed',
+  SKIPPED: 'skipped',
+  HALTED: 'halted',
+  DRY_RUN_SIMULATED: 'simulated',
+};
+
+function recomputeSummary(entries) {
+  const summary = {
+    total: entries.length,
+    succeeded: 0,
+    partial_success: 0,
+    failed: 0,
+    skipped: 0,
+    halted: 0,
+    simulated: 0,
+  };
+  for (const entry of entries) {
+    const key = STATUS_TO_SUMMARY[entry?.status];
+    if (key) summary[key] += 1;
+  }
+  return summary;
+}
+
+function sameSummary(actual, expected) {
+  return Object.keys(expected).every((key) => actual?.[key] === expected[key]);
+}
+
+function expectedVerdict(mode, summary, aggregateReadback) {
+  if (mode === 'dry_run') return { decision: 'HOLD', hold_reason: 'AWAITING_OBSERVATION' };
+  if (summary.failed > 0 || summary.halted > 0) return { decision: 'FAIL' };
+  if (summary.total === summary.skipped) {
+    return { decision: 'HOLD', hold_reason: 'INSUFFICIENT_EVIDENCE' };
+  }
+  if (summary.partial_success > 0 || aggregateReadback !== true) {
+    return { decision: 'HOLD', hold_reason: 'PARTIAL_VERIFICATION' };
+  }
+  if (summary.succeeded > 0) return { decision: 'PASS' };
+  return { decision: 'HOLD', hold_reason: 'INSUFFICIENT_EVIDENCE' };
+}
+
+function semanticErrors(document) {
+  if (document?.instance_scope !== 'per_run') return [];
+
+  const errors = [];
+  const identity = document.execution_identity || {};
+  const authority = document.authority || {};
+  const resume = document.resume || {};
+  const receipt = document.receipt || {};
+  const verdict = document.verdict || {};
+  const entries = Array.isArray(receipt.entries) ? receipt.entries : [];
+
+  if (identity.execution_mode === 'live' && !['pre_authorized', 'explicit_decision'].includes(authority.kind)) {
+    errors.push(error('E_LIVE_AUTHORITY', 'live execution requires an existing envelope plus pre-authorization or explicit approval'));
+  }
+  if (authority.kind === 'explicit_decision' && authority.approval_request?.request_id !== authority.approval_decision?.request_id) {
+    errors.push(error('E_APPROVAL_REQUEST', 'approval decision must bind the same request_id as the approval request'));
+  }
+  if (resume.mode === 'from_checkpoint' && !resume.checkpoint) {
+    errors.push(error('E_RESUME_CHECKPOINT', 'from_checkpoint resume requires the authoritative checkpoint snapshot'));
+  }
+  for (const [index, entry] of entries.entries()) {
+    if (entry?.rollback?.capability === 'available' && !entry.rollback.rollback_ref) {
+      errors.push(error('E_ROLLBACK_REF', `receipt entry ${index} declares rollback available without rollback_ref`));
+    }
+  }
+
+  const identityKeys = ['execution_id', 'task_id', 'run_id', 'changeset_id'];
+  for (const key of identityKeys) {
+    if (identity[key] !== receipt[key] || identity[key] !== verdict[key]) {
+      errors.push(error('E_IDENTITY_BINDING', `${key} must match across execution_identity, receipt, and verdict`));
+    }
+  }
+  if (identity.execution_mode !== receipt.execution_mode) {
+    errors.push(error('E_IDENTITY_BINDING', 'execution_mode must match between execution_identity and receipt'));
+  }
+  if (verdict.receipt_id !== receipt.receipt_id) {
+    errors.push(error('E_VERDICT_RECEIPT', 'verdict receipt_id must bind the emitted receipt'));
+  }
+
+  const computedSummary = recomputeSummary(entries);
+  if (!sameSummary(receipt.summary, computedSummary)) {
+    errors.push(error('E_SUMMARY_COUNTS', `receipt summary does not match entries; expected ${JSON.stringify(computedSummary)}`));
+  }
+  const aggregateReadback = expectedReadback(entries);
+  if (!Object.is(receipt.readback_verified, aggregateReadback)) {
+    errors.push(error('E_READBACK_AGGREGATE', `receipt readback aggregate must be ${JSON.stringify(aggregateReadback)}`));
+  }
+
+  if (identity.execution_mode === 'dry_run' && entries.some((entry) => entry.status !== 'DRY_RUN_SIMULATED')) {
+    errors.push(error('E_MODE_STATUS', 'dry_run receipts may contain only DRY_RUN_SIMULATED entries'));
+  }
+  if (identity.execution_mode === 'live' && entries.some((entry) => entry.status === 'DRY_RUN_SIMULATED')) {
+    errors.push(error('E_MODE_STATUS', 'live receipts may not contain DRY_RUN_SIMULATED entries'));
+  }
+  if (verdict.decision === 'PASS' && aggregateReadback !== true) {
+    errors.push(error('E_PASS_READBACK', 'PASS requires verified readback; unknown or false is not success'));
+  }
+
+  const derived = expectedVerdict(identity.execution_mode, computedSummary, aggregateReadback);
+  if (verdict.decision !== derived.decision || verdict.hold_reason !== derived.hold_reason) {
+    errors.push(error('E_VERDICT_DERIVATION', `verdict must be ${derived.decision}${derived.hold_reason ? `/${derived.hold_reason}` : ''} for this receipt`));
+  }
+  return errors;
+}
+
+if (!existsSync(SCHEMA_FILE)) {
+  console.error(`${RED}Schema not found: ${SCHEMA_FILE}${RESET}`);
+  process.exit(1);
+}
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+const validate = ajv.compile(loadYaml(SCHEMA_FILE));
+
+const work = [];
+for (const file of readdirSync(TEMPLATE_DIR).filter((name) => name.endsWith('.template.yaml')).sort()) {
+  work.push({ file, path: join(TEMPLATE_DIR, file), kind: 'valid', label: `template/${file}` });
+}
+for (const file of readdirSync(FIXTURE_DIR).filter((name) => name.startsWith('valid_') && name.endsWith('.yaml')).sort()) {
+  work.push({ file, path: join(FIXTURE_DIR, file), kind: 'valid', label: `fixtures/${file}` });
+}
+for (const file of readdirSync(FIXTURE_DIR).filter((name) => name.startsWith('invalid_') && name.endsWith('.yaml')).sort()) {
+  work.push({ file, path: join(FIXTURE_DIR, file), kind: 'invalid', label: `fixtures/${file}` });
+}
+
+let failures = 0;
+const seenInvalid = new Set();
+console.log(`\nGoverned Execution Contract — schema + semantic validation (${work.length} cases)\n`);
+
+for (const item of work) {
+  try {
+    const document = item.kind === 'invalid' ? materializeInvalid(item.path) : loadYaml(item.path);
+    const ajvOk = validate(document);
+    const ajvErrors = ajvOk ? [] : (validate.errors || []);
+    const semantic = semanticErrors(document);
+
+    if (item.kind === 'valid') {
+      if (ajvOk && semantic.length === 0) {
+        console.log(`${GREEN}✅ ${item.label}${RESET} ${DIM}(passed Layer A + Layer B)${RESET}`);
+      } else {
+        failures += 1;
+        console.log(`${RED}❌ ${item.label}${RESET} (expected PASS)`);
+        for (const issue of ajvErrors) {
+          console.log(`   ${RED}- [Layer-A] ${issue.instancePath || '/'} ${issue.message}${RESET}`);
+        }
+        for (const issue of semantic) {
+          console.log(`   ${RED}- [Layer-B:${issue.code}] ${issue.detail}${RESET}`);
+        }
+      }
+      continue;
+    }
+
+    const expected = EXPECTED_INVALID.get(item.file);
+    seenInvalid.add(item.file);
+    if (!expected) {
+      failures += 1;
+      console.log(`${RED}❌ ${item.label}${RESET} (missing explicit expectation-table entry)`);
+      continue;
+    }
+    const ajvLayerMet = expected.ajv === 'pass' ? ajvOk : !ajvOk;
+    const markerMet = semantic.some((issue) => issue.code === expected.marker);
+    if (ajvLayerMet && markerMet) {
+      console.log(`${GREEN}✅ ${item.label}${RESET} ${DIM}(Layer A ${expected.ajv}; intended marker ${expected.marker} fired)${RESET}`);
+    } else {
+      failures += 1;
+      console.log(`${RED}❌ ${item.label}${RESET} (expected Layer A ${expected.ajv} + ${expected.marker})`);
+      console.log(`   ${RED}- Layer A was ${ajvOk ? 'pass' : 'reject'}${RESET}`);
+      console.log(`   ${RED}- Layer B markers: ${semantic.map((issue) => issue.code).join(', ') || '(none)'}${RESET}`);
+      for (const issue of ajvErrors.slice(0, 4)) {
+        console.log(`   ${RED}- [Layer-A] ${issue.instancePath || '/'} ${issue.message}${RESET}`);
+      }
+    }
+  } catch (cause) {
+    failures += 1;
+    console.log(`${RED}❌ ${item.label}${RESET} (fixture/validator error: ${cause.message})`);
+  }
+}
+
+for (const file of EXPECTED_INVALID.keys()) {
+  if (!seenInvalid.has(file)) {
+    failures += 1;
+    console.log(`${RED}❌ fixtures/${file}${RESET} (expectation exists but fixture is missing)`);
+  }
+}
+
+console.log('');
+if (failures > 0) {
+  console.error(`${RED}FAIL-CLOSED: ${failures} case(s) did not meet expectation.${RESET}\n`);
+  process.exit(1);
+}
+console.log(`${GREEN}All ${work.length} cases met expectation.${RESET}\n`);


### PR DESCRIPTION
## Summary

- add `_meta/contracts/execution/` with a draft-07 schema, honesty-bound template, and valid/invalid fixtures
- encode the verified approval, checkpoint-authoritative resume, receipt/readback, receipt-bound verdict, and rollback-reference semantics
- add a dedicated two-layer validator: AJV structure plus recomputed identity, receipt summary/readback, and conservative verdict checks
- wire the validator fail-closed into `contracts-gate.yml`
- update the root navigator to the 22-schema / 6-dedicated-validator current state

## Why

C4 establishes governed execution as a durable contract language before any orchestration layer is retained or rebuilt. It moves verified semantics into the L0 contract spine while keeping implementation inside domain engines.

The contract is locked to `contract_status: schema_validated_only`: conformance does not imply a runner, engine binding, write authority, or runtime exists.

## Guardrails and scope

- no runner, worker, queue, scheduler, state broker, mission broker, or universal action payload
- no D2 rewrite or D0-D3 promotion change (reserved for C5)
- no cell routing or cross-client mutation authority
- no rollback executor; only a rollback reference when capability exists
- no `EXPAND` verdict because the verified builder does not emit it
- live `PASS` requires an existing authorization envelope, called-party brake, receipt, and verified readback

## Validation

- `node _meta/contracts/scripts/validate-governed-execution.mjs` — 13/13 cases met expectation
- `node _meta/contracts/scripts/validate-governed-work-loop.mjs` — 21/21 cases passed
- `node _meta/contracts/scripts/validate-contracts.mjs` — passed
- `node _meta/contracts/scripts/validate-contracts.mjs --check-ssot` — passed
- `node _meta/contracts/scripts/validate-playbook-io.mjs --scan data/traces/` — 4/4 passed
- `node .claude/scripts/guardrail.mjs` — passed
- `npm test -- --run` — 25 files / 477 tests passed
- repository pre-commit hook — guardrail, staged artifact gate, env hygiene, blocklist, and forbidden-name lint passed

## Decision anchors

Q1, Q4, Q5, Q9, and roadmap item C4. This PR is propose-only and remains Draft for operator review/merge.
