### PR TITLE
feat(contracts): engine_manifest v2.1 — eval_suites declaration + write_capability removal (Phase 3 registry, PR①)

### DIFF
--- a/_meta/contracts/engine/engine_manifest.schema.v2.1.yaml
+++ b/_meta/contracts/engine/engine_manifest.schema.v2.1.yaml
@@ -1,0 +1,447 @@
+# Engine Manifest Contract v2.1.0
+# SSOT: _meta/contracts/engine/engine_manifest.schema.v2.1.yaml
+# Predecessor: engine_manifest.schema.v2.yaml (v2.0, retained; dual-accept window)
+#
+# Domain Engine 能力声明规范 v2.1 — 两个已批准变更一次落地：
+#
+# 1. 移除 deprecated 字段 `write_capability`（兑现 v2.0 头注 "REMOVED in v2.1"）。
+#    v2.0 承诺的兼容期 ≥30 天（自 GHL ADR Accepted 2026-05-19）已届满；
+#    两仓 grep 证实该 v1 字段零机器消费者（审计:
+#    amazon-growth-engine docs/prompt-audits/2026-07-15-phase3-eval-registry-
+#    contract-audit.md §1.2）。注: GHL ADR 原将此动作归属 Phase 4；本次随
+#    prompting-playbook Phase 3 前移，由 operator 在本 schema 的引入 PR 追认。
+#
+# 2. 新增 `eval_suites` 声明（prompting-playbook 落地方案 Phase 3,
+#    liye_os docs/plans/2026-07-08-prompting-playbook-adoption.md）:
+#    suite id、覆盖决策点、提示词面、分集规模、promotion gate、最近绿灯证据。
+#    v2.1 下 eval_suites 为 required 且 minItems 1 —— "引擎无 Eval 声明 =
+#    协议不完整"（方案原文）。尚无 eval suite 的引擎停留在 v2.0（双收期内合法），
+#    这是有意的协议压力，不是迁移障碍。
+#
+# 路由（Phase 0c.2 延伸）:
+# - validate-contracts.mjs routeManifestSchema: 缺 schema_version → v1;
+#   "2.0" → v2; "2.1" → 本 schema; 其他 → fail-closed。
+# - validate_manifest_reality.py R5: "2.0"/"2.1" 双收，各自绑定 $id。
+#   部署顺序（审计 F-2）: 本文件 + 双收路由必须先于任何 manifest 实例 bump 合并，
+#   否则 Band B reality clock 当日 FAIL 并重置 streak。
+# - eval_suites 的 reality 校验（R7: suite_path/entrypoint 实存）有意暂缓——
+#   新 R 检查失败会重置 Band B streak，先声明、观察一个周期再入 clock（审计 §5）。
+
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://liye.com/contracts/engine/engine_manifest.v2.1"
+title: "Engine Manifest Schema v2.1"
+description: "Domain Engine 能力声明 v2.1 — 移除 deprecated write_capability + 新增 eval_suites 声明。"
+version: "2.1.0"
+type: object
+
+required:
+  - schema_version
+  - engine_id
+  - engine_version
+  - domain
+  - contracts_compat
+  - playbooks
+  - data_sources
+  - write_capability_declared
+  - write_capability_effective
+  - capabilities
+  - runtime_gates
+  - eval_suites
+
+properties:
+  schema_version:
+    type: string
+    enum:
+      - "2.1"
+    description: |
+      manifest 自身的 schema 版本。validate-contracts.mjs 按本字段路由到对应 schema：
+      - "2.1": 当前活动版本（write_capability 已移除; eval_suites required）
+      - "2.0": 前代（engine_manifest.schema.v2.yaml），双收期内继续接受
+      未声明 schema_version 的 manifest 视为 v1.x（fallback 走 engine_manifest.schema.yaml）。
+    examples:
+      - "2.1"
+
+  engine_id:
+    type: string
+    pattern: "^[a-z0-9-]+$"
+    minLength: 3
+    maxLength: 64
+    description: "Engine 唯一标识符，小写字母+数字+连字符"
+    examples:
+      - amazon-growth-engine
+      - chaming
+      - notion-sync-engine
+
+  engine_version:
+    type: string
+    pattern: "^\\d+\\.\\d+\\.\\d+$"
+    description: "Engine 版本号 (SemVer)"
+    examples:
+      - "1.0.0"
+      - "2.1.0"
+
+  domain:
+    type: string
+    description: "所属领域，必须与 learned_policy_ghl_v1.domain 对应"
+    examples:
+      - amazon-advertising
+      - domain-investment
+      - notion-sync
+
+  contracts_compat:
+    type: string
+    pattern: "^>=\\d+\\.\\d+(\\.\\d+)? <\\d+\\.\\d+(\\.\\d+)?$"
+    description: "兼容的 contract schema 版本范围 (SemVer range)"
+    examples:
+      - ">=2.0 <3.0"
+
+  playbooks:
+    type: array
+    minItems: 0
+    items:
+      type: object
+      required:
+        - id
+        - entrypoint
+        - description
+        - required_permissions
+        - io_schema
+      properties:
+        id:
+          type: string
+          pattern: "^[a-z0-9_]+$"
+          description: "Playbook 唯一标识符"
+        entrypoint:
+          type: string
+          description: "可执行路径，相对 engine repo root"
+        description:
+          type: string
+          maxLength: 200
+        required_permissions:
+          type: array
+          items:
+            type: string
+            enum:
+              - read:metrics
+              - read:ads_api
+              - read:learned_bundle
+              - read:alert_history
+              - read:duckdb
+              - read:fact_events
+              - write:bids
+              - write:keywords
+              - write:budget
+              - write:evidence_package
+              - write:fact_events
+          description: "所需权限。GHL 引入 read:fact_events / write:fact_events 用于 emit_fact pipeline (D-14)。"
+        io_schema:
+          type: object
+          required:
+            - inputs
+            - outputs
+          properties:
+            inputs:
+              type: object
+              additionalProperties: true
+            outputs:
+              type: object
+              additionalProperties: true
+          additionalProperties: false
+        status:
+          type: string
+          enum:
+            - active
+            - deprecated
+            - placeholder
+          default: active
+      additionalProperties: false
+    description: "Engine 提供的 playbooks 列表"
+
+  data_sources:
+    type: array
+    items:
+      type: object
+      required:
+        - type
+        - description
+      properties:
+        type:
+          type: string
+          enum:
+            - ads_api
+            - duckdb
+            - qdrant
+            - postgres
+            - sqlite
+            - api
+            - fact_events_log
+          description: "数据源类型。GHL 引入 fact_events_log 用于 emit_fact pipeline (D-14)。"
+        description:
+          type: string
+          maxLength: 200
+        required:
+          type: boolean
+          default: true
+      additionalProperties: false
+    description: "数据源声明 (不含凭据)"
+
+  write_capability_declared:
+    type: string
+    enum:
+      - none
+      - limited
+      - full
+    description: |
+      manifest 静态声明的写入能力 (policy 设计意图):
+      - none: 只读 (推荐 GHL Pilot 1)
+      - limited: 有限写入 (需 OS execute_limited 层级许可)
+      - full: 完整写入 (需特殊审批)
+      GHL Pilot 1 期间 (≥ 90 天 from 2026-05-09) 所有 engine 必须声明 declared=none，per Hard Gate 8。
+
+  write_capability_effective:
+    type: string
+    enum:
+      - none
+      - limited
+      - full
+    description: |
+      runtime 实际可执行的写入能力 (declared ∩ runtime_gates 实际状态)。
+      约束 (由 validate_manifest_reality.py 验证, Phase 0c.4):
+      - effective ≤ declared (manifest 不能 effective 比 declared 更宽)
+      - effective = none if Pilot 1 期间 (Hard Gate 8)
+      - effective 由所有 runtime_gates 共同决定 (任一 gate=closed → effective 降级)
+
+  # 注: v1 字段 `write_capability` 在 v2.1 已移除（additionalProperties: false 拒绝）。
+  # v2.0 兼容期（≥30 天, 2026-05-19 起）已届满; 仍带该字段的 manifest 请停留在
+  # schema_version "2.0" 或随升版删除该行。
+
+  capabilities:
+    type: array
+    minItems: 0
+    items:
+      type: object
+      required:
+        - id
+        - description
+        - boundary
+        - required_permissions
+        - runtime_gate_refs
+      properties:
+        id:
+          type: string
+          pattern: "^[a-z0-9_]+$"
+          description: "Capability 唯一标识符 (engine 范围内)"
+          examples:
+            - emit_fact_run_outcome
+            - submit_skill_candidate
+            - apply_bid_adjustment
+        description:
+          type: string
+          maxLength: 200
+        boundary:
+          type: string
+          enum:
+            - content_guard
+            - truth_write_guard
+            - context_inject_guard
+            - shadow_guard
+            - fact_emit
+            - none
+          description: |
+            Capability 归属的 loamwise P3 boundary (per ADR-Loamwise-P3-Candidate-Operation-Guard-Coverage)。
+            fact_emit = GHL emit_fact pipeline 新引入 (D-14)。
+            none = capability 不经过任何 guard (例如纯读)。
+        required_permissions:
+          type: array
+          items:
+            type: string
+        runtime_gate_refs:
+          type: array
+          items:
+            type: string
+            pattern: "^[a-z0-9_]+$"
+          description: "引用 runtime_gates[].id；所有引用 gate 必须 = open 才能 effective"
+        status:
+          type: string
+          enum:
+            - active
+            - deprecated
+            - placeholder
+          default: active
+      additionalProperties: false
+    description: "Engine 显式列举的 capabilities 及其 boundary / gates 归属"
+
+  runtime_gates:
+    type: array
+    minItems: 0
+    items:
+      type: object
+      required:
+        - id
+        - kind
+        - default_state
+      properties:
+        id:
+          type: string
+          pattern: "^[a-z0-9_]+$"
+          description: "Gate 唯一标识符 (engine 范围内)"
+        kind:
+          type: string
+          enum:
+            - env_var
+            - feature_flag
+            - manual_approval
+        var_name:
+          type: string
+          pattern: "^[A-Z][A-Z0-9_]*$"
+          description: "若 kind=env_var，对应环境变量名 (大写蛇形)"
+          examples:
+            - AGE_BD_SP_WRITE_ENABLED
+            - AGE_FACT_EMIT_ENABLED
+        description:
+          type: string
+          maxLength: 200
+        default_state:
+          type: string
+          enum:
+            - open
+            - closed
+          description: "未配置时的默认状态"
+        evidence_required_for_open:
+          type: string
+          description: "什么样的 evidence 才能让此 gate 转 open (审计可读)"
+      additionalProperties: false
+    description: "Engine 所有 runtime 闸门的显式列表 (per validate_manifest_reality.py 验证 reality)"
+
+  eval_suites:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      required:
+        - id
+        - decision_point
+        - suite_path
+        - prompt_surfaces
+        - split_sizes
+        - promotion_gate
+        - last_green_run
+      properties:
+        id:
+          type: string
+          pattern: "^[a-z0-9_]+$"
+          description: "Eval suite 唯一标识符 (engine 范围内)"
+          examples:
+            - product_selection
+            - measurement_verdict
+            - campaign_blueprint
+        decision_point:
+          type: string
+          maxLength: 200
+          description: "本 suite 覆盖的决策点（人读，一句话）"
+        suite_path:
+          type: string
+          minLength: 1
+          description: "Eval suite 目录，相对 engine repo root (e.g. eval/campaign_blueprint)"
+        prompt_surfaces:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            minLength: 1
+          description: |
+            本 suite 守护的提示词面（相对 engine repo root 的路径/glob）。
+            这些路径的 diff 必须以本 suite 绿灯为合并前提（Phase 3 CI 门禁语义）。
+            同一路径可被多个 suite 声明 —— diff 时全部对应 suite 都要绿。
+        split_sizes:
+          type: object
+          minProperties: 1
+          additionalProperties:
+            type: integer
+            minimum: 0
+          description: |
+            分集规模。key 为该 suite 自己的分集词表（e.g. control/edge/boundary,
+            train/holdout, scenarios），value 为场景数。不强制统一分类学 ——
+            各 suite 的分集语义由其 SCENARIO_SCHEMA/README 定义。
+        promotion_gate:
+          type: object
+          required:
+            - gate_commands
+          properties:
+            gate_commands:
+              type: array
+              minItems: 1
+              items:
+                type: string
+                minLength: 1
+              description: "从 engine repo root 执行、必须全部 exit 0 的门禁命令（确定性）"
+            threshold:
+              type: string
+              maxLength: 200
+              description: "人读阈值描述; 缺省语义 = gate_commands 全绿"
+          additionalProperties: false
+          description: "Promotion gate: 提示词面 diff 合并前必须通过的确定性命令组"
+        last_green_run:
+          type:
+            - string
+            - "null"
+          description: |
+            最近绿灯证据指针（CI run id / ledger 引用 / 本地验证记录路径）。
+            null = 尚无落盘证据（e.g. 需 API key 的 live 跑分未建基线, 或 CI 未接线）。
+            有意为可空的运营态字段：绿灯证据的 SSOT 在 CI/ledger 侧，manifest 不
+            要求每次绿灯回写（避免 manifest churn + hash 漂移; 审计 §5 裁决方向 ①+②）。
+        status:
+          type: string
+          enum:
+            - active
+            - placeholder
+          default: active
+      additionalProperties: false
+    description: |
+      Engine 的 Eval suite 声明（prompting-playbook Phase 3）。
+      引擎无 Eval 声明 = 协议不完整 —— v2.1 下本字段 required 且至少一条。
+      本声明是提示词面 CI 门禁的"声明面" SSOT。
+
+  bundle_consumption:
+    type: object
+    properties:
+      env_var:
+        type: string
+        default: "LEARNED_BUNDLE_PATH"
+      required:
+        type: boolean
+        default: false
+      min_version:
+        type: string
+        pattern: "^\\d+\\.\\d+\\.\\d+$"
+    additionalProperties: false
+    description: "Bundle 消费配置 (v1 保留)"
+
+  health_check:
+    type: object
+    properties:
+      entrypoint:
+        type: string
+      timeout_seconds:
+        type: integer
+        minimum: 1
+        maximum: 60
+        default: 10
+    additionalProperties: false
+    description: "健康检查配置 (v1 保留)"
+
+  metadata:
+    type: object
+    properties:
+      maintainer:
+        type: string
+      repository:
+        type: string
+        format: uri
+      documentation:
+        type: string
+        format: uri
+    additionalProperties: false
+    description: "元数据 (v1 保留)"
+
+additionalProperties: false

