### PR TITLE
ci(governance): run Live Site Gate on every PR for required-check compatibility

### DIFF
--- a/.github/workflows/live-site-gate.yml
+++ b/.github/workflows/live-site-gate.yml
@@ -3,17 +3,15 @@
 #
 # 防止 Live 站点（客户资产）被意外提交到公开仓库
 # 只有 example-site/ 允许被 tracked
+#
+# 刻意在每个 PR 上运行（无 paths 过滤）：GitHub required status check
+# 不出勤即永久阻塞合并，path 过滤会把不碰 websites/ 的 PR 全部卡死。
+# 未改动 websites/ 时 git diff 为空，classifier 直接放行，成本为秒级。
 
 name: Live Site Gate
 
 on:
   pull_request:
-    paths:
-      - 'websites/**'
-      - '.github/workflows/live-site-gate.yml'
-      - '.github/scripts/check-live-site-files.sh'
-      - 'tests/governance/test_live_site_gate.sh'
-      - 'tests/fixtures/live-site-gate/**'
 
 jobs:
   check-live-sites:


### PR DESCRIPTION
## Summary

- remove the `paths:` filter from `live-site-gate.yml` so the gate reports on every pull request
- prerequisite for adding **Block Live Sites from PR** to required status checks: GitHub blocks merge indefinitely when a required check never reports, so a paths-filtered gate would deadlock every non-website PR
- no-op cost on non-website PRs: the `git diff ... -- websites/` result is empty and the classifier exits 0 in seconds; public-repo Actions minutes are free

## What is unchanged

- classifier script, three-state exit contract (0 pass / 1 block / 2 fail-closed), regression fixtures, and the fixture test step are all untouched
- self-guarding is preserved as a superset: the gate now runs on all PRs, including those that modify the gate's own files

## Verification

- YAML parses (`yaml.safe_load`)
- `tests/governance/test_live_site_gate.sh` local run: **3/3 PASS** (allowed paths pass / forbidden blocked verbatim / tool error fails closed)
- diff is +4/-6 on a single file

## Follow-up (operator, after merge)

1. Settings → Branches → main → require **Block Live Sites from PR**
2. one controlled rejection PR to certify enforcement end-to-end (Q6 third leg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)