### PR TITLE
fix(governance): make Live Site Gate fail closed

### DIFF
--- a/.github/scripts/check-live-site-files.sh
+++ b/.github/scripts/check-live-site-files.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Public interface: read changed website paths from stdin.
+# Exit 0 when every path is allowed, 1 for policy violations, 2 for matcher/tool failure.
+ALLOWLIST_REGEX='^websites/(example-site/|_templates/|\.gitignore$|README\.md$)'
+CHANGED=$(cat)
+
+if [ -z "$CHANGED" ]; then
+  exit 0
+fi
+
+set +e
+LIVE_FILES=$(printf '%s\n' "$CHANGED" | grep -Ev "$ALLOWLIST_REGEX")
+MATCHER_STATUS=$?
+set -e
+
+case "$MATCHER_STATUS" in
+  0)
+    printf '%s\n' "$LIVE_FILES"
+    exit 1
+    ;;
+  1)
+    exit 0
+    ;;
+  *)
+    echo "ERROR: live-site classifier failed (grep exit $MATCHER_STATUS)" >&2
+    exit 2
+    ;;
+esac

--- a/.github/workflows/live-site-gate.yml
+++ b/.github/workflows/live-site-gate.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     paths:
       - 'websites/**'
+      - '.github/workflows/live-site-gate.yml'
+      - '.github/scripts/check-live-site-files.sh'
+      - 'tests/governance/test_live_site_gate.sh'
+      - 'tests/fixtures/live-site-gate/**'
 
 jobs:
   check-live-sites:
@@ -22,13 +26,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Run classifier regression fixtures
+        run: bash tests/governance/test_live_site_gate.sh
+
       - name: Check for Live Site files
         run: |
           echo "🛡️ §4.6 Live Site Gate - Checking for unauthorized site files..."
           echo ""
 
           # Get changed files in websites/ directory
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '^websites/' || true)
+          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- websites/)
 
           if [ -z "$CHANGED" ]; then
             echo "✅ No websites/ changes detected"
@@ -39,10 +46,14 @@ jobs:
           echo "$CHANGED"
           echo ""
 
-          # Check for Live site files (anything except example-site/, .gitignore, README.md, _templates/)
-          LIVE_FILES=$(echo "$CHANGED" | grep -E '^websites/(?!example-site/|\.gitignore$|README\.md$|_templates/)' || true)
+          # Classify with a runner-compatible ERE. Status 1 is a policy block;
+          # status 2+ is a matcher/tool failure and must also fail closed.
+          set +e
+          LIVE_FILES=$(printf '%s\n' "$CHANGED" | .github/scripts/check-live-site-files.sh)
+          CLASSIFIER_STATUS=$?
+          set -e
 
-          if [ -n "$LIVE_FILES" ]; then
+          if [ "$CLASSIFIER_STATUS" -eq 1 ]; then
             echo ""
             echo "❌ BLOCKED: Live site files detected in PR!"
             echo ""
@@ -56,6 +67,13 @@ jobs:
             echo "🔧 Fix: Remove these files from your commit:"
             echo "   git rm -r --cached <path>"
             echo "   git commit --amend"
+            exit 1
+          fi
+
+          if [ "$CLASSIFIER_STATUS" -ne 0 ]; then
+            echo ""
+            echo "❌ BLOCKED: Live site classifier failed (exit $CLASSIFIER_STATUS)"
+            echo "The gate cannot classify safely, so this PR fails closed."
             exit 1
           fi
 

--- a/tests/fixtures/live-site-gate/allowed.txt
+++ b/tests/fixtures/live-site-gate/allowed.txt
@@ -1,0 +1,5 @@
+websites/example-site/src/pages/index.astro
+websites/example-site/public/favicon.svg
+websites/_templates/base/README.md
+websites/.gitignore
+websites/README.md

--- a/tests/fixtures/live-site-gate/failing-bin/grep
+++ b/tests/fixtures/live-site-gate/failing-bin/grep
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "synthetic grep failure" >&2
+exit 2

--- a/tests/fixtures/live-site-gate/forbidden.txt
+++ b/tests/fixtures/live-site-gate/forbidden.txt
@@ -1,0 +1,3 @@
+websites/client-site/src/pages/index.astro
+websites/example-site-copy/index.astro
+websites/README.md.bak

--- a/tests/governance/test_live_site_gate.sh
+++ b/tests/governance/test_live_site_gate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+CHECKER="$ROOT_DIR/.github/scripts/check-live-site-files.sh"
+FIXTURES="$ROOT_DIR/tests/fixtures/live-site-gate"
+
+if ! "$CHECKER" < "$FIXTURES/allowed.txt"; then
+  echo "FAIL: allowed website paths must pass" >&2
+  exit 1
+fi
+
+echo "PASS: allowed website paths pass"
+
+set +e
+FORBIDDEN_OUTPUT=$("$CHECKER" < "$FIXTURES/forbidden.txt" 2>&1)
+FORBIDDEN_STATUS=$?
+set -e
+
+if [ "$FORBIDDEN_STATUS" -ne 1 ]; then
+  echo "FAIL: forbidden website paths must exit 1, got $FORBIDDEN_STATUS" >&2
+  exit 1
+fi
+
+if [ "$FORBIDDEN_OUTPUT" != "$(cat "$FIXTURES/forbidden.txt")" ]; then
+  echo "FAIL: classifier must report every forbidden path verbatim" >&2
+  exit 1
+fi
+
+echo "PASS: forbidden website paths are reported and blocked"
+
+set +e
+ERROR_OUTPUT=$(PATH="$FIXTURES/failing-bin:$PATH" "$CHECKER" < "$FIXTURES/allowed.txt" 2>&1)
+ERROR_STATUS=$?
+set -e
+
+if [ "$ERROR_STATUS" -ne 2 ]; then
+  echo "FAIL: matcher/tool errors must exit 2, got $ERROR_STATUS" >&2
+  exit 1
+fi
+
+if [[ "$ERROR_OUTPUT" != *"live-site classifier failed"* ]]; then
+  echo "FAIL: matcher/tool errors must emit a classifier failure" >&2
+  exit 1
+fi
+
+echo "PASS: matcher/tool errors fail closed"


### PR DESCRIPTION
## Summary

- replace the unsupported `grep -E` negative lookahead in Live Site Gate with a portable allowlist classifier
- make policy violations and matcher/tool failures distinct, fail-closed outcomes
- add positive, negative, prefix/suffix-bypass, and injected matcher-failure fixtures
- run the regression suite whenever the workflow, classifier, or fixtures change

## Root cause

The existing GNU/runner ERE matcher used `(?!...)`, which `grep -E` does not support. Its exit `2` was swallowed by `|| true`, leaving `LIVE_FILES` empty and allowing the gate to pass.

The new classifier has an explicit exit contract:

- `0`: every changed website path is allowlisted
- `1`: at least one forbidden live-site path was found
- `2`: matcher/tool failure; the workflow fails closed

## Verification

- TDD RED -> GREEN for allowed paths
- TDD RED -> GREEN for forbidden paths and prefix/suffix bypass attempts
- TDD RED -> GREEN for an injected `grep` exit `2`
- `bash -n` passed for the classifier and test scripts
- regression test passed: `bash tests/governance/test_live_site_gate.sh`
- workflow YAML parse passed
- `git diff --check` passed
- staged no-bidi and sensitive-additions scans passed
- `gitleaks detect --source . --redact --no-banner` passed
- repository pre-commit checks passed

## Boundaries

- no website assets or migrations
- no deploy or production activation
- no SSOT rewrite or machine-enforcement certification
- Draft PR only; ready/merge remain operator flips