--- a/_meta/contracts/scripts/validate-contracts.mjs
+++ b/_meta/contracts/scripts/validate-contracts.mjs
@@ -5,7 +5,7 @@
  *
  * 校验模式：
  * 1. 默认模式：Schema + 目录分区 + Lifecycle 校验
- *    含 Phase 0c.2 engine_manifest dual-routing (v1 legacy ↔ v2 by schema_version field).
+ *    含 Phase 0c.2 engine_manifest 版本路由 (v1 legacy / "2.0" / "2.1" by schema_version field).
  *    含 GHL Phase 0b 新增 9 learning schemas + confidence_formulas formula instance.
  * 2. Bundle 模式（--bundle <path>）：校验 learned-bundle.tgz
  * 3. Self-test 模式（--self-test）：内联 fixture 验证 routeManifestSchema (Phase 0c.2)
@@ -315,16 +315,19 @@ function validateLearnedPolicies() {
 }
 
 /**
- * 路由 engine_manifest schema 版本（Phase 0c.2 dual-schema routing）
+ * 路由 engine_manifest schema 版本（Phase 0c.2 dual-schema routing; v2.1 三收 per
+ * prompting-playbook Phase 3 eval registry）
  *
  * 规则（fail-closed）：
  * - 缺 schema_version 字段（或 null）→ v1 schema (legacy)
- * - schema_version === "2.0"        → v2 schema
- * - 其他值（含 "1.0" / "1.0.0" / "2.1" 等显式但未声明的版本）→ 拒绝 (fail-closed)
+ * - schema_version === "2.0"        → v2 schema（双收期内继续接受）
+ * - schema_version === "2.1"        → v2.1 schema（-write_capability / +eval_suites）
+ * - 其他值（含 "1.0" / "1.0.0" / "2.2" 等显式但未声明的版本）→ 拒绝 (fail-closed)
  *
- * 注：legacy v1 schema 自身未声明 schema_version 字段；v2 schema 强制 enum ["2.0"]（Tranche 1 fix）.
+ * 注：legacy v1 schema 自身未声明 schema_version 字段；v2 schema 强制 enum ["2.0"]
+ * （Tranche 1 fix）；v2.1 schema 强制 enum ["2.1"]。
  */
-function routeManifestSchema(data, v1Schema, v2Schema) {
+function routeManifestSchema(data, v1Schema, v2Schema, v21Schema) {
   const sv = data && Object.prototype.hasOwnProperty.call(data, 'schema_version') ? data.schema_version : undefined;
   if (sv === undefined || sv === null) {
     return { schema: v1Schema, route: 'v1-legacy-no-schema-version' };
@@ -332,8 +335,11 @@ function routeManifestSchema(data, v1Schema, v2Schema) {
   if (sv === '2.0') {
     return { schema: v2Schema, route: 'v2' };
   }
+  if (sv === '2.1') {
+    return { schema: v21Schema, route: 'v2.1' };
+  }
   return {
-    error: `Unsupported engine_manifest schema_version: ${JSON.stringify(sv)}. Valid: omit (=v1) | "2.0" (=v2). Fail-closed per Phase 0c.2.`,
+    error: `Unsupported engine_manifest schema_version: ${JSON.stringify(sv)}. Valid: omit (=v1) | "2.0" (=v2) | "2.1" (=v2.1). Fail-closed per Phase 0c.2.`,
   };
 }
 
@@ -402,20 +408,23 @@ function runSelfTest() {
 
   const v1Schema = loadSchema(join(CONTRACTS_DIR, 'engine', 'engine_manifest.schema.yaml'));
   const v2Schema = loadSchema(join(CONTRACTS_DIR, 'engine', 'engine_manifest.schema.v2.yaml'));
+  const v21Schema = loadSchema(join(CONTRACTS_DIR, 'engine', 'engine_manifest.schema.v2.1.yaml'));
 
   const fixtures = [
     { name: 'legacy manifest (no schema_version) → v1',     data: { engine_id: 'legacy' },                       expect: { route: 'v1-legacy-no-schema-version' } },
     { name: 'schema_version="2.0" → v2',                    data: { schema_version: '2.0', engine_id: 'v2' },    expect: { route: 'v2' } },
+    { name: 'schema_version="2.1" → v2.1',                  data: { schema_version: '2.1', engine_id: 'v21' },   expect: { route: 'v2.1' } },
     { name: 'schema_version="9.9.9" → fail-closed',         data: { schema_version: '9.9.9' },                   expect: { error: true } },
     { name: 'schema_version="1.0" (legacy explicit) → fail-closed', data: { schema_version: '1.0' },             expect: { error: true } },
     { name: 'schema_version=null → v1 (null=absent)',       data: { schema_version: null, engine_id: 'null' },   expect: { route: 'v1-legacy-no-schema-version' } },
-    { name: 'schema_version="2.1" → fail-closed',           data: { schema_version: '2.1' },                     expect: { error: true } },
+    { name: 'schema_version="2.2" → fail-closed',           data: { schema_version: '2.2' },                     expect: { error: true } },
     { name: 'schema_version=2.0 (number, not string) → fail-closed', data: { schema_version: 2.0 },              expect: { error: true } },
+    { name: 'schema_version=2.1 (number, not string) → fail-closed', data: { schema_version: 2.1 },              expect: { error: true } },
   ];
 
   let pass = 0, fail = 0;
   for (const fx of fixtures) {
-    const routed = routeManifestSchema(fx.data, v1Schema, v2Schema);
+    const routed = routeManifestSchema(fx.data, v1Schema, v2Schema, v21Schema);
     const gotErr = !!routed.error;
     const wantErr = !!fx.expect.error;
     let ok;
@@ -455,6 +464,7 @@ function validateEngineManifests() {
 
   const manifestSchemaV1 = loadSchema(join(CONTRACTS_DIR, 'engine', 'engine_manifest.schema.yaml'));
   const manifestSchemaV2 = loadSchema(join(CONTRACTS_DIR, 'engine', 'engine_manifest.schema.v2.yaml'));
+  const manifestSchemaV21 = loadSchema(join(CONTRACTS_DIR, 'engine', 'engine_manifest.schema.v2.1.yaml'));
 
   // 候选 manifest 路径列表。
   // ENGINE_MANIFEST_PATH（如设置）优先；视为完整文件路径，用于跨仓库 manifest 发现
@@ -478,8 +488,8 @@ function validateEngineManifests() {
         const content = readFileSync(manifestPath, 'utf-8');
         const data = parseYaml(content);
 
-        // Phase 0c.2: route by schema_version
-        const routed = routeManifestSchema(data, manifestSchemaV1, manifestSchemaV2);
+        // Phase 0c.2: route by schema_version (v2.1 三收 per Phase 3 eval registry)
+        const routed = routeManifestSchema(data, manifestSchemaV1, manifestSchemaV2, manifestSchemaV21);
         if (routed.error) {
           logError(manifestPath, routed.error);
           continue;
@@ -532,6 +542,8 @@ function validateContractSchemas() {
     join(CONTRACTS_DIR, 'learning', 'phase4_prereq_attestation_v1.schema.yaml'),
     // GHL Phase 0b engine manifest v2
     join(CONTRACTS_DIR, 'engine', 'engine_manifest.schema.v2.yaml'),
+    // Prompting-playbook Phase 3 engine manifest v2.1 (-write_capability / +eval_suites)
+    join(CONTRACTS_DIR, 'engine', 'engine_manifest.schema.v2.1.yaml'),
     // Note: confidence_formulas.yaml is a formula INSTANCE (not a JSON Schema) — validated by validateFormulaInstances()
   ];
 

--- a/_meta/contracts/scripts/validate_manifest_reality.py
+++ b/_meta/contracts/scripts/validate_manifest_reality.py
@@ -3,7 +3,8 @@
 validate_manifest_reality.py — Engine Manifest Reality Validator (Phase 0c.4)
 
 SSOT: _meta/contracts/scripts/validate_manifest_reality.py
-Schema: _meta/contracts/engine/engine_manifest.schema.v2.yaml (delegated)
+Schema: _meta/contracts/engine/engine_manifest.schema.v2.yaml /
+        engine_manifest.schema.v2.1.yaml (delegated; routed by schema_version)
 
 Schema validation answers "is the manifest shape correct?" (validate-contracts.mjs).
 Reality validation answers "does the manifest claim match the filesystem / git
@@ -16,8 +17,13 @@ Reality checks (minimal set per Phase 0c.4 design):
   R2  data_sources[].path           — if a path key is present, file/dir exists
   R3  capability runtime_gate_refs  — every ref resolves to a runtime_gates[].id
   R4  effective ≤ declared          — write_capability_effective not wider than declared
-  R5  schema_version routing        — "2.0" routes to v2 schema $id
+  R5  schema_version routing        — "2.0"/"2.1" route to their schema $id (dual-accept
+                                      per prompting-playbook Phase 3 eval registry)
   R6  Pilot 1 invariant             — engine_id=amazon-growth-engine → effective=none
+
+Note: eval_suites reality checks (suite_path/prompt_surfaces existence) are
+deliberately NOT part of R1-R6 yet — a new R check failing would reset the
+Band B streak; declare first, observe a cycle, then gate (audit 2026-07-15 §5).
 
 CLI:
   validate_manifest_reality.py --manifest-path <path> [--engine-repo <dir>] [--json]
@@ -42,6 +48,8 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = SCRIPT_DIR.parent.parent.parent
 V2_SCHEMA_PATH = PROJECT_ROOT / "_meta/contracts/engine/engine_manifest.schema.v2.yaml"
 V2_SCHEMA_ID = "https://liye.com/contracts/engine/engine_manifest.v2"
+V21_SCHEMA_PATH = PROJECT_ROOT / "_meta/contracts/engine/engine_manifest.schema.v2.1.yaml"
+V21_SCHEMA_ID = "https://liye.com/contracts/engine/engine_manifest.v2.1"
 FIXTURES_DIR = SCRIPT_DIR / "validate_manifest_reality_fixtures"
 
 # Total order on write_capability levels (per v2 schema enum semantics).
@@ -55,12 +63,22 @@ def load_yaml(path: Path) -> dict[str, Any]:
         return yaml.safe_load(f)
 
 
+def _schema_path_for(schema_version: Any) -> Path:
+    """Route manifest schema_version to its schema file.
+
+    "2.1" → v2.1; anything else → v2 (whose enum then rejects unsupported
+    versions, keeping the fail-closed behavior in the schema layer).
+    Reads module globals at call time so tests can monkeypatch *_SCHEMA_PATH.
+    """
+    return V21_SCHEMA_PATH if schema_version == "2.1" else V2_SCHEMA_PATH
+
+
 def schema_check(manifest: dict[str, Any]) -> list[str]:
     """Delegate-equivalent: run jsonschema Draft7Validator on manifest.
 
     Returns list of error messages. Empty list = schema valid.
     """
-    schema = load_yaml(V2_SCHEMA_PATH)
+    schema = load_yaml(_schema_path_for(manifest.get("schema_version")))
     validator = Draft7Validator(schema)
     errors = sorted(validator.iter_errors(manifest), key=lambda e: list(e.absolute_path))
     return [
@@ -129,18 +147,25 @@ def check_r4_effective_within_declared(manifest: dict[str, Any]) -> list[str]:
 
 def check_r5_schema_version_routing(manifest: dict[str, Any]) -> list[str]:
     sv = manifest.get("schema_version")
-    schema = load_yaml(V2_SCHEMA_PATH)
-    actual_id = schema.get("$id")
     if sv == "2.0":
+        actual_id = load_yaml(V2_SCHEMA_PATH).get("$id")
         if actual_id != V2_SCHEMA_ID:
             return [
                 f"R5 routing mismatch: schema_version='2.0' but v2 schema $id "
                 f"is '{actual_id}', expected '{V2_SCHEMA_ID}'"
             ]
         return []
+    if sv == "2.1":
+        actual_id = load_yaml(V21_SCHEMA_PATH).get("$id")
+        if actual_id != V21_SCHEMA_ID:
+            return [
+                f"R5 routing mismatch: schema_version='2.1' but v2.1 schema $id "
+                f"is '{actual_id}', expected '{V21_SCHEMA_ID}'"
+            ]
+        return []
     return [
         f"R5 unsupported schema_version: {sv!r}. validate_manifest_reality.py "
-        f"binds to v2 ('2.0') only; v1 manifests are out-of-scope here."
+        f"binds to v2 ('2.0') / v2.1 ('2.1') only; v1 manifests are out-of-scope here."
     ]
 
 

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_v21_eval_suites.yaml
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_v21_eval_suites.yaml
@@ -1,0 +1,61 @@
+# Self-test fixture: v2.1 manifest (-write_capability / +eval_suites). All reality checks PASS.
+# Exercises R5 "2.1" routing + schema_check v2.1 delegation (required eval_suites present,
+# deprecated v1 write_capability absent).
+schema_version: "2.1"
+engine_id: amazon-growth-engine
+engine_version: "1.0.0"
+domain: amazon-advertising
+contracts_compat: ">=2.0 <3.0"
+
+playbooks:
+  - id: anomaly_detect
+    entrypoint: src/playbooks/anomaly_detect.py
+    description: "fixture placeholder"
+    required_permissions:
+      - read:metrics
+    io_schema:
+      inputs: {}
+      outputs: {}
+    status: placeholder
+
+data_sources:
+  - type: ads_api
+    description: "Amazon Ads API (read-only)"
+    required: true
+
+write_capability_declared: none
+write_capability_effective: none
+
+capabilities:
+  - id: emit_fact_run_outcome
+    description: "fixture placeholder D-14 fact emit"
+    boundary: fact_emit
+    required_permissions:
+      - write:fact_events
+    runtime_gate_refs:
+      - emit_fact_enabled
+    status: placeholder
+
+runtime_gates:
+  - id: emit_fact_enabled
+    kind: env_var
+    var_name: AGE_FACT_EMIT_ENABLED
+    description: "fixture placeholder"
+    default_state: closed
+    evidence_required_for_open: "Phase 1a impl + 30d PASS"
+
+eval_suites:
+  - id: campaign_blueprint
+    decision_point: "asin-growth Step 8 campaign blueprint authoring/freeze quality"
+    suite_path: eval/campaign_blueprint
+    prompt_surfaces:
+      - .claude/skills/asin-growth/SKILL.md
+    split_sizes:
+      scenarios: 11
+    promotion_gate:
+      gate_commands:
+        - "uv run --extra dev python -m pytest tests/campaign_blueprint -q"
+        - "uv run --extra dev python -m eval.campaign_blueprint.selfcheck"
+      threshold: "all gate_commands exit 0"
+    last_green_run: null
+    status: active

--- a/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_v21_eval_suites_repo/src/playbooks/anomaly_detect.py
+++ b/_meta/contracts/scripts/validate_manifest_reality_fixtures/must_pass/manifest_v21_eval_suites_repo/src/playbooks/anomaly_detect.py
@@ -1,0 +1,1 @@
+# fixture entrypoint placeholder

--- a/tests/test_phase2a_gamma.mjs
+++ b/tests/test_phase2a_gamma.mjs
@@ -496,13 +496,13 @@ test('DoD#11/#7: input anchors + 1e producer + confidence_formulas + File-B are 
   }
 });
 
-test('DoD#10: d11_rolling_30d_v1 is registered in validate-contracts schemaFiles; gate count == 21', () => {
-  // γ's own carve-out landed 19->20. Phase-4 (phase4_prereq_attestation_v1) then added the 21st
-  // schema (deterministic +1), so the absolute count is now 21. γ's schema must STILL be registered.
+test('DoD#10: d11_rolling_30d_v1 is registered in validate-contracts schemaFiles; gate count == 22', () => {
+  // γ's own carve-out landed 19->20. Phase-4 (phase4_prereq_attestation_v1) added the 21st,
+  // engine_manifest v2.1 (eval_suites) added the 22nd. γ's schema must STILL be registered.
   const vc = readFileSync(join(REPO, '_meta/contracts/scripts/validate-contracts.mjs'), 'utf-8');
   assert.ok(/d11_rolling_30d_v1\.schema\.yaml/.test(vc), 'schema must be registered in schemaFiles array');
   const out = spawnSync('node', [join(REPO, '_meta/contracts/scripts/validate-contracts.mjs')], { encoding: 'utf-8' });
-  assert.match(out.stdout, /Passed:\s*21/, `expected gate count 21 (γ 19->20 carve-out; Phase-4 +1 -> 21); got:\n${out.stdout}`);
+  assert.match(out.stdout, /Passed:\s*22/, `expected gate count 22 (γ 19->20 carve-out; Phase-4 +1 -> 21; engine_manifest v2.1 +1 -> 22); got:\n${out.stdout}`);
 });
 
 test('CLI --help exits 0 and documents the fixed 30-day span', () => {


### PR DESCRIPTION
## 🎯 Goal
Prompting-playbook **Phase 3 eval registry** 第一步（PR①/审计 §7 序列）：engine_manifest 升 v2.1，为 AGE 侧 `eval_suites` 声明与提示词 diff CI 门禁铺契约面。

审计依据: AGE `docs/prompt-audits/2026-07-15-phase3-eval-registry-contract-audit.md`（loudmirror/amazon-growth-engine#676）。

## 🧩 Changes
- **新增 `engine_manifest.schema.v2.1.yaml`**: required `eval_suites[]`（id / decision_point / suite_path / prompt_surfaces / split_sizes / promotion_gate.gate_commands / **nullable** last_green_run）+ 移除 deprecated v1 `write_capability`。
- **validate-contracts.mjs**: v1/"2.0"/"2.1" 三路由（其余 fail-closed），self-test fixtures 7→9，v2.1 注册进 `schemaFiles[]`。
- **validate_manifest_reality.py**: schema_check + R5 双收 "2.0"/"2.1"，各自绑定 $id；新增 must_pass v2.1 fixture。
- **R7（eval_suites reality 校验）有意暂缓**——新 R 检查失败会重置 Band B streak；先声明、观察一个周期再入 clock（审计 §5）。

## ⚖️ 需 operator 追认的裁决（F-1 版本号撞车）
GHL ADR 曾把 v2.1 预定为"移除 write_capability"（归属 Phase 4）。本 PR 采纳审计推荐**选项 (a)**：v2.1 一次承载移除+新增——兼容期（≥30 天,自 2026-05-19）已届满，两仓 grep 证实 v1 字段零机器消费者。**等效于把 GHL Phase 4 的这一小步前移**；如你倾向选项 (c)（保留 deprecated 字段到 v2.2），review 时说明即可，改动极小。

## ⚠️ 合并顺序（审计 F-2,不可逆序）
**本 PR 必须先于任何 manifest 实例 bump 合并**——R5/路由不先双收，AGE manifest 升 "2.1" 当日 reality clock FAIL 并重置 Band B streak。合并后 clock 机器的 liye_os checkout 需 pull 到本 PR 之后再让 AGE 侧升版落地。ledger 最后入账 2026-07-09（streak len=6），07-10 后连续性请顺带在 clock 机器核实。

## ✅ Verification（本地全绿）
- `validate-contracts.mjs`: 22 passed / 0 errors；`--self-test` 9/9
- `validate_manifest_reality.py --self-test`: 2 must_pass + 4 must_fail 全部按预期隔离
- C12 detection exercise 8 OK；clock tests 9 OK
- 负向检查: v2.1 拒绝 `write_capability` / 缺 `eval_suites` / 空数组；`last_green_run` 可空但不可缺省

## ⚠️ Risk & Rollback
- Low——纯加法+双收：v2.0 manifest 路由行为逐字节不变（AGE 现行 manifest 不受影响）；revert 本 commit 即回滚。

🤖 Generated with [Claude Code](https://claude.com/claude-code)